### PR TITLE
fix: use allow(missing_docs) on stub crates until Phase 1

### DIFF
--- a/crates/brokkr-cas/src/lib.rs
+++ b/crates/brokkr-cas/src/lib.rs
@@ -4,4 +4,5 @@
 //! the REAPI `ContentAddressableStorage` and `ByteStream` services.
 //! Phase 3 adds hash-prefix sharding, replication, and tiered storage.
 
-#![deny(missing_docs)]
+//! Stub crate — real implementation in Phase 1+.
+#![allow(missing_docs)]

--- a/crates/brokkr-common/src/lib.rs
+++ b/crates/brokkr-common/src/lib.rs
@@ -3,4 +3,5 @@
 //! `brokkr-common` is the only crate every other Brokkr crate may depend on.
 //! Keep it small and dependency-light.
 
-#![deny(missing_docs)]
+//! Stub crate — real implementation in Phase 1+.
+#![allow(missing_docs)]

--- a/crates/brokkr-sdk/src/lib.rs
+++ b/crates/brokkr-sdk/src/lib.rs
@@ -3,4 +3,5 @@
 //! Wraps the REAPI gRPC services with ergonomic Rust APIs. Used by
 //! `brokkr-cli` and embeddable in any Rust application.
 
-#![deny(missing_docs)]
+//! Stub crate — real implementation in Phase 1+.
+#![allow(missing_docs)]

--- a/crates/brokkr-test-utils/src/lib.rs
+++ b/crates/brokkr-test-utils/src/lib.rs
@@ -2,4 +2,5 @@
 //!
 //! Not published to crates.io.
 
-#![deny(missing_docs)]
+//! Stub crate — real implementation in Phase 1+.
+#![allow(missing_docs)]


### PR DESCRIPTION
## Summary
- Changed `#![deny(missing_docs)]` to `#![allow(missing_docs)]` on stub crates (`brokkr-cas`, `brokkr-sdk`, `brokkr-common`, `brokkr-test-utils`)
- `brokkr-proto` already had the allow directive due to generated code
- This prevents compile errors when real public API items are added without documentation during Phase 1+

## Test plan
- [x] `cargo build --workspace` succeeds
- [x] No `missing_docs` denial on stub crates

Closes #5