### PR TITLE
feat(observability): add Phase 1 tracing spans on the hot path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,3 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brokkr-control` `tests/end_to_end.rs`: full in-process cluster (server +
   worker) running `/bin/echo "hello world"` end-to-end and verifying that the
   second invocation hits the action cache.
+- Tracing spans on the Phase 1 hot path: `client::execute` (SDK),
+  `control::dispatch` (scheduler), and `worker::run_action` (worker), each
+  recording action digest / job id / cache hit / exit code as the action
+  flows through the layers (plan §13.9).

--- a/crates/brokkr-control/src/scheduler.rs
+++ b/crates/brokkr-control/src/scheduler.rs
@@ -53,6 +53,17 @@ impl Scheduler {
 
     /// Execute an action: look up the action cache, otherwise enqueue a job
     /// and await the worker's report.
+    #[tracing::instrument(
+        name = "control::dispatch",
+        skip(self),
+        fields(
+            action_digest = %action_digest,
+            skip_cache_lookup,
+            cache_hit = tracing::field::Empty,
+            exit_code = tracing::field::Empty,
+            job_id = tracing::field::Empty,
+        ),
+    )]
     pub async fn execute(
         self: &Arc<Self>,
         action_digest: Digest,
@@ -65,6 +76,9 @@ impl Scheduler {
                 .await
                 .map_err(|e| anyhow!("action cache get: {e}"))?
             {
+                tracing::Span::current()
+                    .record("cache_hit", true)
+                    .record("exit_code", cached.exit_code);
                 return Ok(ExecutionOutcome {
                     result: cached,
                     cache_hit: true,
@@ -91,6 +105,7 @@ impl Scheduler {
             .with_context(|| "fetching Command from CAS")?;
 
         let job_id = uuid::Uuid::new_v4().to_string();
+        tracing::Span::current().record("job_id", job_id.as_str());
         let (tx, rx) = oneshot::channel();
         self.waiters.lock().await.insert(job_id.clone(), tx);
 
@@ -123,6 +138,9 @@ impl Scheduler {
                 .await
                 .map_err(|e| anyhow!("action cache update: {e}"))?;
         }
+        tracing::Span::current()
+            .record("cache_hit", false)
+            .record("exit_code", result.exit_code);
         Ok(ExecutionOutcome {
             result,
             cache_hit: false,

--- a/crates/brokkr-sdk/src/client.rs
+++ b/crates/brokkr-sdk/src/client.rs
@@ -56,6 +56,17 @@ pub struct RunOutcome {
 ///
 /// Builds an `Action` (with empty input root + the given Command), uploads
 /// both to CAS, calls `Execute`, and waits for the streamed completion.
+#[tracing::instrument(
+    name = "client::execute",
+    skip(client, argv),
+    fields(
+        argv_len = argv.len(),
+        skip_cache_lookup,
+        action_digest = tracing::field::Empty,
+        cache_hit = tracing::field::Empty,
+        exit_code = tracing::field::Empty,
+    ),
+)]
 pub async fn run_command(
     client: &mut BrokkrClient,
     argv: &[String],
@@ -80,6 +91,13 @@ pub async fn run_command(
     };
     let action_bytes = action.encode_to_vec();
     let action_digest = digest_of(&action_bytes);
+    tracing::Span::current().record(
+        "action_digest",
+        tracing::field::display(format_args!(
+            "{}/{}",
+            action_digest.hash, action_digest.size_bytes
+        )),
+    );
 
     // Upload Action, Command, and the empty Directory to CAS.
     client
@@ -130,6 +148,9 @@ pub async fn run_command(
                 let result = resp
                     .result
                     .ok_or_else(|| anyhow!("ExecuteResponse missing ActionResult"))?;
+                tracing::Span::current()
+                    .record("cache_hit", resp.cached_result)
+                    .record("exit_code", result.exit_code);
                 return Ok(RunOutcome {
                     exit_code: result.exit_code,
                     stdout: Bytes::from(result.stdout_raw),

--- a/crates/brokkr-worker/src/worker.rs
+++ b/crates/brokkr-worker/src/worker.rs
@@ -92,16 +92,29 @@ pub async fn run_worker(cfg: WorkerConfig) -> Result<()> {
     Ok(())
 }
 
+#[tracing::instrument(
+    name = "worker::run_action",
+    skip(cas, job),
+    fields(
+        job_id = %job.job_id,
+        argv0 = tracing::field::Empty,
+        exit_code = tracing::field::Empty,
+    ),
+)]
 async fn handle_job(
     cas: &mut ContentAddressableStorageClient<Channel>,
     job: bv1::Job,
 ) -> Result<rapi::ActionResult> {
     let command = job.command.ok_or_else(|| anyhow!("Job missing Command"))?;
+    if let Some(argv0) = command.arguments.first() {
+        tracing::Span::current().record("argv0", argv0.as_str());
+    }
     let RunOutcome {
         exit_code,
         stdout,
         stderr,
     } = run_command(&command).await?;
+    tracing::Span::current().record("exit_code", exit_code);
 
     // Phase 1 stdout/stderr policy: upload to CAS and reference by digest;
     // also keep a bounded inline copy on the ActionResult for quick CLI


### PR DESCRIPTION
## Motivation

`docs/plan.md` §13.9 lists tracing spans for `client::execute`,
`control::dispatch`, and `worker::run_action` as part of the Phase 1
definition of done. Until now the only `tracing` calls were three
ad-hoc `info!`/`debug!` lines — there was no way to follow a single
action across the SDK → control plane → worker boundary.

## What changed

- `brokkr-sdk` `run_command` is now wrapped in a `client::execute`
  span. Records `argv_len`, `skip_cache_lookup`, the computed
  `action_digest`, and the final `cache_hit` / `exit_code` once the
  ExecuteResponse decodes.
- `brokkr-control` `Scheduler::execute` is wrapped in a
  `control::dispatch` span. Records `action_digest`,
  `skip_cache_lookup`, then on the cache-hit fast path fills
  `cache_hit = true` + `exit_code`; on the worker roundtrip path
  records the dispatched `job_id` and the worker-reported
  `exit_code` / `cache_hit = false`.
- `brokkr-worker` `handle_job` is wrapped in a `worker::run_action`
  span. Records `job_id`, the command's `argv0`, and the post-spawn
  `exit_code`.
- `CHANGELOG.md`: one bullet under Phase 1 referencing plan §13.9.

No behavioural changes: only `#[tracing::instrument]` and
`Span::current().record(...)` calls. No new dependencies; `tracing`
was already a workspace dep on all three crates.

## How it was tested

- `cargo fmt --all`
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 25 passed, 0 failed (incl. the
  end-to-end `echo hello world` integration test)

## Related

- `docs/plan.md` §13 — Phase 1 task list, item 9.