### PR TITLE
docs: add Phase 0 ADRs 0002-0007

### DIFF
--- a/docs/architecture/0002-reapi-compatibility.md
+++ b/docs/architecture/0002-reapi-compatibility.md
@@ -1,0 +1,135 @@
+# 0002 — REAPI compatibility
+
+- **Status:** accepted
+- **Date:** 2026-04-30
+- **Deciders:** Brokkr maintainers
+
+## Context
+
+Brokkr's purpose is to run arbitrary jobs (builds, tests, ML training,
+transcoding) on a fleet of Linux workers and to do so for users who already
+have a build tool. The dominant build tools that need a remote executor
+(Bazel, Buck2, Pants) all speak the **Bazel Remote Execution API v2 (REAPI)**.
+The spec lives at <https://github.com/bazelbuild/remote-apis> and is defined
+in protobuf.
+
+This is a load-bearing choice because the protocol shapes:
+
+- The data model (Action, Command, Directory, Digest, ActionResult).
+- The wire (gRPC over HTTP/2; ByteStream for blobs >4 MiB).
+- The semantics of caching (`GetActionResult` is the cache; `Execute` is the
+  scheduler entry point).
+- The integration surface for every client we want to attract.
+
+Project axiom: **compatibility is leverage** (`docs/plan.md` §1). We do not
+ask users to rewrite their toolchain; we meet them where they already are.
+
+There is also a tempting alternative: invent a smaller, cleaner Brokkr-native
+protocol that fits exactly what we need. This is what every greenfield system
+considers and most regret.
+
+## Decision
+
+**REAPI v2 is the canonical public protocol.** Brokkr implements every REAPI
+service required by Bazel as a remote executor:
+
+- `build.bazel.remote.execution.v2.Execution` (`Execute`, `WaitExecution`)
+- `build.bazel.remote.execution.v2.ActionCache`
+  (`GetActionResult`, `UpdateActionResult`)
+- `build.bazel.remote.execution.v2.ContentAddressableStorage`
+  (`FindMissingBlobs`, `BatchUpdateBlobs`, `BatchReadBlobs`, `GetTree`)
+- `build.bazel.remote.execution.v2.Capabilities` (`GetCapabilities`)
+- `google.bytestream.ByteStream` (`Read`, `Write`, `QueryWriteStatus`)
+
+Brokkr's own internal RPCs (worker lifecycle, admin, debug) live in a
+**separate proto namespace**, `brokkr.v1.*`, and are versioned independently.
+They never extend or replace REAPI types in place.
+
+Wire-level Bazel conformance is a Phase 4 hard requirement: a real
+`bazel build //...` against `brokk` as the remote executor must succeed
+(`docs/plan.md` §16, Phase 4 task 9).
+
+## Alternatives considered
+
+- **Invent a Brokkr-native protocol.**
+  - Pros: zero legacy baggage; can model exactly what we need; smaller surface.
+  - Cons: reinvents `Action` / `Digest` / `ActionResult` poorly; we would have
+    to write Bazel/Buck2/Pants adapters anyway, paying the REAPI cost twice;
+    zero day-one users; opaque to anyone who already knows REAPI.
+
+- **Buck2-native protocol.**
+  - Pros: Buck2 is technically interesting and gaining traction; its protocol
+    is well-engineered.
+  - Cons: not an open standard; not stable; smaller user base than Bazel;
+    Buck2 itself can speak REAPI.
+
+- **HTTP/REST + JSON.**
+  - Pros: easier to debug with `curl`; lower barrier for casual contributors.
+  - Cons: blob transfer is poor over HTTP/1.1 (no multiplexing, head-of-line
+    blocking); JSON-over-the-wire is wasteful for digests and binary blobs;
+    no native streaming primitives without HTTP/2 (at which point gRPC is the
+    sensible layer); protobuf already exists and is ratified by the spec.
+
+- **REAPI v1 / pre-v2 dialects.**
+  - Cons: deprecated by Bazel; not maintained.
+
+- **`bazel-remote` HTTP cache protocol** (subset of REAPI).
+  - Pros: dead simple; many existing CI integrations use it.
+  - Cons: cache-only — no remote execution, no scheduling, no worker pool.
+    We need the full REAPI surface, not just the cache.
+
+## Consequences
+
+### Positive
+
+- **Day-one users.** Existing Bazel/Buck2/Pants installations can point at
+  `brokk` with one config flag.
+- **Free conformance harness.** Bazel's own test suite tells us when we're
+  spec-compliant.
+- **Free prior art.** BuildBuddy, EngFlow, bazel-remote, and buildbarn all
+  implement the same surface; their public docs and source illuminate
+  every dark corner of the spec.
+- **Stable contract.** REAPI v2 evolves slowly and additively. Our public
+  surface inherits that stability without effort on our part.
+
+### Negative
+
+- **Inherit REAPI quirks.** ByteStream's `resource_name` format, the
+  asymmetry between `Execute` and `WaitExecution`, the
+  `do_not_cache` flag's interaction with `update_enabled`, and the
+  `Tree`-vs-`Directory` ambiguity — all are ours to implement faithfully,
+  warts included.
+- **Strict digest validation is mandatory.** Every blob upload must be
+  hash-verified server-side; mismatches return `INVALID_ARGUMENT`. No
+  shortcuts.
+- **Streaming gRPC complexity.** ByteStream `Write` is resumable and
+  per-spec; we cannot replace it with a simpler unary RPC.
+- **No room to fix REAPI's mistakes.** When REAPI is wrong (e.g.,
+  `Platform` constraints are bag-of-strings rather than a proper type
+  system), we cannot improve it without breaking compatibility — only
+  layer on top in `brokkr.v1.*`.
+
+### Neutral
+
+- **Brokkr extensions** (`WorkerService`, `AdminService`, `JobLease`,
+  `WorkerCapability`) live in `brokkr.v1.*` and are versioned per-namespace
+  (`docs/plan.md` §9). Internal protocol evolution does not touch the
+  public REAPI surface.
+- **Vendored protos.** REAPI + `googleapis` protos live under
+  `crates/brokkr-proto/protos/`; `build.rs` invokes `tonic-build` with a
+  vendored `protoc` so the build needs no system protobuf installation.
+- **Versioning policy** — for REAPI we follow upstream; for `brokkr.v1.*` we
+  hold the line on backwards compatibility within a major version, per the
+  CLAUDE.md hard rule on public API stability.
+
+## References
+
+- REAPI v2 spec: <https://github.com/bazelbuild/remote-apis>
+- `docs/plan.md` §6 (Core Components), §8 (Data Model), §9 (Wire Protocol),
+  §16 (Phase 4 Bazel conformance).
+- `crates/brokkr-proto/protos/` — vendored proto layout.
+- `crates/brokkr-proto/build.rs` — codegen pipeline.
+- BuildBuddy: <https://www.buildbuddy.io/blog/>
+- EngFlow: <https://blog.engflow.com/>
+- bazel-remote: <https://github.com/buchgr/bazel-remote>
+- buildbarn: <https://github.com/buildbarn/bb-remote-execution>

--- a/docs/architecture/0003-embedded-kv-redb.md
+++ b/docs/architecture/0003-embedded-kv-redb.md
@@ -1,0 +1,158 @@
+# 0003 — Embedded KV store: redb
+
+- **Status:** accepted
+- **Date:** 2026-04-30
+- **Deciders:** Brokkr maintainers
+
+## Context
+
+The control plane and CAS need a durable, transactional key-value store
+for metadata: action cache entries, worker registry rows, tenant config,
+and CAS reference counts (`docs/plan.md` §6.6, §10). Phase 0–4 use a
+single-node embedded store; Phase 5 replaces it with a from-scratch Raft
+KV (separate ADR will follow when Phase 5 begins). This decision is about
+the Phase 0–4 store only.
+
+Requirements:
+
+1. **ACID transactions.** Action-cache writes must be all-or-nothing —
+   the action key, the result blob digests, and the metadata update must
+   commit atomically.
+2. **Pure Rust.** Cross-compilation to Linux x86_64 and aarch64 must not
+   require a C/C++ toolchain on the build host (`docs/plan.md` §7).
+3. **Embedded, single-process.** No external server to operate during
+   Phase 0–4.
+4. **Predictable point-read latency.** Action-cache hot path is a
+   `digest(Action)` lookup; performance target is p99 <5 ms
+   (`docs/plan.md` §23).
+5. **Stable on-disk format.** We will live with this format until Phase 5;
+   we do not want to migrate Phase 1 data because the storage engine
+   broke compatibility.
+6. **Path to Raft.** When Phase 5 lands, the embedded store's tables
+   should be reusable as the Raft state machine's snapshot format.
+
+## Decision
+
+Use **redb 2.x** (`redb` crate) as the embedded KV store across the
+control plane and CAS during Phases 0–4. Tables encode protobuf-serialized
+values; keys are typed via redb's `TableDefinition`.
+
+Concrete usage already in tree:
+
+- `crates/brokkr-cas/src/redb_backend.rs` — CAS blob index + refcounts.
+- `crates/brokkr-cas/src/action_cache.rs` — action cache table.
+- Future: `workers.redb`, `tenants.redb` in `brokkr-control` per
+  `docs/plan.md` §10.
+
+Workspace dependency is pinned to `redb = "2"` in the root `Cargo.toml`.
+
+## Alternatives considered
+
+- **sled.**
+  - Pros: pure Rust; log-structured; tree API is ergonomic; supports
+    subscribers/watchers out of the box.
+  - Cons: has been on `0.34` for years; the planned 1.0 rewrite has
+    stalled multiple times; non-trivial history of crash-recovery bugs;
+    upstream maintenance cadence is uncertain. For a store that holds
+    every action-cache entry we ever care about, "uncertain crash
+    recovery" is disqualifying.
+
+- **RocksDB** (via `rust-rocksdb`).
+  - Pros: battle-tested in TiKV, CockroachDB, Kafka; LSM is a good fit
+    for write-heavy workloads; rich tuning surface.
+  - Cons: C++ dependency — adds a system toolchain requirement that
+    breaks the "pure Rust, no C deps in the data plane" invariant;
+    multi-minute clean compile on cold CI; ~10 MB binary inflation; LSM
+    write-amp tradeoffs are wrong for our workload (action-cache writes
+    are infrequent, reads dominate); tuning surface is a footgun for a
+    solo project.
+
+- **LMDB** (via `heed` or `lmdb-rkv`).
+  - Pros: extremely fast point reads (mmap zero-copy); decades of
+    production use; small code surface.
+  - Cons: C dependency; mmap semantics are subtle on WSL2 and over
+    network filesystems (the Brokkr dev environment is WSL2); writer
+    serialization is single-process global; database file size is
+    pre-allocated and fragile to grow; harder to fuzz.
+
+- **SQLite** (via `rusqlite` or `sqlx`).
+  - Pros: the most boring, most-tested embedded store on earth; SQL is
+    universally understood; great tooling.
+  - Cons: SQL surface is overkill for typed KV; we would store
+    bincode-encoded protobuf in `BLOB` columns, which throws away the
+    SQL win; C dependency; row-level overhead on point lookups vs. a
+    pure B-tree; schema migrations become a problem we did not need to
+    have.
+
+- **Hand-rolled bincode-on-disk.**
+  - Pros: zero dependencies; full control.
+  - Cons: we would be reinventing crash recovery, transactions, and a
+    page cache; this is a tar pit; the educational core of the project
+    is Raft (Phase 5), not a B-tree (Phase 0).
+
+- **Use Raft KV from day one** (`raft-rs`, `openraft`, etc.).
+  - Cons: violates CLAUDE.md hard rule #10 (no external Raft crate);
+    delays Phase 1 by months; inverts the learning order — we want to
+    *use* a simple store first so we know what the Raft store needs to
+    replace.
+
+## Consequences
+
+### Positive
+
+- **Pure Rust.** Cross-compilation to Linux aarch64 from x86_64 (and to
+  macOS/Windows for the CLI) needs no system protobuf or C++ toolchain.
+- **B-tree predictability.** Action-cache point reads are O(log n) with
+  bounded variance — the right shape for our hot path.
+- **Single-file databases.** Backups, snapshots, and `scp`-style
+  operational moves are trivial; one file per logical store.
+- **MVCC reads** allow long readers without blocking writers — fits the
+  control-plane pattern of frequent reads, occasional writes.
+- **Format stability** — redb 2.x explicitly commits to read-compatibility
+  for older databases. Phase 1 data will still open in Phase 4.
+- **Migration path to Raft.** Each redb table maps cleanly to a Raft
+  state-machine column family; the snapshot format becomes "the redb
+  file at log index N." We will not need to redesign the storage shape
+  to bolt on Raft — only the replication layer above it.
+
+### Negative
+
+- **Single-process only.** No client/server mode; the metadata store
+  *is* the control-plane process. Acceptable through Phase 4; Phase 5
+  changes this by design.
+- **Smaller community than RocksDB or SQLite.** Bug reports against
+  redb are answered, but ecosystem expertise is shallower. Mitigated
+  by: redb is small enough to read end-to-end if we hit a bug.
+- **No replication, no async I/O.** redb is synchronous and local. We
+  call it from `tokio::task::spawn_blocking` to keep the runtime
+  responsive. Documented as a wrapper pattern in `brokkr-common`.
+- **No SQL.** Ad-hoc operational queries ("which tenant owns this
+  action cache row?") require either a small CLI subcommand or a
+  redb-aware inspection tool. Acceptable; we ship `brokk admin` for
+  this.
+
+### Neutral
+
+- **Encoding** is protobuf for values that travel over the wire (so
+  the disk format matches the RPC format) and bincode for values that
+  never leave the node (refcounts, internal indices). Documented in
+  `crates/brokkr-cas/src/redb_backend.rs`.
+- **One file per logical store** (`action-cache.redb`, `workers.redb`,
+  `tenants.redb`, `refcount.redb`) per `docs/plan.md` §10. Different
+  stores have different durability requirements and are easy to
+  reason about when they are physically separate.
+- **Phase 5 supersession.** This ADR will be superseded by the Raft KV
+  ADR when Phase 5 begins. The supersession is planned, not a failure.
+
+## References
+
+- redb: <https://github.com/cberner/redb>
+- redb file-format stability notes:
+  <https://github.com/cberner/redb/blob/master/docs/design.md>
+- `docs/plan.md` §6.6 (Metadata Store), §7 (Technology Stack),
+  §10 (Storage Layout), §17 (Phase 5 Raft).
+- `crates/brokkr-cas/src/redb_backend.rs` — current usage.
+- TiKV's RocksDB experience (counter-example at scale):
+  <https://github.com/tikv/tikv>
+- sled status discussion:
+  <https://github.com/spacejam/sled/issues>

--- a/docs/architecture/0004-tracing-from-day-one.md
+++ b/docs/architecture/0004-tracing-from-day-one.md
@@ -1,0 +1,145 @@
+# 0004 — Tracing from day one
+
+- **Status:** accepted
+- **Date:** 2026-04-30
+- **Deciders:** Brokkr maintainers
+
+## Context
+
+Brokkr's project axioms include "**observable from day one** — if you can't
+trace a job's lifecycle through the system in 30 seconds, the system is
+broken" (`docs/plan.md` §1). This is not aspirational; it is a constraint
+on every line of code written from Phase 0 onward.
+
+Distributed systems retrofitted with observability are observability
+catastrophes. The instrumentation has to be load-bearing in the type
+system: every async function on the hot path needs a span, every RPC has
+to propagate context, every error has to carry structured fields. Adding
+this in Phase 4 means re-touching every async fn in the codebase.
+
+We must commit to one observability stack before Phase 1 writes its first
+RPC handler.
+
+## Decision
+
+Use the **`tracing` crate** as the universal facade for both logging and
+spans, paired with **`tracing-subscriber`** for sinks and
+**`tracing-opentelemetry`** for OTLP export. Concretely:
+
+- **Facade:** `tracing` is the *only* logging/observability API used in
+  library crates. No `log`, no `slog`, no `println!`, no `eprintln!`.
+- **Spans on every public async fn** at module-or-higher visibility.
+  Use `#[tracing::instrument(skip(...))]` with explicit field allowlists.
+- **Structured fields** (`tracing::info!(field = ?value, "message")`),
+  never `format!("…{value}…")` interpolation.
+- **Span on every RPC** — inbound (server handler) and outbound (client
+  call). Span names follow `<service>.<method>` (`cas.batch_read_blobs`).
+- **W3C Trace Context propagation** through gRPC metadata
+  (`traceparent` header). Helper lives in
+  `brokkr-common::trace_context::{inject, extract}`.
+- **Subscriber per binary**, not per library:
+  - **Dev profile:** pretty stdout subscriber with `RUST_LOG`-driven
+    `EnvFilter`.
+  - **Prod profile:** JSON subscriber to stdout *plus* OTLP exporter to
+    a configured collector endpoint.
+- **No `tokio::spawn` without `.in_current_span()`** — orphaned tasks
+  break trace continuity. Enforced by code review.
+
+Standard span fields, populated wherever they exist in scope:
+`tenant_id`, `job_id`, `worker_id`, `digest`, `phase`. These names are
+fixed across crates so dashboards and trace queries stay portable.
+
+## Alternatives considered
+
+- **`log` + `env_logger`.**
+  - Pros: simplest, smallest, matches a decade of Rust convention.
+  - Cons: no spans (cannot represent "this work happens inside that
+    work"); no contextual fields without the `kv` extension that few
+    appenders implement; useless for tracing a job across crate
+    boundaries; would have to be replaced anyway by Phase 3.
+
+- **`slog`.**
+  - Pros: structured logging, contextual loggers via `BorrowedKV`.
+  - Cons: no real spans, weaker async story than `tracing`, smaller
+    ecosystem in 2026, no first-party OTLP integration.
+
+- **`opentelemetry-rust` directly (no `tracing` facade).**
+  - Pros: one fewer indirection layer; full OTel feature surface
+    available natively.
+  - Cons: ergonomics are noticeably worse than `tracing!` macros;
+    every crate would need to pin an OTel API version; loses the
+    pluggable subscriber model that makes tests easy.
+
+- **`tracing` + Jaeger-only (no OpenTelemetry).**
+  - Pros: lighter dep tree.
+  - Cons: locks us to one backend; OTLP is the industry standard and
+    Jaeger speaks it natively.
+
+- **printf debugging / `eprintln!` until Phase N.**
+  - Cons: rejected by project axiom; explicitly listed as an
+    anti-pattern in `docs/plan.md` §27.
+
+## Consequences
+
+### Positive
+
+- **Cross-service traces.** A `brokk run` invocation produces a single
+  trace spanning CLI → control plane → CAS → worker → sandbox, because
+  every hop propagates the same trace context.
+- **Structured logs are queryable.** `tenant_id=X` filters work
+  uniformly in stdout JSON, in OTLP collectors, and in tests.
+- **Performance overhead is negligible.** `tracing`'s zero-cost
+  filtering means events below the active level cost ~1ns; spans cost
+  ~50ns when enabled. Far below our latency targets (`docs/plan.md`
+  §23).
+- **Test ergonomics.** `tracing-test` lets unit tests assert on
+  emitted spans/events without taking dependencies on global state.
+- **Graceful degradation.** OTLP collector down? The exporter buffers
+  and drops; the application keeps running. The dev subscriber writes
+  to stdout regardless.
+
+### Negative
+
+- **Discipline cost.** Contributors must remember `.in_current_span()`
+  on spawned tasks and `skip(self)` on `&self` instrument macros.
+  Mitigated by clippy lints below.
+- **Subscriber init order matters.** Initializing tracing after the
+  first event drops that event. Each binary's `main` initializes the
+  subscriber as its first non-trivial action.
+- **Span explosion is a real failure mode.** `#[instrument]` on a hot
+  inner function produces millions of spans. Reserve `instrument` for
+  public-facing async fns; use `tracing::trace_span!` inside hot loops
+  and disable by default.
+
+### Neutral
+
+- **Lint enforcement.** `clippy.toml` will list:
+  ```
+  disallowed-macros = [
+      { path = "std::println", reason = "use tracing::info! / debug!" },
+      { path = "std::eprintln", reason = "use tracing::warn! / error!" },
+      { path = "std::dbg", reason = "use tracing::debug!" },
+  ]
+  ```
+  Binaries that legitimately print user-facing output (`brokk` CLI)
+  opt out via `#[allow(clippy::disallowed_macros)]` on the specific
+  call site.
+- **Dependency footprint** is meaningful but justified: `tracing`,
+  `tracing-subscriber`, `tracing-opentelemetry`, and the OTLP exporter
+  add ~15 transitive crates. All are widely used and actively
+  maintained.
+- **Span fields documented centrally** in
+  `crates/brokkr-common/src/trace_fields.rs` so cross-crate field
+  names do not drift.
+
+## References
+
+- `docs/plan.md` §1 (Project axioms), §22 (Observability), §27
+  (Anti-patterns), §23 (Performance targets).
+- `tracing`: <https://docs.rs/tracing>
+- `tracing-opentelemetry`: <https://docs.rs/tracing-opentelemetry>
+- W3C Trace Context: <https://www.w3.org/TR/trace-context/>
+- "Tracing in Rust" (Tokio blog):
+  <https://tokio.rs/blog/2019-08-tracing>
+- OpenTelemetry Protocol (OTLP):
+  <https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md>

--- a/docs/architecture/0005-no-docker-for-sandbox.md
+++ b/docs/architecture/0005-no-docker-for-sandbox.md
@@ -1,0 +1,174 @@
+# 0005 — No Docker (or other container runtime) for the sandbox
+
+- **Status:** accepted
+- **Date:** 2026-04-30
+- **Deciders:** Brokkr maintainers
+
+## Context
+
+The sandbox runtime (`brokkr-sandbox`, Phase 2 — `docs/plan.md` §6.5,
+§14) is the most security-sensitive subsystem in Brokkr. It executes
+arbitrary, untrusted code on workers and is responsible for: filesystem
+isolation, process isolation, network isolation, resource limits, syscall
+restriction, and capability dropping.
+
+It is also the most **educational** subsystem. The reason for building
+Brokkr at all (`docs/plan.md` §1) is to internalize how distributed
+systems work end-to-end. Sandboxing on Linux is a deep, well-documented
+craft built on a small set of kernel primitives: namespaces, cgroups,
+seccomp-bpf, capabilities. Understanding these primitives at the
+syscall level is non-negotiable for anyone serious about systems work.
+
+The temptation is obvious: shell out to `docker run` (or `runc`, or
+`podman`) and inherit a battle-tested isolation story for ~200 lines of
+glue code. The temptation must be refused.
+
+## Decision
+
+**Build the sandbox directly on Linux primitives.** No Docker, no runc,
+no containerd, no podman, no OCI-runtime spec, no external container
+runtime of any kind in `brokkr-sandbox`. This is encoded as **CLAUDE.md
+hard rule #9** and is a project-level invariant, not an
+implementation-detail preference.
+
+Concrete primitives used (per `docs/plan.md` §6.5):
+
+1. **Mount namespace + `pivot_root`** — minimal rootfs, bind-mounts of
+   `/usr/bin`, `/lib`, `/lib64` from a configurable host allowlist;
+   tmpfs for `/tmp` and `/work`.
+2. **PID namespace** — sandboxed process is PID 1 with a small reaper
+   for SIGCHLD.
+3. **User namespace** — host UID `brokkr-sandbox` maps to UID 0 inside.
+4. **Network namespace** — empty by default; opt-in network from the
+   action's `Platform` constraints.
+5. **cgroups v2** — per-action cgroup with CPU, memory, pids, io
+   limits; OOM = structured action failure.
+6. **seccomp-bpf** — default-deny syscall filter with an explicit
+   allowlist (initial list in `docs/plan.md` §14 task 6).
+7. **Capability dropping** — all capabilities removed by default.
+8. **Determinism guards** — `LD_PRELOAD` blocked; `/proc/self/environ`
+   minimized; hostname pinned to `brokkr-sandbox`; TZ forced to UTC;
+   `SOURCE_DATE_EPOCH` injected.
+
+Crate dependencies are limited to direct syscall bindings:
+**`nix`** (general syscall wrappers), **`caps`** (capability
+manipulation), and **`libseccomp`** (seccomp-bpf filter compilation).
+No higher-level container abstraction.
+
+## Alternatives considered
+
+- **Docker (`docker run` per action).**
+  - Pros: ubiquitous; mature; large policy ecosystem; "everyone knows
+    Docker."
+  - Cons: requires the Docker daemon (root, single point of failure on
+    the host, host coupling); per-container startup latency 100–500 ms
+    — exceeds our `<50 ms` sandbox-setup target (`docs/plan.md` §23);
+    abdicates the educational core; image-pull semantics force us to
+    pre-publish images for every tool version; `docker exec` semantics
+    are loose around signals and reaping; project axiom (1) says we
+    want to learn this layer.
+
+- **runc (OCI runtime, no daemon).**
+  - Pros: no daemon; widely deployed via Kubernetes; the de facto OCI
+    reference; lower latency than Docker.
+  - Cons: still abstracts away namespaces/cgroups behind `config.json`
+    — we'd be marshaling JSON and missing the point. We would learn
+    the OCI runtime spec, not the kernel primitives. The OCI hooks
+    surface is a poor fit for our determinism guards.
+
+- **podman.**
+  - Pros: rootless; CLI-compatible with Docker; daemonless.
+  - Cons: same abdication problem as Docker; adds another runtime
+    surface to integrate with and test against; rootless mode has its
+    own UID/GID gotchas that we would have to debug at a layer we
+    don't own.
+
+- **gVisor (userspace kernel).**
+  - Pros: strongest isolation short of full virtualization; defends
+    against kernel exploits that escape namespaces.
+  - Cons: real performance cost (commonly 20–50 % on syscall-heavy
+    workloads); adds a Go runtime dependency; still a higher-level
+    abstraction over the primitives. **Worth revisiting in Phase 6+
+    as an *additional* opt-in isolation tier**, not as a replacement
+    for the primitive layer this ADR establishes.
+
+- **Firecracker (microVM per action).**
+  - Pros: VM-grade isolation; AWS Lambda's choice; fast for VMs.
+  - Cons: ~125 ms boot floor even with snapshotting; designed for
+    long-lived FaaS workers, not sub-second build steps; Linux
+    KVM-only; overkill for the "compile a C file" baseline workload.
+
+- **Bubblewrap.**
+  - Pros: closest in spirit — a thin C wrapper over the same kernel
+    primitives. Used by Flatpak.
+  - Cons: still a wrapper; we want to write the wrapper. Reading its
+    source is allowed and recommended.
+
+- **NsJail / Bazel `linux-sandbox` / nsjail-style as a dependency.**
+  - Pros: closest existing sandbox shaped like ours.
+  - Cons: same abdication; using their code defeats the learning
+    purpose. Reading their source is required and informs our design.
+
+## Consequences
+
+### Positive
+
+- **Educational core preserved.** Phase 2 forces deep familiarity with
+  `man 7 namespaces`, `man 7 cgroups`, `man 2 seccomp`. This compounds
+  into Phase 5 (Raft) and beyond — the kernel-level fluency makes
+  every later phase easier.
+- **Lower latency.** No daemon, no container image pull, no
+  marshaling through `config.json`. Our `<50 ms` sandbox-setup target
+  (`docs/plan.md` §23) is achievable; with Docker it would not be.
+- **Tighter security policy.** We can author seccomp filters per
+  *action class* (compilers, test runners, ML training) rather than
+  one-size-fits-all. Easy when we own the policy generator; awkward
+  through OCI.
+- **No host coupling.** Workers do not require a Docker daemon, a
+  containerd socket, or any privileged service except their own
+  user-namespace setup.
+- **Fewer moving parts.** A sandbox bug is a Brokkr bug, not a
+  Docker-version bug. We own the entire failure mode.
+
+### Negative
+
+- **More code.** Estimated 2–3 kLOC for the full sandbox vs. ~200 for
+  an OCI-shim; expect a Phase 2 of significant size.
+- **Steeper kernel knowledge curve.** Every contributor touching
+  `brokkr-sandbox` needs to read the relevant `man` pages
+  (Phase 2 reading list, `docs/plan.md` §28 Tier 2).
+- **We own boundary bugs.** A sandbox escape is on us. Mitigated by
+  the "evil action" test suite (`docs/plan.md` §14 task 10) — every
+  isolation boundary tested with an attacker.
+- **Linux-only workers.** Confirmed and intentional (`docs/plan.md`
+  §2). The CLI and control plane stay portable; only worker
+  binaries require Linux.
+
+### Neutral
+
+- **gVisor as Phase 6+ extension.** Adding a "high-isolation mode"
+  later that wraps the primitive sandbox in gVisor does **not**
+  invalidate this ADR. It layers above the primitive layer this
+  decision establishes.
+- **Phase 1 uses plain `tokio::process::Command`** with no
+  isolation. That is documented as correct in the CLAUDE.md
+  phase-awareness section, not a bug. The sandbox lands in Phase 2.
+- **Crate dependency invariants.** `brokkr-sandbox` depends only on
+  `brokkr-common` plus the primitive bindings (`nix`, `caps`,
+  `libseccomp`). It does not depend on any HTTP/RPC code; the
+  worker calls into it.
+
+## References
+
+- `docs/plan.md` §1 (Project axioms), §6.5 (Sandbox Runtime),
+  §14 (Phase 2 tasks), §27 (Anti-patterns), §28 Tier 2
+  (kernel reading list).
+- CLAUDE.md hard rule #9.
+- `man 7 namespaces`, `man 7 cgroups`, `man 2 unshare`, `man 2 seccomp`.
+- Aleksa Sarai's container blog: <https://www.cyphar.com/blog>
+- Bazel `linux-sandbox` source:
+  <https://github.com/bazelbuild/bazel/tree/master/src/main/tools>
+- gVisor architecture: <https://gvisor.dev/docs/architecture_guide/>
+- NsJail: <https://github.com/google/nsjail>
+- Bubblewrap: <https://github.com/containers/bubblewrap>
+- Firecracker: <https://firecracker-microvm.github.io/>

--- a/docs/architecture/0006-license-apache-2-0.md
+++ b/docs/architecture/0006-license-apache-2-0.md
@@ -1,0 +1,163 @@
+# 0006 — License: Apache-2.0
+
+- **Status:** accepted
+- **Date:** 2026-04-30
+- **Deciders:** Brokkr maintainers
+
+## Context
+
+Brokkr is open-source server infrastructure that executes untrusted
+code, will eventually run multi-tenant, and aspires to be embedded by
+build tools and CI systems at organizations that scrutinize licenses
+during procurement. The license is therefore not a ceremonial choice
+— it shapes:
+
+- **Patent risk** for contributors and downstream adopters.
+- **Enterprise adoption** (most procurement teams allowlist
+  permissive licenses, blocklist copyleft).
+- **Trademark protection** for the "Brokkr" name.
+- **Compatibility** with the rest of the REAPI ecosystem
+  (Bazel itself is Apache-2.0; buildbarn is Apache-2.0;
+  bazel-remote is BSD-3).
+- **Contributor onboarding** — the inbound license rules whether a CLA
+  is needed.
+
+The Rust ecosystem convention is **dual MIT / Apache-2.0**, but that
+convention exists primarily so the Rust *toolchain* can be embedded
+freely in any downstream regardless of patent posture. Brokkr is a
+server, not a toolchain — the convention is informative but not
+load-bearing here.
+
+## Decision
+
+License everything in the workspace under **Apache-2.0**, applied
+uniformly:
+
+- `LICENSE` at the repo root contains the full Apache-2.0 text.
+- `Cargo.toml` `[workspace.package]` sets `license = "Apache-2.0"`.
+- Every crate inherits the workspace license; no per-crate license
+  overrides.
+- Source files do **not** require per-file SPDX headers, but new files
+  may include `// SPDX-License-Identifier: Apache-2.0` at author's
+  discretion.
+- Third-party assets (vendored protos, fixtures) keep their original
+  licenses; aggregate `NOTICE` file is added when the first such
+  attribution accumulates.
+
+## Alternatives considered
+
+- **MIT alone.**
+  - Pros: shortest, most familiar, smallest legal surface.
+  - Cons: **no explicit patent grant** — leaves contributors and
+    downstream exposed to patent-ambush by past contributors. For a
+    project that runs untrusted code and may be embedded in commercial
+    CI products, this is the dealbreaker.
+
+- **Dual MIT / Apache-2.0** (Rust ecosystem convention).
+  - Pros: matches every published Rust crate; downstream picks
+    whichever fits their context; SPDX `MIT OR Apache-2.0` is
+    universally understood.
+  - Cons: the convention exists for *toolchain portability* — that is
+    not Brokkr's situation; doubles the LICENSE files; complicates
+    contributor IP attribution because every contribution is
+    simultaneously dual-licensed; we get no benefit Apache-2.0 alone
+    does not already give us for *server* software.
+
+- **MPL-2.0 (Mozilla Public License).**
+  - Pros: file-level copyleft strikes a middle ground; common in
+    infrastructure (e.g., HashiCorp until 2023).
+  - Cons: less familiar to procurement; weaker patent grant than
+    Apache-2.0; recent industry sentiment has moved away from
+    file-level copyleft for infra.
+
+- **GPL-3.0.**
+  - Pros: forces downstream to contribute back; aligns with
+    free-software ideals.
+  - Cons: incompatible with most enterprise procurement; deters the
+    "point Bazel at it" use case; closes the door on commercial
+    embeddings (which we may want, even if we are not building a
+    SaaS).
+
+- **AGPL-3.0.**
+  - Pros: closes the SaaS loophole; ensures network-deployed forks
+    contribute back.
+  - Cons: enterprise procurement actively blocklists AGPL; "deployment
+    as distribution" semantics frighten self-hosters; severe adoption
+    headwind for a project whose value is "self-host this and point
+    Bazel at it."
+
+- **BUSL (Business Source License).**
+  - Pros: source-available with a delayed open-source conversion;
+    protects against direct SaaS competition during the early years.
+  - Cons: not OSI-approved (so not "open source" in the strict sense);
+    alienates contributors; useful only when there is a SaaS
+    competitor to fend off — premature for Brokkr; the project axioms
+    do not require SaaS-defense.
+
+- **Elastic License v2 / SSPL.**
+  - Cons: same problems as BUSL; community sentiment in 2024–2026 has
+    been openly hostile after the Elastic and MongoDB precedents;
+    not a fit.
+
+## Consequences
+
+### Positive
+
+- **Explicit patent grant.** Apache-2.0 §3 grants a patent license
+  from contributors to downstream users. Without this, any
+  contributor's employer could in principle sue downstream adopters
+  over patents covering contributed code.
+- **Trademark reservation.** Apache-2.0 §6 explicitly does not grant
+  trademark rights — preserves our ability to defend the "Brokkr"
+  name against forks claiming endorsement.
+- **Enterprise-friendly.** Apache-2.0 is on every major
+  procurement-team allowlist (CNCF, Apache Software Foundation, AWS,
+  Google, Microsoft all default to it). Removes the most common
+  adoption friction.
+- **REAPI ecosystem fit.** Bazel (Apache-2.0), buildbarn
+  (Apache-2.0), and BuildBuddy (MIT) are all permissively licensed;
+  we integrate cleanly.
+- **Inbound = outbound.** Per Apache-2.0 §5, contributions are
+  inbound under the same terms unless explicitly stated otherwise.
+  No CLA required during the solo phase.
+- **One license, one SPDX expression.** Easier `cargo deny check
+  licenses`; simpler audit; no choice paralysis when filing PRs.
+
+### Negative
+
+- **Not GPLv2-compatible.** GPLv2-only code cannot link Apache-2.0
+  code (the patent terms conflict). GPLv3 is fine. We never depend
+  on GPLv2-only Rust crates; `deny.toml` will enforce this.
+- **Per-file headers convention.** Apache-2.0 traditionally expects
+  per-file copyright headers. We waive this for code clarity and
+  rely on the root `LICENSE` and `Cargo.toml` metadata; this is a
+  defensible reading of the license but worth noting.
+- **No "viral" protection.** Forks may take Brokkr private. Accepted
+  as the cost of broad adoption; the project axioms do not include
+  "force downstream contribution."
+
+### Neutral
+
+- **Crate publishing readiness** (Phase 4+). `license = "Apache-2.0"`
+  is already set in the workspace; nothing changes when we publish to
+  crates.io.
+- **Future re-licensing** would require contributor consent from
+  every author. Manageable in the solo phase; if external
+  contributors arrive, we will add a CLA before accepting their
+  patches if re-licensing remains a possibility. **No such CLA is
+  required today.**
+- **Vendored REAPI protos** (`crates/brokkr-proto/protos/`) carry
+  their upstream Apache-2.0 license; combination is straightforward
+  and a `NOTICE` entry will be added when we cut a release.
+
+## References
+
+- Apache License 2.0 text: <https://www.apache.org/licenses/LICENSE-2.0>
+- "Choose a License" overview: <https://choosealicense.com/licenses/apache-2.0/>
+- Rust dual-licensing rationale (historical):
+  <https://internals.rust-lang.org/t/rationale-of-dual-licensing-mit-x11-asl2/8794>
+- `docs/plan.md` §31 Open Questions (license item, now resolved by
+  this ADR).
+- Workspace metadata: `Cargo.toml` `[workspace.package]`.
+- REAPI license posture:
+  <https://github.com/bazelbuild/remote-apis/blob/main/LICENSE>

--- a/docs/architecture/0007-cas-gc-strategy.md
+++ b/docs/architecture/0007-cas-gc-strategy.md
@@ -1,0 +1,68 @@
+# 0007 — CAS garbage collection strategy
+
+- **Status:** proposed (placeholder — to be filled out during Phase 3 design)
+- **Date:** 2026-04-30
+- **Deciders:** Brokkr maintainers
+
+## Context
+
+The CAS accumulates blobs indefinitely. Without a garbage collector,
+local NVMe and cold S3 storage grow without bound. We need a GC
+strategy that:
+
+- Never deletes a blob still reachable from a live action-cache entry.
+- Reclaims space predictably under storage pressure.
+- Survives a crash mid-collection without losing data or double-freeing.
+- Works across the tiered storage hierarchy (hot / warm / cold).
+- Eventually composes with hash-prefix sharding (Phase 3) and Raft-backed
+  metadata (Phase 5).
+
+The tentative direction (`docs/plan.md` §31): **reference counting backed
+by the action cache, plus LRU eviction in the warm tier.** This ADR is
+the placeholder for the full decision.
+
+## Decision
+
+**To be decided during Phase 3 design.** The current placeholder
+direction:
+
+- Refcount table in `refcount.redb` (already sketched in
+  `docs/plan.md` §10).
+- Increment on `UpdateActionResult` for every output digest + every
+  input digest in the referenced `Action`.
+- Decrement on action-cache TTL expiry or explicit eviction.
+- Warm-tier LRU eviction independent of refcount (a refcounted blob
+  can be cold-tier-only if it's not hot).
+
+## Alternatives to evaluate
+
+(Deferred — fill out before Phase 3 implementation begins.)
+
+- Reference counting + LRU (tentative).
+- Mark-and-sweep with periodic full scans.
+- Generational / time-based eviction (Bigtable-style TTL columns).
+- External GC service vs. in-process collector.
+- Hybrid: refcount for correctness, LRU for capacity, mark-sweep as
+  periodic safety net.
+
+## Consequences
+
+To be filled out alongside the decision.
+
+## Open questions for Phase 3
+
+- How are refcounts kept consistent across sharded CAS nodes?
+- What happens to a blob whose only reference is a soft-evicted action
+  cache entry?
+- Do we refcount per-tier (hot/warm/cold) or per-blob globally?
+- How does GC interact with in-flight `BatchUpdateBlobs` writes?
+- What is the failure mode if the refcount table diverges from
+  ground truth — repair scan, or fail-stop?
+
+## References
+
+- `docs/plan.md` §6.1 (CAS), §10 (Storage layout), §15 (Phase 3),
+  §31 (Open Questions — GC item).
+- Bigtable paper (TTL/garbage collection patterns).
+- bazel-remote GC implementation (LRU prior art):
+  <https://github.com/buchgr/bazel-remote>

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1145,11 +1145,11 @@ Place ADRs (Architecture Decision Records) in `docs/architecture/`. Format:
 
 Track unresolved design questions here. Resolve before they become blockers.
 
-- [ ] **License:** Apache-2.0 (default for infra) vs. MIT (simpler)? **Tentative: Apache-2.0** for explicit patent grant.
+- [x] **License:** Apache-2.0 (default for infra) vs. MIT (simpler)? **Resolved: Apache-2.0** — see ADR `0006-license-apache-2-0.md`.
 - [ ] **MSRV policy:** lock to 1.78 or follow latest stable? **Tentative: lock, bump quarterly.**
 - [ ] **Single binary vs. multi-binary?** Probably multi (`brokk`, `brokkr-control`, `brokkr-worker`, `brokkr-cas`) — clearer ops, separate metrics.
 - [ ] **Action cache TTL default?** 30 days starting point.
-- [ ] **GC strategy for CAS?** Reference counting + LRU. Need an ADR.
+- [ ] **GC strategy for CAS?** Reference counting + LRU. Placeholder ADR `0007-cas-gc-strategy.md`; finalize during Phase 3 design.
 - [ ] **mTLS vs. token auth as default?** Probably mTLS for worker↔control, tokens for client↔control.
 - [ ] **Schema evolution policy for protos?** Brokkr-internal protos versioned per-namespace; REAPI is upstream so we follow upstream.
 - [ ] **Telemetry-by-default?** No. Self-hosted infra ships with telemetry off; opt-in only.


### PR DESCRIPTION
## Summary

Backfills the ADRs called out in `docs/plan.md` §30 ("ADRs to write before Phase 0 ends") plus a placeholder for the CAS GC strategy from §31. Each ADR follows the §30 template and cites the relevant plan sections plus in-tree files where applicable.

- **0002 — REAPI compatibility.** REAPI v2 is the canonical public wire; Brokkr extensions live in `brokkr.v1.*` and never extend REAPI in place.
- **0003 — Embedded KV: redb.** redb 2.x for Phases 0–4. Pure Rust, ACID, B-tree; supersession by the Phase 5 Raft KV is anticipated, not a failure.
- **0004 — Tracing from day one.** `tracing` + `tracing-subscriber` + `tracing-opentelemetry` + W3C Trace Context propagation; bans `println!`/`eprintln!` in lib code.
- **0005 — No Docker for sandbox.** Codifies CLAUDE.md hard rule #9. Rejects Docker, runc, podman, gVisor, Firecracker, and bubblewrap with reasons each; gVisor flagged as a possible Phase 6+ opt-in tier above the primitive layer.
- **0006 — License: Apache-2.0.** Single Apache-2.0 (not the Rust dual-license convention); explains why server software differs from toolchain software, and notes the patent-grant and trademark-reservation reasoning.
- **0007 — CAS GC strategy (placeholder).** `proposed` status; tentative direction (refcount + LRU) recorded, full decision deferred to Phase 3 design with open questions enumerated.

Also updates `docs/plan.md` §31:
- License open question marked resolved with a pointer to ADR 0006.
- GC open question now points at the 0007 placeholder.

## Test plan

Docs-only change — no code touched, no tests to run.

- [ ] Skim each ADR for accuracy against the current state of `Cargo.toml`, `crates/brokkr-proto/build.rs`, and `crates/brokkr-cas/src/redb_backend.rs`.
- [ ] Confirm 0005's primitives list still matches `docs/plan.md` §6.5 / §14.
- [ ] Confirm 0006's license matches `LICENSE` and `[workspace.package].license` in `Cargo.toml`.