### PR TITLE
fix: update README.md MSRV from 1.78 to 1.85

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ jobs — builds, tests, ML training, transcoding. It speaks the
 
 ## Quick start (developer)
 
-Requires Rust 1.78 (pinned via `rust-toolchain.toml`).
+Requires Rust 1.85 (pinned via `rust-toolchain.toml`).
 
 ```sh
 cargo build --workspace


### PR DESCRIPTION
## Summary
- Fixed README.md line 23 to reflect actual MSRV of 1.85 (matching `rust-toolchain.toml` and `Cargo.toml`)

## Test plan
- [x] `rustc --version` confirms 1.85
- [x] `cargo build --workspace` succeeds

Closes #6