### PR TITLE
fix: correct repository URL in workspace Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.85"
 license = "Apache-2.0"
-repository = "https://github.com/brokkr/brokkr"
+repository = "https://github.com/jackthepunished/brokkr"
 authors = ["Brokkr contributors"]
 
 [workspace.dependencies]


### PR DESCRIPTION
## Summary
- Fixed `repository` field in `[workspace.package]` from `https://github.com/brokkr/brokkr` to `https://github.com/jackthepunished/brokkr`

## Test plan
- [x] `cargo metadata` parses without errors
- [x] No other files reference the old URL

Closes #1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->