### PR TITLE
feat(phase2): M1 — host-compatibility check + cgroup install script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,3 +79,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   commands, miss-then-hit each, `#[ignore]`-soak) and
   `cache_hit_faster_than_miss` (median-of-10 timing comparison).
   Shared cluster fixture moved to `tests/common/mod.rs`.
+
+## Phase 2 (in progress)
+
+### Added
+- `docs/phase-2-plan.md` — detailed Phase 2 implementation plan (threat
+  model, re-exec runner architecture, public API, per-subsystem designs,
+  evil-action matrix, M1–M9 milestones, CI / WSL2 notes).
+- `brokkr-sandbox::host_check` — Linux host-compatibility probes (kernel
+  version, unprivileged userns, cgroup v2, brokkr.slice writable, seccomp
+  presence, `memory.peak`, `/proc/self/setgroups`) returning a structured
+  `Report` with pass/warn/fail outcomes.
+- `brokkr-worker --check-host` — runs the host probes, prints the
+  checklist, exits 0 iff the sandbox is functional on this host
+  (warnings allowed). Plan §10.3.
+- `scripts/install-cgroup-slice.sh` — one-shot host setup that creates
+  `/sys/fs/cgroup/brokkr.slice`, chowns it to the target user, and
+  delegates the cpu/memory/pids/io controllers. Idempotent.
+- `docs/journal/phase-2.md` — Phase 2 journal, started with the M1 entry.

--- a/crates/brokkr-sandbox/src/host_check.rs
+++ b/crates/brokkr-sandbox/src/host_check.rs
@@ -1,0 +1,491 @@
+//! Linux host-compatibility probes for the Phase 2 sandbox.
+//!
+//! Returns a structured [`Report`] rather than printing directly so different
+//! callers (the worker's `--check-host` flag, a future `brokk doctor`, and
+//! integration tests) can format it as they wish. Linux-only checks are
+//! gated on `target_os = "linux"`; on other hosts the report contains a
+//! single `Fail` outcome explaining why.
+//!
+//! See `docs/phase-2-plan.md` §10.3 for the canonical output format.
+
+use std::fmt;
+
+/// Pass / warn / fail outcome of a single probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    /// Passes; no concern.
+    Pass,
+    /// Functional but degraded — a fallback path will be used.
+    Warn,
+    /// Sandbox cannot start without this fixed.
+    Fail,
+}
+
+impl Status {
+    fn label(self) -> &'static str {
+        match self {
+            Status::Pass => " OK  ",
+            Status::Warn => "WARN ",
+            Status::Fail => "FAIL ",
+        }
+    }
+}
+
+/// Result of a single named check.
+#[derive(Debug, Clone)]
+pub struct Outcome {
+    /// Short, human-readable name.
+    pub name: String,
+    /// Pass / warn / fail.
+    pub status: Status,
+    /// Optional remediation hint or detail (e.g. the value we read).
+    pub detail: Option<String>,
+}
+
+/// All check outcomes for one host probe pass.
+#[derive(Debug, Clone)]
+pub struct Report {
+    /// OS string (`linux`, `macos`, …).
+    pub os: &'static str,
+    /// CPU arch (`x86_64`, `aarch64`, …).
+    pub arch: &'static str,
+    /// Kernel release string when readable from `/proc/sys/kernel/osrelease`.
+    pub kernel_release: Option<String>,
+    /// Outcome list, in deterministic order.
+    pub outcomes: Vec<Outcome>,
+}
+
+impl Report {
+    /// True iff every outcome is `Pass` or `Warn` (no `Fail`).
+    pub fn is_functional(&self) -> bool {
+        !self
+            .outcomes
+            .iter()
+            .any(|o| matches!(o.status, Status::Fail))
+    }
+
+    /// `(failures, warnings)` count.
+    pub fn counts(&self) -> (usize, usize) {
+        let mut failures = 0;
+        let mut warnings = 0;
+        for o in &self.outcomes {
+            match o.status {
+                Status::Fail => failures += 1,
+                Status::Warn => warnings += 1,
+                Status::Pass => {}
+            }
+        }
+        (failures, warnings)
+    }
+}
+
+impl fmt::Display for Report {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let kernel = self.kernel_release.as_deref().unwrap_or("unknown");
+        writeln!(
+            f,
+            "brokkr host compatibility check ({} {}, kernel {})",
+            self.os, self.arch, kernel
+        )?;
+        writeln!(f)?;
+        for o in &self.outcomes {
+            match &o.detail {
+                Some(d) => writeln!(f, "[{}] {} — {}", o.status.label(), o.name, d)?,
+                None => writeln!(f, "[{}] {}", o.status.label(), o.name)?,
+            }
+        }
+        let (fail, warn) = self.counts();
+        writeln!(f)?;
+        if fail > 0 {
+            writeln!(
+                f,
+                "Sandbox is NOT functional. {fail} failure{}, {warn} warning{}.",
+                plural(fail),
+                plural(warn),
+            )
+        } else if warn > 0 {
+            writeln!(f, "Sandbox is functional. {warn} warning{}.", plural(warn))
+        } else {
+            writeln!(f, "Sandbox is functional.")
+        }
+    }
+}
+
+fn plural(n: usize) -> &'static str {
+    if n == 1 {
+        ""
+    } else {
+        "s"
+    }
+}
+
+/// Run all host-compatibility probes and return a structured report.
+///
+/// On non-Linux hosts the report contains a single `Fail` outcome since the
+/// Phase 2 sandbox is Linux-only.
+pub fn run() -> Report {
+    let os = std::env::consts::OS;
+    let arch = std::env::consts::ARCH;
+
+    #[cfg(target_os = "linux")]
+    {
+        linux::run(os, arch)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        Report {
+            os,
+            arch,
+            kernel_release: None,
+            outcomes: vec![Outcome {
+                name: "linux required".to_string(),
+                status: Status::Fail,
+                detail: Some(format!(
+                    "the Phase 2 sandbox is Linux-only; this host is {os}"
+                )),
+            }],
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+
+    pub fn run(os: &'static str, arch: &'static str) -> Report {
+        let kernel_release = fs::read_to_string("/proc/sys/kernel/osrelease")
+            .ok()
+            .map(|s| s.trim().to_string());
+
+        let outcomes = vec![
+            check_kernel_version(kernel_release.as_deref()),
+            check_user_namespaces(),
+            check_cgroup_v2(),
+            check_brokkr_slice(),
+            check_seccomp(),
+            check_memory_peak(kernel_release.as_deref()),
+            check_setgroups(),
+        ];
+
+        Report {
+            os,
+            arch,
+            kernel_release,
+            outcomes,
+        }
+    }
+
+    /// Parse the leading `MAJOR.MINOR` from a kernel release string like
+    /// `6.6.87.2-microsoft-standard-WSL2`.
+    pub(super) fn parse_kernel_version(s: &str) -> Option<(u32, u32)> {
+        let mut parts = s.split(['.', '-']);
+        let major: u32 = parts.next()?.parse().ok()?;
+        let minor: u32 = parts.next()?.parse().ok()?;
+        Some((major, minor))
+    }
+
+    fn check_kernel_version(release: Option<&str>) -> Outcome {
+        const NAME: &str = "kernel ≥ 5.10";
+        match release.and_then(parse_kernel_version) {
+            Some((major, minor)) if (major, minor) >= (5, 10) => Outcome {
+                name: NAME.to_string(),
+                status: Status::Pass,
+                detail: None,
+            },
+            Some((major, minor)) => Outcome {
+                name: NAME.to_string(),
+                status: Status::Fail,
+                detail: Some(format!("found {major}.{minor}; sandbox requires 5.10+")),
+            },
+            None => Outcome {
+                name: NAME.to_string(),
+                status: Status::Fail,
+                detail: Some("could not read /proc/sys/kernel/osrelease".to_string()),
+            },
+        }
+    }
+
+    fn check_user_namespaces() -> Outcome {
+        const NAME: &str = "unprivileged user namespaces enabled";
+        // /proc/sys/user/max_user_namespaces is universal across distros.
+        // /proc/sys/kernel/unprivileged_userns_clone is a Debian/Ubuntu-specific
+        // gate (= 0 disables the unprivileged path even when the kernel supports
+        // userns). Both must be permissive.
+        let max = fs::read_to_string("/proc/sys/user/max_user_namespaces")
+            .ok()
+            .and_then(|s| s.trim().parse::<u64>().ok());
+        let gate = fs::read_to_string("/proc/sys/kernel/unprivileged_userns_clone")
+            .ok()
+            .map(|s| s.trim().to_string());
+        match (max, gate.as_deref()) {
+            (Some(0), _) => Outcome {
+                name: NAME.to_string(),
+                status: Status::Fail,
+                detail: Some("user.max_user_namespaces = 0".to_string()),
+            },
+            (Some(_), Some("1") | None) => Outcome {
+                name: NAME.to_string(),
+                status: Status::Pass,
+                detail: None,
+            },
+            (Some(_), Some(other)) => Outcome {
+                name: NAME.to_string(),
+                status: Status::Fail,
+                detail: Some(format!(
+                    "kernel.unprivileged_userns_clone = {other} (the Debian/Ubuntu gate)"
+                )),
+            },
+            (None, _) => Outcome {
+                name: NAME.to_string(),
+                status: Status::Fail,
+                detail: Some("could not read /proc/sys/user/max_user_namespaces".to_string()),
+            },
+        }
+    }
+
+    fn check_cgroup_v2() -> Outcome {
+        const NAME: &str = "cgroup v2 unified hierarchy";
+        let mounts = match fs::read_to_string("/proc/mounts") {
+            Ok(s) => s,
+            Err(e) => {
+                return Outcome {
+                    name: NAME.to_string(),
+                    status: Status::Fail,
+                    detail: Some(format!("/proc/mounts: {e}")),
+                };
+            }
+        };
+        // /proc/mounts lines: "<source> <mountpoint> <fstype> <options>..."
+        let unified = mounts.lines().any(|l| {
+            let mut it = l.split_ascii_whitespace();
+            let _source = it.next();
+            let mountpoint = it.next();
+            let fstype = it.next();
+            mountpoint == Some("/sys/fs/cgroup") && fstype == Some("cgroup2")
+        });
+        if unified {
+            Outcome {
+                name: NAME.to_string(),
+                status: Status::Pass,
+                detail: None,
+            }
+        } else {
+            Outcome {
+                name: NAME.to_string(),
+                status: Status::Fail,
+                detail: Some(
+                    "/sys/fs/cgroup is not cgroup2 — host is on cgroup v1 or hybrid".to_string(),
+                ),
+            }
+        }
+    }
+
+    fn check_brokkr_slice() -> Outcome {
+        const NAME: &str = "brokkr cgroup slice writable";
+        const SLICE: &str = "/sys/fs/cgroup/brokkr.slice";
+        let path = Path::new(SLICE);
+        if !path.exists() {
+            return Outcome {
+                name: NAME.to_string(),
+                status: Status::Fail,
+                detail: Some(format!(
+                    "{SLICE} missing — run scripts/install-cgroup-slice.sh"
+                )),
+            };
+        }
+        // A real write probe: try to mkdir under the slice and immediately
+        // remove it. Cgroup files don't honour open(O_RDWR) consistently, so
+        // mkdir is the only reliable test.
+        let probe = path.join(format!("brokkr-check-{}", std::process::id()));
+        match fs::create_dir(&probe) {
+            Ok(()) => {
+                let _ = fs::remove_dir(&probe);
+                Outcome {
+                    name: NAME.to_string(),
+                    status: Status::Pass,
+                    detail: None,
+                }
+            }
+            Err(e) => Outcome {
+                name: NAME.to_string(),
+                status: Status::Fail,
+                detail: Some(format!("cannot mkdir under {SLICE}: {e}")),
+            },
+        }
+    }
+
+    fn check_seccomp() -> Outcome {
+        const NAME: &str = "seccomp-bpf available";
+        // /proc/self/status lists `Seccomp:` on any kernel built with
+        // CONFIG_SECCOMP. The numeric value (0/1/2) doesn't matter to us.
+        match fs::read_to_string("/proc/self/status") {
+            Ok(s) if s.lines().any(|l| l.starts_with("Seccomp:")) => Outcome {
+                name: NAME.to_string(),
+                status: Status::Pass,
+                detail: None,
+            },
+            Ok(_) => Outcome {
+                name: NAME.to_string(),
+                status: Status::Fail,
+                detail: Some(
+                    "/proc/self/status has no Seccomp: line — kernel built without CONFIG_SECCOMP"
+                        .to_string(),
+                ),
+            },
+            Err(e) => Outcome {
+                name: NAME.to_string(),
+                status: Status::Fail,
+                detail: Some(format!("/proc/self/status: {e}")),
+            },
+        }
+    }
+
+    fn check_memory_peak(release: Option<&str>) -> Outcome {
+        const NAME: &str = "cgroup memory.peak (kernel ≥ 5.19)";
+        if Path::new("/sys/fs/cgroup/memory.peak").exists() {
+            return Outcome {
+                name: NAME.to_string(),
+                status: Status::Pass,
+                detail: None,
+            };
+        }
+        let kver = release.unwrap_or("unknown");
+        Outcome {
+            name: NAME.to_string(),
+            status: Status::Warn,
+            detail: Some(format!(
+                "absent on kernel {kver}; falling back to memory.events on the per-action cgroup"
+            )),
+        }
+    }
+
+    fn check_setgroups() -> Outcome {
+        const NAME: &str = "/proc/self/setgroups present";
+        if Path::new("/proc/self/setgroups").exists() {
+            Outcome {
+                name: NAME.to_string(),
+                status: Status::Pass,
+                detail: None,
+            }
+        } else {
+            Outcome {
+                name: NAME.to_string(),
+                status: Status::Fail,
+                detail: Some("required for gid_map writes under unprivileged userns".to_string()),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_labels_match_plan_format() {
+        assert_eq!(Status::Pass.label(), " OK  ");
+        assert_eq!(Status::Warn.label(), "WARN ");
+        assert_eq!(Status::Fail.label(), "FAIL ");
+    }
+
+    #[test]
+    fn counts_and_functional() {
+        let r = Report {
+            os: "linux",
+            arch: "x86_64",
+            kernel_release: Some("6.6.0".to_string()),
+            outcomes: vec![
+                Outcome {
+                    name: "a".into(),
+                    status: Status::Pass,
+                    detail: None,
+                },
+                Outcome {
+                    name: "b".into(),
+                    status: Status::Warn,
+                    detail: Some("note".into()),
+                },
+                Outcome {
+                    name: "c".into(),
+                    status: Status::Pass,
+                    detail: None,
+                },
+            ],
+        };
+        assert_eq!(r.counts(), (0, 1));
+        assert!(r.is_functional());
+
+        let mut bad = r.clone();
+        bad.outcomes.push(Outcome {
+            name: "d".into(),
+            status: Status::Fail,
+            detail: None,
+        });
+        assert_eq!(bad.counts(), (1, 1));
+        assert!(!bad.is_functional());
+    }
+
+    #[test]
+    fn display_summary_branches() {
+        let mut r = Report {
+            os: "linux",
+            arch: "x86_64",
+            kernel_release: Some("6.6.0".into()),
+            outcomes: vec![Outcome {
+                name: "ok".into(),
+                status: Status::Pass,
+                detail: None,
+            }],
+        };
+        let out = format!("{r}");
+        assert!(out.contains("Sandbox is functional."));
+        assert!(!out.contains("warning"));
+
+        r.outcomes.push(Outcome {
+            name: "warn".into(),
+            status: Status::Warn,
+            detail: None,
+        });
+        let out = format!("{r}");
+        assert!(out.contains("1 warning."));
+
+        r.outcomes.push(Outcome {
+            name: "fail".into(),
+            status: Status::Fail,
+            detail: Some("d".into()),
+        });
+        let out = format!("{r}");
+        assert!(out.contains("Sandbox is NOT functional"));
+        assert!(out.contains("1 failure"));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn parse_kernel_version_basic() {
+        use super::linux::parse_kernel_version;
+        assert_eq!(parse_kernel_version("5.10.0"), Some((5, 10)));
+        assert_eq!(parse_kernel_version("6.6.87.2-microsoft"), Some((6, 6)));
+        assert_eq!(parse_kernel_version("6.10-rc2"), Some((6, 10)));
+        assert_eq!(parse_kernel_version("not.a.version"), None);
+        assert_eq!(parse_kernel_version(""), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_run_produces_seven_outcomes() {
+        let report = run();
+        assert_eq!(report.os, "linux");
+        assert_eq!(report.outcomes.len(), 7);
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn non_linux_run_reports_unsupported() {
+        let report = run();
+        assert!(!report.is_functional());
+        assert_eq!(report.outcomes.len(), 1);
+    }
+}

--- a/crates/brokkr-sandbox/src/lib.rs
+++ b/crates/brokkr-sandbox/src/lib.rs
@@ -2,7 +2,9 @@
 //!
 //! Built directly on Linux primitives — mount/PID/user/network namespaces,
 //! cgroups v2, seccomp-bpf, capability dropping. **No Docker, runc, or
-//! containerd dependency, ever.** Phase 2 lights this crate up; Phase 0–1
-//! ship it as an empty stub.
+//! containerd dependency, ever.** Phase 2 lights this crate up incrementally
+//! per `docs/phase-2-plan.md`.
 
 #![deny(missing_docs)]
+
+pub mod host_check;

--- a/crates/brokkr-worker/src/main.rs
+++ b/crates/brokkr-worker/src/main.rs
@@ -1,6 +1,9 @@
 //! `brokkr-worker` daemon entrypoint.
 
+use std::process::ExitCode;
+
 use anyhow::Result;
+use brokkr_sandbox::host_check;
 use brokkr_worker::{run_worker, WorkerConfig};
 use clap::Parser;
 
@@ -10,10 +13,15 @@ struct Args {
     /// gRPC endpoint of the brokkr-control server (e.g. `http://127.0.0.1:7878`).
     #[arg(long, default_value = "http://127.0.0.1:7878")]
     control: String,
+
+    /// Run the Phase 2 host-compatibility check and exit. Prints a per-probe
+    /// checklist and exits 0 iff the sandbox can run on this host (warnings
+    /// allowed). See `docs/phase-2-plan.md` §10.3.
+    #[arg(long)]
+    check_host: bool,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> ExitCode {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
@@ -22,11 +30,40 @@ async fn main() -> Result<()> {
         .init();
 
     let args = Args::parse();
+    if args.check_host {
+        return run_check_host();
+    }
+    match tokio::runtime::Runtime::new() {
+        Ok(rt) => match rt.block_on(run_daemon(args)) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("brokkr-worker: {e:#}");
+                ExitCode::FAILURE
+            }
+        },
+        Err(e) => {
+            eprintln!("brokkr-worker: starting tokio runtime: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run_daemon(args: Args) -> Result<()> {
     let cfg = WorkerConfig {
         control_endpoint: args.control,
         hostname: hostname_or("worker".to_string()),
     };
     run_worker(cfg).await
+}
+
+fn run_check_host() -> ExitCode {
+    let report = host_check::run();
+    print!("{report}");
+    if report.is_functional() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
 }
 
 fn hostname_or(fallback: String) -> String {

--- a/docs/journal/phase-2.md
+++ b/docs/journal/phase-2.md
@@ -1,0 +1,52 @@
+# Phase 2 — Hermetic Sandboxing
+
+- **Status:** in progress
+- **Plan:** `docs/phase-2-plan.md`
+- **Started:** 2026-04-30
+
+This journal accumulates short retrospectives as each milestone (M1–M9)
+lands. Each milestone is a single PR; each section here is the post-merge
+debrief.
+
+## M1 — `feat/phase2-host-check`
+
+- **Date:** 2026-04-30
+- **PR:** _(filled in after merge)_
+- **Outcome:** `brokkr-worker --check-host` runs seven probes against the
+  host kernel and prints a per-probe `[ OK | WARN | FAIL ]` checklist. A
+  one-shot `scripts/install-cgroup-slice.sh` creates the
+  `/sys/fs/cgroup/brokkr.slice` cgroup, chowns it, and enables the
+  controllers we'll need (cpu/memory/pids/io). The journal you're reading
+  was started in this milestone too.
+
+### Open questions resolved
+
+- **Cgroup delegation default** (plan §11.1). Going with the manual chown
+  path — `scripts/install-cgroup-slice.sh` — as the documented default.
+  systemd's `Delegate=yes` keeps working; documenting both paths is M9.
+- **`unprivileged_userns_clone` is Debian/Ubuntu-only.** Probe via the
+  universal `/proc/sys/user/max_user_namespaces` first; treat the
+  Debian/Ubuntu sysctl as an *additional* gate, not the only one. Saves us
+  spurious failures on Fedora / RHEL / Arch.
+
+### Open questions deferred
+
+- **`brokkr-sandboxd` discovery** (plan §11.2). Not relevant until M2
+  when the binary actually exists. Decision: relative path next to the
+  worker binary, with `$PATH` fallback.
+- **systemd vs no-systemd hosts** (plan §11.5). M1 documents only the
+  no-systemd path; M9 will add a systemd unit file.
+
+### What surprised me
+
+- `/proc/sys/kernel/unprivileged_userns_clone` is *not* universal —
+  Debian/Ubuntu added it as an extra hardening knob. The cross-distro probe
+  has to look at `/proc/sys/user/max_user_namespaces` (universal) and
+  *also* honour the Debian/Ubuntu sysctl when it's present.
+- Cgroup write-tests can't use `open(O_RDWR)` reliably — the only
+  trustworthy probe is `mkdir`-then-`rmdir`. The directory name needs the
+  PID baked in to avoid collisions if two workers run `--check-host`
+  concurrently.
+- Kernel release strings on WSL2 look like `6.6.87.2-microsoft-standard-WSL2`
+  — the parser splits on both `.` and `-` to extract the leading
+  `(major, minor)` pair without choking on the suffix.

--- a/scripts/install-cgroup-slice.sh
+++ b/scripts/install-cgroup-slice.sh
@@ -24,31 +24,42 @@ fi
 
 ROOT="/sys/fs/cgroup"
 
-if ! grep -q "^cgroup2 $ROOT cgroup2" /proc/mounts; then
+# Match host_check.rs: identify cgroup2 by mountpoint + fstype, not the
+# source field — some hosts mount with `none` (or other sentinels) as source.
+if ! awk -v mp="$ROOT" '$2 == mp && $3 == "cgroup2" { found=1 } END { exit !found }' /proc/mounts; then
     echo "error: $ROOT is not a cgroup2 unified hierarchy" >&2
     echo "       brokkr Phase 2 requires cgroup v2; see docs/phase-2-plan.md §5.5" >&2
     exit 1
 fi
 
-# Sanity-check the controllers we plan to use exist on this kernel.
+# Build the enable string from the controllers that actually exist on this
+# kernel. Writing "+foo" to subtree_control when "foo" is absent fails with
+# EINVAL, so we warn and skip rather than abort the whole install.
 controllers=$(cat "$ROOT/cgroup.controllers")
+enable=""
 for c in cpu memory pids io; do
     case " $controllers " in
-        *" $c "*) ;;
+        *" $c "*) enable="$enable +$c" ;;
         *) echo "warning: controller '$c' is missing from $ROOT/cgroup.controllers" >&2 ;;
     esac
 done
+if [ -z "$enable" ]; then
+    echo "error: none of cpu/memory/pids/io are available on this kernel" >&2
+    exit 1
+fi
+# Strip leading space so the kernel sees a clean token list.
+enable="${enable# }"
 
 # Delegate the controllers from the root cgroup to its immediate children
 # (which is what brokkr.slice will be). No-op if already enabled.
-echo "+cpu +memory +pids +io" > "$ROOT/cgroup.subtree_control"
+echo "$enable" > "$ROOT/cgroup.subtree_control"
 
 mkdir -p "$SLICE"
 chown -R "$TARGET_USER:$(id -gn "$TARGET_USER")" "$SLICE"
 
 # Enable the same controllers within brokkr.slice's subtree so per-action
 # cgroups (the leaves we will create at runtime) inherit them.
-echo "+cpu +memory +pids +io" > "$SLICE/cgroup.subtree_control"
+echo "$enable" > "$SLICE/cgroup.subtree_control"
 
 echo "ok: $SLICE owned by $TARGET_USER:$(id -gn "$TARGET_USER")"
 echo "    controllers cpu/memory/pids/io delegated"

--- a/scripts/install-cgroup-slice.sh
+++ b/scripts/install-cgroup-slice.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Phase 2 host setup for brokkr.
+#
+# Creates /sys/fs/cgroup/brokkr.slice and gives the target user write
+# access, plus enables the cpu/memory/pids/io controllers under it. Running
+# this once per host is the documented Phase 2 prerequisite for cgroup
+# delegation; running it again is idempotent.
+#
+# Usage:
+#   sudo scripts/install-cgroup-slice.sh
+#   SLICE=/sys/fs/cgroup/brokkr.slice TARGET_USER=alice sudo -E scripts/install-cgroup-slice.sh
+#
+# After it succeeds, run `brokkr-worker --check-host` to verify.
+
+set -eu
+
+SLICE="${SLICE:-/sys/fs/cgroup/brokkr.slice}"
+TARGET_USER="${TARGET_USER:-${SUDO_USER:-$(id -un)}}"
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "re-running under sudo (target user: $TARGET_USER)..." >&2
+    exec sudo -E SLICE="$SLICE" TARGET_USER="$TARGET_USER" "$0" "$@"
+fi
+
+ROOT="/sys/fs/cgroup"
+
+if ! grep -q "^cgroup2 $ROOT cgroup2" /proc/mounts; then
+    echo "error: $ROOT is not a cgroup2 unified hierarchy" >&2
+    echo "       brokkr Phase 2 requires cgroup v2; see docs/phase-2-plan.md §5.5" >&2
+    exit 1
+fi
+
+# Sanity-check the controllers we plan to use exist on this kernel.
+controllers=$(cat "$ROOT/cgroup.controllers")
+for c in cpu memory pids io; do
+    case " $controllers " in
+        *" $c "*) ;;
+        *) echo "warning: controller '$c' is missing from $ROOT/cgroup.controllers" >&2 ;;
+    esac
+done
+
+# Delegate the controllers from the root cgroup to its immediate children
+# (which is what brokkr.slice will be). No-op if already enabled.
+echo "+cpu +memory +pids +io" > "$ROOT/cgroup.subtree_control"
+
+mkdir -p "$SLICE"
+chown -R "$TARGET_USER:$(id -gn "$TARGET_USER")" "$SLICE"
+
+# Enable the same controllers within brokkr.slice's subtree so per-action
+# cgroups (the leaves we will create at runtime) inherit them.
+echo "+cpu +memory +pids +io" > "$SLICE/cgroup.subtree_control"
+
+echo "ok: $SLICE owned by $TARGET_USER:$(id -gn "$TARGET_USER")"
+echo "    controllers cpu/memory/pids/io delegated"
+echo "verify with: brokkr-worker --check-host"


### PR DESCRIPTION
First milestone of Phase 2 (`docs/phase-2-plan.md` §9, M1). Lays the
groundwork before any sandbox code lands.

## Why this milestone first

We need three things in place before namespace work begins:

1. A way for operators (and CI) to verify "can this host run the sandbox?"
   without writing a full sandbox first.
2. The cgroup delegation prerequisite, scriptable so the host setup is
   reproducible.
3. A Phase 2 journal seed so each subsequent milestone has a place to
   land its short retrospective.

This PR delivers all three. No sandbox code lands here; that begins in M2
(`feat/phase2-sandbox-skeleton`).

## What's in it

### Library (`brokkr-sandbox::host_check`)

A new public module that runs Linux probes and returns a structured
`Report`. Public types:

- `Status` — `Pass` / `Warn` / `Fail`.
- `Outcome { name, status, detail }`.
- `Report { os, arch, kernel_release, outcomes, … }` with
  `is_functional()` / `counts()` helpers and a `Display` impl matching
  the format in plan §10.3.
- `pub fn run() -> Report`.

Seven probes (Linux only; non-Linux returns a single `Fail`):

| Probe                                 | Pass condition                                                  |
|---------------------------------------|-----------------------------------------------------------------|
| kernel ≥ 5.10                         | parses `/proc/sys/kernel/osrelease`                             |
| unprivileged user namespaces enabled  | `user.max_user_namespaces > 0` AND (`unprivileged_userns_clone == 1` OR sysctl absent — universal cross-distro logic) |
| cgroup v2 unified hierarchy           | `cgroup2` mounted on `/sys/fs/cgroup` per `/proc/mounts`        |
| brokkr cgroup slice writable          | mkdir-then-rmdir under `/sys/fs/cgroup/brokkr.slice`            |
| seccomp-bpf available                 | `Seccomp:` line present in `/proc/self/status`                  |
| cgroup `memory.peak` (kernel ≥ 5.19)  | warns + falls back to `memory.events` if absent                 |
| `/proc/self/setgroups` present        | required for gid_map writes under unprivileged userns           |

### Worker (`brokkr-worker --check-host`)

A new top-level flag. When set, runs the probes, prints the report, and
exits 0 iff `is_functional()` (warnings allowed), 1 otherwise. Default
behaviour (the daemon) is unchanged.

Sample output on this WSL2 host (kernel 6.6.87.2):

```
brokkr host compatibility check (linux x86_64, kernel 6.6.87.2-microsoft-standard-WSL2)

[ OK  ] kernel ≥ 5.10
[ OK  ] unprivileged user namespaces enabled
[ OK  ] cgroup v2 unified hierarchy
[FAIL ] brokkr cgroup slice writable — /sys/fs/cgroup/brokkr.slice missing — run scripts/install-cgroup-slice.sh
[ OK  ] seccomp-bpf available
[WARN ] cgroup memory.peak (kernel ≥ 5.19) — absent on kernel 6.6.87.2-microsoft-standard-WSL2; falling back to memory.events on the per-action cgroup
[ OK  ] /proc/self/setgroups present

Sandbox is NOT functional. 1 failure, 1 warning.
```

After running the install script:

```
[ OK  ] brokkr cgroup slice writable
…
Sandbox is functional. 1 warning.
```

### Install script (`scripts/install-cgroup-slice.sh`)

Idempotent. Re-execs under sudo if needed. Verifies the unified
hierarchy is mounted, sanity-checks that the kernel exposes
`cpu`/`memory`/`pids`/`io` controllers, delegates them from the root
cgroup down through `brokkr.slice`'s subtree, creates the slice, and
chowns it to the target user.

### Journal (`docs/journal/phase-2.md`)

Started for Phase 2. M1 entry resolves plan §11.1 (cgroup delegation
default = manual chown) and notes the WSL2 kernel-version-string
parsing gotcha.

### CHANGELOG

New "Phase 2 (in progress)" section with bullets for the plan, the
host-check module, the worker flag, the install script, and the journal.

## Open questions

- §11.1 (cgroup delegation default) — **resolved**: manual chown is the
  documented path. systemd `Delegate=yes` will be supported in M9.
- §11.2 (sandboxd discovery) — **deferred to M2** (the binary doesn't
  exist yet).
- §11.5 (systemd vs no-systemd) — **deferred to M9**.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 31 passed (was 26; +5 new
      `host_check` unit tests covering label format, count math,
      Display branches, kernel version parsing, and the 7-probe
      Linux smoke run)
- [x] `brokkr-worker --check-host` exit codes verified locally
      (1 with slice missing, 0 after running the install script)
- [ ] Reviewer runs `--check-host` on their own host
- [ ] Reviewer runs the install script on a fresh Ubuntu 24.04 VM and
      confirms idempotency

## Related

- `docs/plan.md` §14 (Phase 2 task list)
- `docs/phase-2-plan.md` §9 (M1 milestone), §10.3 (output format)
- `CLAUDE.md` rule #9 (no external container runtimes)

## Phase 2 progress

- [x] M1 — host-check + install script (this PR)
- [ ] M2 — sandbox skeleton (re-exec model, plain spawn parity)
- [ ] M3 — mount namespace + pivot_root
- [ ] M4 — PID + user namespaces
- [ ] M5 — network namespace
- [ ] M6 — cgroups v2
- [ ] M7 — seccomp + caps
- [ ] M8 — determinism + wall-clock
- [ ] M9 — worker integration + defaults

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--check-host` CLI option to verify host compatibility and display diagnostic results for each system probe.
  * Added host setup script to configure and enable cgroup delegation for sandbox operations.

* **Documentation**
  * Updated changelog with Phase 2 artifacts and components.
  * Added Phase 2 journey documentation with milestone M1 details and architectural decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->