### PR TITLE
feat(phase2): M2 — sandbox skeleton, re-exec model, plain-spawn parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,3 +79,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   commands, miss-then-hit each, `#[ignore]`-soak) and
   `cache_hit_faster_than_miss` (median-of-10 timing comparison).
   Shared cluster fixture moved to `tests/common/mod.rs`.
+
+## Phase 2 (in progress)
+
+### Added
+- `docs/phase-2-plan.md` — detailed Phase 2 implementation plan (threat
+  model, re-exec runner architecture, public API, per-subsystem designs,
+  evil-action matrix, M1–M9 milestones, CI / WSL2 notes).
+- `brokkr-sandbox` public API: `Sandbox`, `SandboxConfig`, `SandboxOutcome`,
+  `ExitStatus`, `ResourceAccounting`, `SandboxTimings`, `SandboxError` —
+  full type surface that subsequent milestones light up incrementally.
+  `SandboxConfig` is also the IPC payload between host and runner
+  (serde JSON over fd 3).
+- `brokkr-sandboxd` runner binary inside the `brokkr-sandbox` crate.
+  M2 reads the config from fd 3, optionally chdirs to `workdir`, and
+  `execvpe`s the action — Phase-1 parity inside the new re-exec model.
+  Namespace / cgroup / seccomp setup is added by M3–M8.
+- Host-side spawn uses `pipe2(O_CLOEXEC)` for the config pipe so the
+  runner's inherited copy of the write end auto-closes on `execve`,
+  letting `read_to_end(fd 3)` see EOF.
+- `brokkr-sandbox/tests/sandbox_smoke.rs` — seven end-to-end smoke
+  tests (echo, /bin/false, missing argv0, empty argv error, env
+  passthrough, workdir, timings populated).
+- `nix` workspace dep (`features = ["fs", "process", "user"]`) for the
+  raw Linux primitives the sandbox needs.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,7 +269,13 @@ name = "brokkr-sandbox"
 version = "0.1.0"
 dependencies = [
  "brokkr-common",
+ "bytes",
+ "nix",
+ "serde",
+ "serde_json",
+ "tempfile",
  "thiserror",
+ "tokio",
  "tracing",
 ]
 
@@ -338,6 +344,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -828,6 +840,18 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nu-ansi-term"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,9 @@ clap = { version = "4", features = ["derive"] }
 proptest = "1"
 tempfile = "3"
 
+# Linux primitives (sandbox)
+nix = { version = "0.29", default-features = false, features = ["fs", "process", "user"] }
+
 # Internal crates
 brokkr-common = { path = "crates/brokkr-common", version = "0.1.0" }
 brokkr-proto = { path = "crates/brokkr-proto", version = "0.1.0" }

--- a/crates/brokkr-sandbox/Cargo.toml
+++ b/crates/brokkr-sandbox/Cargo.toml
@@ -11,7 +11,21 @@ description = "Linux-primitive sandbox runtime for Brokkr (namespaces, cgroups, 
 [lints]
 workspace = true
 
+[[bin]]
+name = "brokkr-sandboxd"
+path = "src/bin/sandboxd.rs"
+
 [dependencies]
 brokkr-common.workspace = true
+bytes.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 tracing.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+nix.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/brokkr-sandbox/src/bin/sandboxd.rs
+++ b/crates/brokkr-sandbox/src/bin/sandboxd.rs
@@ -1,0 +1,15 @@
+//! `brokkr-sandboxd` — the Phase 2 sandbox runner binary.
+//!
+//! The host worker spawns this binary once per action with a
+//! [`SandboxConfig`](brokkr_sandbox::SandboxConfig) on file descriptor 3.
+//! The runner reads the config, sets up the sandbox, and `execve`s the
+//! action.
+//!
+//! Phase 2 lights up the sandbox setup incrementally — see
+//! `docs/phase-2-plan.md` §9. M2 ships this as a thin re-exec shim that
+//! reads the config and executes the action with no isolation, mirroring
+//! Phase 1 behaviour inside the new process model.
+
+fn main() -> ! {
+    brokkr_sandbox::run_as_runner()
+}

--- a/crates/brokkr-sandbox/src/config.rs
+++ b/crates/brokkr-sandbox/src/config.rs
@@ -31,7 +31,9 @@ pub struct SandboxConfig {
     #[serde(default)]
     pub workdir: Option<PathBuf>,
 
-    /// What the action's stdin should be wired to.
+    /// What the action's stdin should be wired to. **M2 ignores this**:
+    /// the host always spawns the runner with `Stdio::null()`. Honouring
+    /// this field is scheduled alongside the determinism work in M8.
     #[serde(default)]
     pub stdin: StdioPolicy,
 

--- a/crates/brokkr-sandbox/src/config.rs
+++ b/crates/brokkr-sandbox/src/config.rs
@@ -1,0 +1,200 @@
+//! Configuration types for a single sandboxed action.
+//!
+//! [`SandboxConfig`] is also the IPC payload between the host worker and the
+//! `brokkr-sandboxd` runner: it serialises to JSON and is sent over the
+//! configuration pipe (file descriptor 3 by convention).
+//!
+//! Phase 2 milestones light up the runner-side handling of these fields
+//! incrementally — see `docs/phase-2-plan.md` §9. M2 honours `argv`, `env`,
+//! and `workdir`; the rest are accepted on the wire so the API stays stable
+//! while later milestones add behaviour.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Full configuration for one sandboxed action.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SandboxConfig {
+    /// Command to execute. `argv[0]` is looked up via `PATH` if it does not
+    /// contain a slash.
+    pub argv: Vec<String>,
+
+    /// Environment passed to the action. M2 passes this verbatim. M8 will
+    /// scrub `LD_PRELOAD` etc. and inject deterministic defaults per
+    /// [`DeterminismPolicy`].
+    #[serde(default)]
+    pub env: Vec<(String, String)>,
+
+    /// Working directory inside the sandbox. M2 chdirs the runner to this
+    /// path before exec.
+    #[serde(default)]
+    pub workdir: Option<PathBuf>,
+
+    /// What the action's stdin should be wired to.
+    #[serde(default)]
+    pub stdin: StdioPolicy,
+
+    /// Filesystem layout (M3+).
+    #[serde(default)]
+    pub rootfs: RootfsSpec,
+
+    /// Resource limits (M6).
+    #[serde(default)]
+    pub limits: ResourceLimits,
+
+    /// Network policy (M5).
+    #[serde(default)]
+    pub network: NetworkPolicy,
+
+    /// Determinism guards (M8).
+    #[serde(default)]
+    pub determinism: DeterminismPolicy,
+
+    /// Capabilities to retain (M7). Default: empty (drop everything).
+    #[serde(default)]
+    pub retained_caps: Vec<String>,
+
+    /// Additional syscalls to allow on top of the default seccomp whitelist
+    /// (M7).
+    #[serde(default)]
+    pub extra_seccomp_allow: Vec<String>,
+}
+
+impl SandboxConfig {
+    /// Construct a minimal config that runs `argv` with no env, no workdir,
+    /// default policies for everything else.
+    pub fn new(argv: Vec<String>) -> Self {
+        Self {
+            argv,
+            ..Default::default()
+        }
+    }
+}
+
+/// What the action's stdin should be wired to.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StdioPolicy {
+    /// `/dev/null`.
+    #[default]
+    Null,
+    /// Inherit the runner's stdin (rarely useful; mostly for interactive
+    /// debugging).
+    InheritStdin,
+}
+
+/// Filesystem layout for the sandbox rootfs. M2 ignores this; M3 starts
+/// honouring it. See `docs/phase-2-plan.md` §5.1.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RootfsSpec {
+    /// Read-only host paths to bind into the rootfs. Each entry is
+    /// `(host_path, sandbox_path)`.
+    #[serde(default)]
+    pub ro_binds: Vec<(PathBuf, PathBuf)>,
+
+    /// Read-write tmpfs mounts inside the sandbox. Each entry is
+    /// `(sandbox_path, size_bytes)`.
+    #[serde(default)]
+    pub tmpfs: Vec<(PathBuf, u64)>,
+
+    /// Optional input tree to materialize under [`SandboxConfig::workdir`].
+    #[serde(default)]
+    pub input_root: Option<PathBuf>,
+}
+
+/// Per-action resource limits. `None` means "do not constrain". M6 wires
+/// these into per-action cgroups.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct ResourceLimits {
+    /// CPU bandwidth limit, in milli-CPU (1000 = 1 core). Maps to
+    /// `cpu.max`.
+    #[serde(default)]
+    pub cpu_milli: Option<u64>,
+    /// Memory limit in bytes. Maps to `memory.max`.
+    #[serde(default)]
+    pub memory_bytes: Option<u64>,
+    /// Maximum concurrent PIDs. Maps to `pids.max`.
+    #[serde(default)]
+    pub pids_max: Option<u64>,
+    /// Per-block-device read throughput limit. Maps to `io.max`.
+    #[serde(default)]
+    pub io_read_bytes_per_sec: Option<u64>,
+    /// Per-block-device write throughput limit. Maps to `io.max`.
+    #[serde(default)]
+    pub io_write_bytes_per_sec: Option<u64>,
+    /// Wall-clock timeout, in seconds. The runner SIGKILLs the action when
+    /// this elapses and reports [`crate::ExitStatus::Timeout`].
+    #[serde(default)]
+    pub wall_clock_secs: Option<u64>,
+}
+
+/// Network policy for the action's network namespace. M5 wires this in.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkPolicy {
+    /// New empty netns. No interfaces, no routes — fully hermetic.
+    #[default]
+    None,
+    /// New netns with the loopback interface brought up.
+    Loopback,
+}
+
+/// Determinism guards. M8 wires these in.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DeterminismPolicy {
+    /// Hostname to set inside the UTS namespace. `None` = leave as-is.
+    /// Default policy in `brokkr-worker` will set this to `brokkr-sandbox`.
+    #[serde(default)]
+    pub hostname: Option<String>,
+    /// Force `/etc/localtime` → `Etc/UTC`.
+    #[serde(default)]
+    pub timezone_utc: bool,
+    /// `SOURCE_DATE_EPOCH` to inject for reproducible-build tooling.
+    #[serde(default)]
+    pub source_date_epoch: Option<i64>,
+    /// Strip `LD_PRELOAD` and `LD_LIBRARY_PATH` from the env before exec.
+    #[serde(default)]
+    pub strip_ld_preload: bool,
+    /// Replace `PATH` with a fixed default (`/usr/bin:/bin`).
+    #[serde(default)]
+    pub strip_path: bool,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic, clippy::disallowed_methods)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_round_trips_through_json() {
+        let cfg = SandboxConfig {
+            argv: vec!["/bin/echo".into(), "hi".into()],
+            env: vec![("PATH".into(), "/usr/bin".into())],
+            workdir: Some("/work".into()),
+            limits: ResourceLimits {
+                memory_bytes: Some(1 << 30),
+                ..Default::default()
+            },
+            network: NetworkPolicy::Loopback,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&cfg).unwrap();
+        let back: SandboxConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.argv, cfg.argv);
+        assert_eq!(back.env, cfg.env);
+        assert_eq!(back.workdir, cfg.workdir);
+        assert_eq!(back.limits.memory_bytes, Some(1 << 30));
+        assert_eq!(back.network, NetworkPolicy::Loopback);
+    }
+
+    #[test]
+    fn defaults_compose_into_a_minimal_config() {
+        let cfg = SandboxConfig::new(vec!["/bin/true".into()]);
+        assert_eq!(cfg.stdin, StdioPolicy::Null);
+        assert_eq!(cfg.network, NetworkPolicy::None);
+        assert!(cfg.env.is_empty());
+        assert!(cfg.rootfs.ro_binds.is_empty());
+        assert!(cfg.limits.memory_bytes.is_none());
+    }
+}

--- a/crates/brokkr-sandbox/src/error.rs
+++ b/crates/brokkr-sandbox/src/error.rs
@@ -1,0 +1,48 @@
+//! Public error type for the sandbox.
+//!
+//! Distinguishes setup-time failures (where the host couldn't even get the
+//! action started) from in-action exit conditions (which surface via
+//! [`crate::ExitStatus`] inside a successful [`crate::SandboxOutcome`]).
+
+use thiserror::Error;
+
+/// Anything that can go wrong while attempting to execute an action in the
+/// sandbox. An action that runs and exits non-zero is *not* an error; that's
+/// signalled via the `exit_status` of [`crate::SandboxOutcome`].
+#[derive(Error, Debug)]
+pub enum SandboxError {
+    /// A host-side setup step (creating pipes, spawning the runner, writing
+    /// the config payload, etc.) failed. The `step` is a stable identifier
+    /// suitable for log fields and metrics labels.
+    #[error("sandbox setup failed at step {step}: {source}")]
+    Setup {
+        /// Stable identifier of the failing step.
+        step: &'static str,
+        /// Underlying OS error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// A required kernel feature is missing or disabled on this host.
+    #[error("the kernel does not support a feature we require: {0}")]
+    Unsupported(&'static str),
+
+    /// The runner process exited or was killed before it could exec the
+    /// action (e.g. failed to parse the config, hit a permission error
+    /// during namespace setup). The string is whatever the runner wrote to
+    /// stderr.
+    #[error("the sandbox runner exited abnormally before exec: {0}")]
+    RunnerCrashed(String),
+
+    /// A cgroup operation (open, write, mkdir, accounting readback) failed.
+    #[error("cgroup operation failed: {0}")]
+    Cgroup(#[source] std::io::Error),
+
+    /// Generic I/O error.
+    #[error("io: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Config (de)serialization failed.
+    #[error("config (de)serialization: {0}")]
+    Json(#[from] serde_json::Error),
+}

--- a/crates/brokkr-sandbox/src/error.rs
+++ b/crates/brokkr-sandbox/src/error.rs
@@ -27,10 +27,18 @@ pub enum SandboxError {
     #[error("the kernel does not support a feature we require: {0}")]
     Unsupported(&'static str),
 
-    /// The runner process exited or was killed before it could exec the
-    /// action (e.g. failed to parse the config, hit a permission error
-    /// during namespace setup). The string is whatever the runner wrote to
-    /// stderr.
+    /// The runner process exited before the host could finish handing it
+    /// the [`crate::SandboxConfig`] payload (M2: the host's pipe write hit
+    /// `EPIPE` and the runner exited non-zero with diagnostics on stderr;
+    /// later milestones will also surface namespace- or cgroup-setup
+    /// failures that happen before the action begins).
+    ///
+    /// The string is whatever the runner wrote to stderr. A runner that
+    /// reads the config successfully and only fails afterwards (e.g. a
+    /// missing `argv[0]` or a bad `workdir`) does *not* produce this
+    /// error; instead the action's exit status surfaces in
+    /// [`crate::SandboxOutcome::exit_status`] (typically `Exited(127)`)
+    /// alongside the runner's stderr.
     #[error("the sandbox runner exited abnormally before exec: {0}")]
     RunnerCrashed(String),
 

--- a/crates/brokkr-sandbox/src/host/ipc.rs
+++ b/crates/brokkr-sandbox/src/host/ipc.rs
@@ -1,0 +1,36 @@
+//! IPC plumbing between the host worker and the `brokkr-sandboxd` runner.
+//!
+//! Phase 2 keeps this small: a single anonymous pipe whose read end is
+//! placed on file descriptor 3 in the runner, used to send a JSON-encoded
+//! [`crate::SandboxConfig`]. The pipe is one-shot; the host writes the
+//! payload and closes, the runner reads to EOF.
+
+use std::io;
+use std::os::fd::{IntoRawFd, OwnedFd, RawFd};
+
+use nix::fcntl::OFlag;
+use nix::unistd::pipe2;
+
+/// A unidirectional config pipe.
+///
+/// Both ends are created with `O_CLOEXEC` so they automatically close on
+/// `execve` in the runner. The host's `pre_exec` hook `dup2`s the read end
+/// to file descriptor 3; `dup2` resets the close-on-exec flag on the
+/// target, so fd 3 survives exec while the originals (and the inherited
+/// copy of the write end in the child) close cleanly. Without `O_CLOEXEC`
+/// the runner would inherit a copy of its own write end, `read_to_end`
+/// would never see EOF, and the host would deadlock on `wait_with_output`.
+pub(super) struct ConfigPipe {
+    /// Write end (host-side).
+    pub(super) writer: OwnedFd,
+    /// Read end as a raw fd (intended for `dup2 → 3` in the child).
+    pub(super) child_read_fd: RawFd,
+}
+
+pub(super) fn create_config_pipe() -> Result<ConfigPipe, io::Error> {
+    let (read_end, write_end) = pipe2(OFlag::O_CLOEXEC).map_err(io::Error::from)?;
+    Ok(ConfigPipe {
+        writer: write_end,
+        child_read_fd: read_end.into_raw_fd(),
+    })
+}

--- a/crates/brokkr-sandbox/src/host/ipc.rs
+++ b/crates/brokkr-sandbox/src/host/ipc.rs
@@ -6,7 +6,7 @@
 //! payload and closes, the runner reads to EOF.
 
 use std::io;
-use std::os::fd::{IntoRawFd, OwnedFd, RawFd};
+use std::os::fd::{AsRawFd, OwnedFd};
 
 use nix::fcntl::OFlag;
 use nix::unistd::pipe2;
@@ -20,17 +20,32 @@ use nix::unistd::pipe2;
 /// copy of the write end in the child) close cleanly. Without `O_CLOEXEC`
 /// the runner would inherit a copy of its own write end, `read_to_end`
 /// would never see EOF, and the host would deadlock on `wait_with_output`.
+///
+/// Both ends are kept as `OwnedFd` on the host so a spawn failure (or any
+/// early return) closes them via Drop instead of leaking. The host hands
+/// the read end's *raw* fd to `pre_exec` by value (it's `Copy`); the
+/// `OwnedFd` itself stays in the host until the host explicitly drops it
+/// after the spawn succeeds.
 pub(super) struct ConfigPipe {
     /// Write end (host-side).
     pub(super) writer: OwnedFd,
-    /// Read end as a raw fd (intended for `dup2 → 3` in the child).
-    pub(super) child_read_fd: RawFd,
+    /// Read end (host-side). Drop-closed on the host side after spawn; the
+    /// child's copy of the same fd is what the runner reads from.
+    pub(super) reader: OwnedFd,
+}
+
+impl ConfigPipe {
+    /// Raw fd of the read end, for use inside `pre_exec` (which captures
+    /// fds by `Copy` value, not by ownership).
+    pub(super) fn reader_raw(&self) -> std::os::fd::RawFd {
+        self.reader.as_raw_fd()
+    }
 }
 
 pub(super) fn create_config_pipe() -> Result<ConfigPipe, io::Error> {
     let (read_end, write_end) = pipe2(OFlag::O_CLOEXEC).map_err(io::Error::from)?;
     Ok(ConfigPipe {
         writer: write_end,
-        child_read_fd: read_end.into_raw_fd(),
+        reader: read_end,
     })
 }

--- a/crates/brokkr-sandbox/src/host/linux.rs
+++ b/crates/brokkr-sandbox/src/host/linux.rs
@@ -1,0 +1,129 @@
+//! Linux-only implementation of `Sandbox::run`.
+//!
+//! Phase 2 / M2 walkthrough:
+//!
+//! 1. Serialise the [`SandboxConfig`] to JSON.
+//! 2. Create a config pipe (`pipe(2)`).
+//! 3. Spawn `brokkr-sandboxd` with the read end of the pipe `dup2`'d to
+//!    fd 3, stdout / stderr captured.
+//! 4. Close our copy of the read end; write the JSON to the write end;
+//!    close.
+//! 5. Wait for the child to exit; collect stdout / stderr.
+//!
+//! Subsequent milestones extend this with cgroup attachment (M6),
+//! resource-accounting readback (M6), and wall-clock enforcement (M8).
+
+use std::fs::File;
+use std::io;
+use std::os::fd::RawFd;
+use std::os::unix::process::ExitStatusExt as _;
+use std::path::Path;
+use std::process::Stdio;
+use std::time::Instant;
+
+use bytes::Bytes;
+use tokio::process::Command;
+
+use super::ipc::create_config_pipe;
+use crate::config::SandboxConfig;
+use crate::error::SandboxError;
+use crate::outcome::{ExitStatus, ResourceAccounting, SandboxOutcome, SandboxTimings};
+
+pub(super) async fn run_action(
+    runner_binary: &Path,
+    cfg: SandboxConfig,
+) -> Result<SandboxOutcome, SandboxError> {
+    let setup_start = Instant::now();
+
+    let payload = serde_json::to_vec(&cfg)?;
+
+    let pipe = create_config_pipe().map_err(|e| SandboxError::Setup {
+        step: "create config pipe",
+        source: e,
+    })?;
+    let child_read_fd: RawFd = pipe.child_read_fd;
+
+    let mut cmd = Command::new(runner_binary);
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env_clear();
+
+    // SAFETY: pre_exec runs in the freshly-forked child between fork and
+    // exec. We perform only async-signal-safe operations: dup2(2) and
+    // close(2) on a pre-existing file descriptor we own. We do not allocate,
+    // touch globals, or call non-reentrant libc routines.
+    #[allow(unsafe_code)]
+    unsafe {
+        cmd.pre_exec(move || {
+            const TARGET_FD: RawFd = 3;
+            if child_read_fd != TARGET_FD {
+                nix::unistd::dup2(child_read_fd, TARGET_FD).map_err(io::Error::from)?;
+                nix::unistd::close(child_read_fd).map_err(io::Error::from)?;
+            }
+            Ok(())
+        });
+    }
+
+    let child = cmd.spawn().map_err(|e| SandboxError::Setup {
+        step: "spawn runner",
+        source: e,
+    })?;
+
+    // Close our (host) copy of the read end now that the child has it.
+    let _ = nix::unistd::close(child_read_fd);
+
+    // Write the JSON payload synchronously and close the write end so the
+    // runner sees EOF on fd 3. Phase-2 config payloads are well under the
+    // 64 KiB Linux pipe-buffer size, so this never blocks. We deliberately
+    // bound `file`'s scope so its Drop closes the fd *before* we wait on
+    // the child — otherwise the runner would block forever on `read_to_end`.
+    {
+        use std::io::Write as _;
+        // OwnedFd → File is a safe conversion (impl From in std).
+        let mut file = File::from(pipe.writer);
+        file.write_all(&payload).map_err(|e| SandboxError::Setup {
+            step: "write config payload",
+            source: e,
+        })?;
+        file.flush().map_err(|e| SandboxError::Setup {
+            step: "flush config payload",
+            source: e,
+        })?;
+    } // file dropped here → write end closed → runner sees EOF on fd 3
+
+    let exec_start = Instant::now();
+    let setup_elapsed = exec_start - setup_start;
+
+    let output = child
+        .wait_with_output()
+        .await
+        .map_err(|e| SandboxError::Setup {
+            step: "wait for runner",
+            source: e,
+        })?;
+
+    let teardown_start = Instant::now();
+    let exec_elapsed = teardown_start - exec_start;
+
+    let exit_status = if let Some(code) = output.status.code() {
+        ExitStatus::Exited(code)
+    } else if let Some(signal) = output.status.signal() {
+        ExitStatus::Signaled { signal }
+    } else {
+        // Should not happen: every Unix exit status has a code or a signal.
+        ExitStatus::Signaled { signal: -1 }
+    };
+
+    Ok(SandboxOutcome {
+        exit_status,
+        stdout: Bytes::from(output.stdout),
+        stderr: Bytes::from(output.stderr),
+        accounting: ResourceAccounting::default(),
+        timings: SandboxTimings {
+            setup: setup_elapsed,
+            execution: exec_elapsed,
+            teardown: teardown_start.elapsed(),
+        },
+    })
+}

--- a/crates/brokkr-sandbox/src/host/linux.rs
+++ b/crates/brokkr-sandbox/src/host/linux.rs
@@ -41,7 +41,7 @@ pub(super) async fn run_action(
         step: "create config pipe",
         source: e,
     })?;
-    let child_read_fd: RawFd = pipe.child_read_fd;
+    let child_read_fd: RawFd = pipe.reader_raw();
 
     let mut cmd = Command::new(runner_binary);
     cmd.stdin(Stdio::null())
@@ -50,16 +50,27 @@ pub(super) async fn run_action(
         .env_clear();
 
     // SAFETY: pre_exec runs in the freshly-forked child between fork and
-    // exec. We perform only async-signal-safe operations: dup2(2) and
-    // close(2) on a pre-existing file descriptor we own. We do not allocate,
-    // touch globals, or call non-reentrant libc routines.
+    // exec. We perform only async-signal-safe operations: dup2(2),
+    // close(2), and fcntl(2) on file descriptors we own. We do not
+    // allocate, touch globals, or call non-reentrant libc routines.
     #[allow(unsafe_code)]
     unsafe {
         cmd.pre_exec(move || {
             const TARGET_FD: RawFd = 3;
             if child_read_fd != TARGET_FD {
+                // dup2 atomically clears FD_CLOEXEC on the target.
                 nix::unistd::dup2(child_read_fd, TARGET_FD).map_err(io::Error::from)?;
                 nix::unistd::close(child_read_fd).map_err(io::Error::from)?;
+            } else {
+                // dup2(N, N) is a no-op and does NOT clear CLOEXEC, so we
+                // have to do it explicitly. Without this, the runner's fd 3
+                // (which inherited O_CLOEXEC from `pipe2`) would close on
+                // `execve`, leaving the runner unable to read its config.
+                nix::fcntl::fcntl(
+                    TARGET_FD,
+                    nix::fcntl::FcntlArg::F_SETFD(nix::fcntl::FdFlag::empty()),
+                )
+                .map_err(io::Error::from)?;
             }
             Ok(())
         });
@@ -69,9 +80,14 @@ pub(super) async fn run_action(
         step: "spawn runner",
         source: e,
     })?;
+    // (If `cmd.spawn()` had failed, `pipe.reader` and `pipe.writer` would
+    // close via Drop on the early return above — no fd leaks.)
 
-    // Close our (host) copy of the read end now that the child has it.
-    let _ = nix::unistd::close(child_read_fd);
+    // Decompose the pipe so the host's copy of the read end closes
+    // immediately (the child has its own copy at fd 3) and `writer` is
+    // free to move into the synchronous-write block below.
+    let crate::host::ipc::ConfigPipe { writer, reader } = pipe;
+    drop(reader);
 
     // Write the JSON payload synchronously and close the write end so the
     // runner sees EOF on fd 3. Phase-2 config payloads are well under the
@@ -86,7 +102,7 @@ pub(super) async fn run_action(
     let write_err = {
         use std::io::Write as _;
         // OwnedFd → File is a safe conversion (impl From in std).
-        let mut file = File::from(pipe.writer);
+        let mut file = File::from(writer);
         let res = file.write_all(&payload).and_then(|()| file.flush()).err();
         drop(file);
         res

--- a/crates/brokkr-sandbox/src/host/linux.rs
+++ b/crates/brokkr-sandbox/src/host/linux.rs
@@ -78,19 +78,27 @@ pub(super) async fn run_action(
     // 64 KiB Linux pipe-buffer size, so this never blocks. We deliberately
     // bound `file`'s scope so its Drop closes the fd *before* we wait on
     // the child — otherwise the runner would block forever on `read_to_end`.
-    {
+    //
+    // EPIPE is intentionally tolerated here: it means the runner already
+    // exited (e.g. its `pre_exec` or startup failed). In that case the
+    // runner's stderr + exit status is the authoritative error, not the
+    // pipe write — let `wait_with_output` collect them and report.
+    let write_err = {
         use std::io::Write as _;
         // OwnedFd → File is a safe conversion (impl From in std).
         let mut file = File::from(pipe.writer);
-        file.write_all(&payload).map_err(|e| SandboxError::Setup {
-            step: "write config payload",
-            source: e,
-        })?;
-        file.flush().map_err(|e| SandboxError::Setup {
-            step: "flush config payload",
-            source: e,
-        })?;
-    } // file dropped here → write end closed → runner sees EOF on fd 3
+        let res = file.write_all(&payload).and_then(|()| file.flush()).err();
+        drop(file);
+        res
+    };
+    if let Some(e) = &write_err {
+        if e.kind() != io::ErrorKind::BrokenPipe {
+            return Err(SandboxError::Setup {
+                step: "write config payload",
+                source: io::Error::new(e.kind(), e.to_string()),
+            });
+        }
+    }
 
     let exec_start = Instant::now();
     let setup_elapsed = exec_start - setup_start;
@@ -102,6 +110,15 @@ pub(super) async fn run_action(
             step: "wait for runner",
             source: e,
         })?;
+
+    // If the host's write hit EPIPE *and* the runner exited non-zero with a
+    // diagnostic on stderr, prefer the runner's message — it's almost
+    // certainly more informative than "Broken pipe".
+    if write_err.is_some() && !output.status.success() && !output.stderr.is_empty() {
+        return Err(SandboxError::RunnerCrashed(
+            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+        ));
+    }
 
     let teardown_start = Instant::now();
     let exec_elapsed = teardown_start - exec_start;

--- a/crates/brokkr-sandbox/src/host/mod.rs
+++ b/crates/brokkr-sandbox/src/host/mod.rs
@@ -1,0 +1,111 @@
+//! Host-side sandbox API: spawning the runner, feeding it a config, and
+//! collecting its outcome. The actual namespace / cgroup / seccomp work
+//! happens in the runner (see `crate::runner`); the host's job is to set
+//! the runner up and wait.
+
+use std::path::{Path, PathBuf};
+
+use crate::config::SandboxConfig;
+use crate::error::SandboxError;
+use crate::outcome::SandboxOutcome;
+
+#[cfg(target_os = "linux")]
+mod ipc;
+#[cfg(target_os = "linux")]
+mod linux;
+
+/// Host-side sandbox handle.
+///
+/// One [`Sandbox`] can run many actions sequentially (Phase 2 doesn't
+/// support concurrency on a single worker; see plan §13).
+#[derive(Debug, Clone)]
+pub struct Sandbox {
+    runner_binary: PathBuf,
+}
+
+impl Sandbox {
+    /// Create a sandbox that spawns `runner_binary` (the path to
+    /// `brokkr-sandboxd`) for each action. Use [`Self::with_default_runner`]
+    /// when relying on `$PATH` discovery.
+    pub fn new(runner_binary: impl Into<PathBuf>) -> Self {
+        Self {
+            runner_binary: runner_binary.into(),
+        }
+    }
+
+    /// Look up `brokkr-sandboxd` next to the current executable, then on
+    /// `$PATH`. Returns `Unsupported` if neither location has the binary.
+    pub fn with_default_runner() -> Result<Self, SandboxError> {
+        if let Some(path) = discover_runner_binary() {
+            Ok(Self::new(path))
+        } else {
+            Err(SandboxError::Unsupported(
+                "brokkr-sandboxd not found next to the worker binary or on PATH",
+            ))
+        }
+    }
+
+    /// Path to the runner binary that this sandbox will spawn.
+    pub fn runner_binary(&self) -> &Path {
+        &self.runner_binary
+    }
+
+    /// Execute `cfg` inside the sandbox. On Linux this spawns
+    /// `brokkr-sandboxd`, sends the config over file descriptor 3, and
+    /// waits for the child to exit, draining stdout/stderr. On non-Linux
+    /// hosts this returns [`SandboxError::Unsupported`].
+    #[tracing::instrument(
+        name = "sandbox::run",
+        skip(self, cfg),
+        fields(
+            runner = %self.runner_binary.display(),
+            argv0 = cfg.argv.first().map(String::as_str).unwrap_or(""),
+        ),
+    )]
+    pub async fn run(&self, cfg: SandboxConfig) -> Result<SandboxOutcome, SandboxError> {
+        if cfg.argv.is_empty() {
+            return Err(SandboxError::Setup {
+                step: "validate config",
+                source: std::io::Error::other("argv must not be empty"),
+            });
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            linux::run_action(&self.runner_binary, cfg).await
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            let _ = cfg;
+            Err(SandboxError::Unsupported(
+                "the Phase 2 sandbox is Linux-only",
+            ))
+        }
+    }
+}
+
+fn discover_runner_binary() -> Option<PathBuf> {
+    const NAME: &str = "brokkr-sandboxd";
+
+    // 1. Adjacent to the current executable.
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let candidate = dir.join(NAME);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    // 2. $PATH lookup.
+    if let Some(paths) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&paths) {
+            let candidate = dir.join(NAME);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    None
+}

--- a/crates/brokkr-sandbox/src/lib.rs
+++ b/crates/brokkr-sandbox/src/lib.rs
@@ -2,7 +2,41 @@
 //!
 //! Built directly on Linux primitives — mount/PID/user/network namespaces,
 //! cgroups v2, seccomp-bpf, capability dropping. **No Docker, runc, or
-//! containerd dependency, ever.** Phase 2 lights this crate up; Phase 0–1
-//! ship it as an empty stub.
+//! containerd dependency, ever.** Phase 2 lights this crate up incrementally
+//! per `docs/phase-2-plan.md`.
+//!
+//! ## Architecture
+//!
+//! Two halves share this crate:
+//!
+//! - **Host side** ([`Sandbox`], [`SandboxConfig`], [`SandboxOutcome`]):
+//!   the worker imports this and calls [`Sandbox::run`] for each action.
+//! - **Runner side** ([`run_as_runner`]): the body of the
+//!   `brokkr-sandboxd` binary. The host spawns it once per action, sends
+//!   the config over file descriptor 3, and waits for it to `execve` the
+//!   action.
+//!
+//! Splitting host and runner across two processes is the standard pattern
+//! for Linux sandboxes (bubblewrap, crun, nsjail, runj). See
+//! `docs/phase-2-plan.md` §3.1 for the rationale.
 
 #![deny(missing_docs)]
+// The sandbox crate calls `pre_exec`, `dup2`, and `from_raw_fd` directly.
+// Every `unsafe` block below has a `// SAFETY:` justification per
+// `CLAUDE.md` rule #2; we override the workspace-level deny so the crate
+// can compile.
+#![allow(unsafe_code)]
+
+mod config;
+mod error;
+mod host;
+mod outcome;
+mod runner;
+
+pub use config::{
+    DeterminismPolicy, NetworkPolicy, ResourceLimits, RootfsSpec, SandboxConfig, StdioPolicy,
+};
+pub use error::SandboxError;
+pub use host::Sandbox;
+pub use outcome::{ExitStatus, ResourceAccounting, SandboxOutcome, SandboxTimings};
+pub use runner::run_as_runner;

--- a/crates/brokkr-sandbox/src/outcome.rs
+++ b/crates/brokkr-sandbox/src/outcome.rs
@@ -1,0 +1,72 @@
+//! Result types returned from a sandboxed action.
+
+use std::time::Duration;
+
+use bytes::Bytes;
+
+/// Outcome of running an action in the sandbox.
+#[derive(Debug)]
+pub struct SandboxOutcome {
+    /// How the action terminated.
+    pub exit_status: ExitStatus,
+    /// Captured stdout.
+    pub stdout: Bytes,
+    /// Captured stderr.
+    pub stderr: Bytes,
+    /// Resource accounting from the cgroup. M2 returns zeros; M6 fills it in.
+    pub accounting: ResourceAccounting,
+    /// Wall-clock breakdown of the sandbox lifecycle.
+    pub timings: SandboxTimings,
+}
+
+/// How the action terminated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitStatus {
+    /// `_exit(code)` was called (or main returned code). On Unix the kernel
+    /// stores the low 8 bits of the wait status here.
+    Exited(i32),
+    /// Killed by a signal. M4 will distinguish `core_dumped` once we have
+    /// access to the full wait status; for now the bool is stripped.
+    Signaled {
+        /// Signal number (e.g. 9 for SIGKILL).
+        signal: i32,
+    },
+    /// Killed by the cgroup OOM killer. The action's writable outputs may
+    /// be partial. M6 produces this status; M2 cannot detect OOM and will
+    /// surface it as `Signaled { signal: 9 }`.
+    OutOfMemory,
+    /// Wall-clock limit hit. The runner sent SIGKILL. M8 produces this
+    /// status; M2 surfaces it as `Signaled { signal: 9 }`.
+    Timeout,
+}
+
+/// Cgroup-derived resource counters for one action. M2 returns zeros; M6
+/// reads `cpu.stat`, `memory.peak`, `io.stat`, `pids.peak` after the action
+/// exits and populates these fields.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ResourceAccounting {
+    /// User-mode CPU time consumed.
+    pub cpu_user: Duration,
+    /// Kernel-mode CPU time consumed.
+    pub cpu_system: Duration,
+    /// Peak resident set size in bytes.
+    pub memory_peak_bytes: u64,
+    /// Bytes read from block devices.
+    pub io_read_bytes: u64,
+    /// Bytes written to block devices.
+    pub io_write_bytes: u64,
+    /// Maximum concurrent PIDs observed.
+    pub max_pids: u64,
+}
+
+/// Wall-clock breakdown of one sandbox lifecycle.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SandboxTimings {
+    /// Time spent in host-side setup before the action's child process
+    /// began running (cgroup creation, workspace staging, runner spawn).
+    pub setup: Duration,
+    /// Wall-clock time spent inside the runner from spawn to wait.
+    pub execution: Duration,
+    /// Time spent in host-side teardown after the runner exited.
+    pub teardown: Duration,
+}

--- a/crates/brokkr-sandbox/src/runner/exec.rs
+++ b/crates/brokkr-sandbox/src/runner/exec.rs
@@ -1,0 +1,93 @@
+//! Linux runner main + the final `execvpe` into the action.
+//!
+//! M2 keeps this minimal: read config, chdir, exec. M3+ insert namespace
+//! setup, mount work, cgroup attach, seccomp, etc. between the read and
+//! the exec.
+
+use std::ffi::CString;
+use std::io::Read as _;
+use std::os::fd::{FromRawFd, RawFd};
+
+use crate::config::SandboxConfig;
+
+/// File descriptor on which the host writes the JSON-encoded
+/// `SandboxConfig`. Hard-coded by convention on both sides; see
+/// `docs/phase-2-plan.md` §3.3.
+const CONFIG_FD: RawFd = 3;
+
+pub(super) fn runner_main() -> ! {
+    let cfg = match read_config() {
+        Ok(c) => c,
+        Err(e) => die("failed to read config", &e.to_string()),
+    };
+
+    if let Some(workdir) = &cfg.workdir {
+        if let Err(e) = std::env::set_current_dir(workdir) {
+            die("failed to chdir into workdir", &e.to_string());
+        }
+    }
+
+    let argv = match build_argv(&cfg.argv) {
+        Ok(a) => a,
+        Err(msg) => die("invalid argv", msg),
+    };
+    let env = match build_env(&cfg.env) {
+        Ok(e) => e,
+        Err(msg) => die("invalid env", msg),
+    };
+
+    let argv_refs: Vec<&CString> = argv.iter().collect();
+    let env_refs: Vec<&CString> = env.iter().collect();
+
+    match nix::unistd::execvpe(&argv[0], &argv_refs, &env_refs) {
+        Ok(_) => unreachable!("execvpe returned Ok"),
+        Err(errno) => die(
+            "execvpe failed",
+            &format!("{}: {}", cfg.argv[0], errno_message(errno)),
+        ),
+    }
+}
+
+fn read_config() -> std::io::Result<SandboxConfig> {
+    // SAFETY: the host places the config pipe's read end on CONFIG_FD via
+    // dup2 in pre_exec, and never opens any other fd at that number. We
+    // become its sole owner.
+    #[allow(unsafe_code)]
+    let mut file = unsafe { std::fs::File::from_raw_fd(CONFIG_FD) };
+    let mut buf = Vec::with_capacity(4096);
+    file.read_to_end(&mut buf)?;
+    let cfg: SandboxConfig = serde_json::from_slice(&buf)
+        .map_err(|e| std::io::Error::other(format!("config json: {e}")))?;
+    Ok(cfg)
+}
+
+fn build_argv(argv: &[String]) -> Result<Vec<CString>, &'static str> {
+    if argv.is_empty() {
+        return Err("argv is empty");
+    }
+    argv.iter()
+        .map(|s| CString::new(s.as_bytes()).map_err(|_| "argv entry contains NUL"))
+        .collect()
+}
+
+fn build_env(env: &[(String, String)]) -> Result<Vec<CString>, &'static str> {
+    env.iter()
+        .map(|(k, v)| {
+            if k.contains('=') || k.contains('\0') || v.contains('\0') {
+                Err("env entry contains NUL or '='")
+            } else {
+                CString::new(format!("{k}={v}")).map_err(|_| "env entry contains NUL")
+            }
+        })
+        .collect()
+}
+
+fn errno_message(errno: nix::errno::Errno) -> String {
+    format!("{} ({})", errno.desc(), errno as i32)
+}
+
+fn die(step: &str, message: &str) -> ! {
+    // Best-effort write to stderr; if even that fails we just exit.
+    eprintln!("brokkr-sandboxd: {step}: {message}");
+    std::process::exit(127);
+}

--- a/crates/brokkr-sandbox/src/runner/mod.rs
+++ b/crates/brokkr-sandbox/src/runner/mod.rs
@@ -1,0 +1,31 @@
+//! Runner-side entry point — runs *inside* `brokkr-sandboxd`, after the
+//! re-exec.
+//!
+//! Phase 2 / M2 lights up only the bare bones: read the
+//! [`SandboxConfig`](crate::SandboxConfig) from file descriptor 3, optionally
+//! `chdir` into [`SandboxConfig::workdir`], then `execvpe` the action.
+//! Subsequent milestones add namespace setup, cgroup attachment, seccomp,
+//! capability dropping, and determinism guards before the final `execve`.
+//!
+//! [`run_as_runner`] returns `!`: it always ends in either `execve` or
+//! `_exit`. Errors before exec are written to stderr and exit with code
+//! 127, matching the convention of `sh: command not found`.
+
+#[cfg(target_os = "linux")]
+mod exec;
+
+/// Runner-side `main`. Called from the `brokkr-sandboxd` binary.
+///
+/// Always terminates the process — either by `execve`-ing the action or by
+/// exiting with code 127 if setup fails.
+pub fn run_as_runner() -> ! {
+    #[cfg(target_os = "linux")]
+    {
+        exec::runner_main()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        eprintln!("brokkr-sandboxd: this binary only runs on Linux");
+        std::process::exit(127);
+    }
+}

--- a/crates/brokkr-sandbox/tests/sandbox_smoke.rs
+++ b/crates/brokkr-sandbox/tests/sandbox_smoke.rs
@@ -1,0 +1,111 @@
+//! Smoke tests for `brokkr-sandbox`'s M2 re-exec model.
+//!
+//! These exercise the full host → runner → exec path: the host spawns
+//! `brokkr-sandboxd`, hands it a [`SandboxConfig`] over fd 3, and waits.
+//! At M2 there's no namespace setup, so the action runs as a plain child
+//! process — Phase-1 parity inside the new structure.
+
+#![cfg(target_os = "linux")]
+#![allow(clippy::unwrap_used, clippy::panic, clippy::disallowed_methods)]
+
+use brokkr_sandbox::{ExitStatus, Sandbox, SandboxConfig};
+
+fn runner_path() -> &'static str {
+    env!("CARGO_BIN_EXE_brokkr-sandboxd")
+}
+
+#[tokio::test]
+async fn echo_hello_runs() {
+    let sandbox = Sandbox::new(runner_path());
+    let cfg = SandboxConfig::new(vec!["/bin/echo".to_string(), "hello world".to_string()]);
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(outcome.exit_status, ExitStatus::Exited(0));
+    assert_eq!(outcome.stdout.as_ref(), b"hello world\n");
+    assert!(outcome.stderr.is_empty());
+}
+
+#[tokio::test]
+async fn false_exits_one() {
+    let sandbox = Sandbox::new(runner_path());
+    let cfg = SandboxConfig::new(vec!["/bin/false".to_string()]);
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(outcome.exit_status, ExitStatus::Exited(1));
+}
+
+#[tokio::test]
+async fn nonexistent_argv0_returns_127() {
+    // execvpe fails, the runner writes a diagnostic to stderr and _exit(127).
+    let sandbox = Sandbox::new(runner_path());
+    let cfg = SandboxConfig::new(vec!["/this/path/does/not/exist".to_string()]);
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(outcome.exit_status, ExitStatus::Exited(127));
+    let stderr = String::from_utf8_lossy(&outcome.stderr);
+    assert!(
+        stderr.contains("execvpe failed") || stderr.contains("/this/path/does/not/exist"),
+        "expected diagnostic; got: {stderr}"
+    );
+}
+
+#[tokio::test]
+async fn empty_argv_is_a_setup_error() {
+    let sandbox = Sandbox::new(runner_path());
+    let cfg = SandboxConfig::new(vec![]);
+    let err = sandbox.run(cfg).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("argv"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn env_is_passed_through() {
+    let sandbox = Sandbox::new(runner_path());
+    let cfg = SandboxConfig {
+        argv: vec![
+            "/bin/sh".to_string(),
+            "-c".into(),
+            "echo $BROKKR_TEST".into(),
+        ],
+        env: vec![("BROKKR_TEST".to_string(), "42".to_string())],
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(outcome.exit_status, ExitStatus::Exited(0));
+    assert_eq!(outcome.stdout.as_ref(), b"42\n");
+}
+
+#[tokio::test]
+async fn workdir_is_honoured() {
+    let dir = tempfile::tempdir().unwrap();
+    let sandbox = Sandbox::new(runner_path());
+    let cfg = SandboxConfig {
+        argv: vec!["/bin/pwd".to_string()],
+        workdir: Some(dir.path().to_path_buf()),
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(outcome.exit_status, ExitStatus::Exited(0));
+    let stdout = String::from_utf8_lossy(&outcome.stdout);
+    assert_eq!(
+        stdout.trim(),
+        // pwd may resolve symlinks (e.g. /tmp → /private/tmp on some hosts);
+        // we canonicalize to compare against what the kernel reports.
+        dir.path().canonicalize().unwrap().to_string_lossy()
+    );
+}
+
+#[tokio::test]
+async fn timings_are_populated() {
+    let sandbox = Sandbox::new(runner_path());
+    let cfg = SandboxConfig::new(vec!["/bin/true".to_string()]);
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(outcome.exit_status, ExitStatus::Exited(0));
+    // Setup and execution should both be > 0; teardown might round to 0 on
+    // very fast paths, so just assert it's non-negative (Duration always is).
+    assert!(
+        outcome.timings.setup.as_nanos() > 0,
+        "setup duration should be > 0"
+    );
+    assert!(
+        outcome.timings.execution.as_nanos() > 0,
+        "execution duration should be > 0"
+    );
+}

--- a/crates/brokkr-sandbox/tests/sandbox_smoke.rs
+++ b/crates/brokkr-sandbox/tests/sandbox_smoke.rs
@@ -74,9 +74,9 @@ async fn env_is_passed_through() {
 
 #[tokio::test]
 async fn workdir_is_honoured() {
-    // Use a stable absolute path that exists on every Linux host. The test
-    // crate is `cfg(target_os = "linux")`, so /tmp is /tmp (no symlink
-    // canonicalization quirks like macOS's /private/tmp).
+    // Use a stable absolute path that exists on every Linux host. We
+    // deliberately avoid tempfile + canonicalize here so the test surface
+    // is just `chdir(workdir); pwd`.
     let workdir = std::path::PathBuf::from("/tmp");
     let sandbox = Sandbox::new(runner_path());
     let cfg = SandboxConfig {
@@ -103,18 +103,21 @@ async fn workdir_is_honoured() {
 
 #[tokio::test]
 async fn timings_are_populated() {
+    // Sleep briefly so even on fast machines with coarse timer resolution
+    // the *aggregate* runtime is comfortably above zero. We don't assert
+    // any individual phase is > 0 — `setup`, `execution`, or `teardown`
+    // can legitimately round to zero on a hot path.
     let sandbox = Sandbox::new(runner_path());
-    let cfg = SandboxConfig::new(vec!["/bin/true".to_string()]);
+    let cfg = SandboxConfig::new(vec![
+        "/bin/sh".to_string(),
+        "-c".to_string(),
+        "sleep 0.01".to_string(),
+    ]);
     let outcome = sandbox.run(cfg).await.unwrap();
     assert_eq!(outcome.exit_status, ExitStatus::Exited(0));
-    // Setup and execution should both be > 0; teardown might round to 0 on
-    // very fast paths, so just assert it's non-negative (Duration always is).
+    let total = outcome.timings.setup + outcome.timings.execution + outcome.timings.teardown;
     assert!(
-        outcome.timings.setup.as_nanos() > 0,
-        "setup duration should be > 0"
-    );
-    assert!(
-        outcome.timings.execution.as_nanos() > 0,
-        "execution duration should be > 0"
+        total.as_millis() >= 5,
+        "expected aggregate timing ≥ 5 ms, got {total:?}"
     );
 }

--- a/crates/brokkr-sandbox/tests/sandbox_smoke.rs
+++ b/crates/brokkr-sandbox/tests/sandbox_smoke.rs
@@ -74,21 +74,30 @@ async fn env_is_passed_through() {
 
 #[tokio::test]
 async fn workdir_is_honoured() {
-    let dir = tempfile::tempdir().unwrap();
+    // Use a stable absolute path that exists on every Linux host. The test
+    // crate is `cfg(target_os = "linux")`, so /tmp is /tmp (no symlink
+    // canonicalization quirks like macOS's /private/tmp).
+    let workdir = std::path::PathBuf::from("/tmp");
     let sandbox = Sandbox::new(runner_path());
     let cfg = SandboxConfig {
-        argv: vec!["/bin/pwd".to_string()],
-        workdir: Some(dir.path().to_path_buf()),
+        argv: vec!["/bin/sh".to_string(), "-c".into(), "pwd".into()],
+        workdir: Some(workdir.clone()),
         ..Default::default()
     };
-    let outcome = sandbox.run(cfg).await.unwrap();
-    assert_eq!(outcome.exit_status, ExitStatus::Exited(0));
-    let stdout = String::from_utf8_lossy(&outcome.stdout);
+    let outcome = match sandbox.run(cfg).await {
+        Ok(o) => o,
+        Err(e) => panic!("sandbox.run failed: {e:#}"),
+    };
     assert_eq!(
-        stdout.trim(),
-        // pwd may resolve symlinks (e.g. /tmp → /private/tmp on some hosts);
-        // we canonicalize to compare against what the kernel reports.
-        dir.path().canonicalize().unwrap().to_string_lossy()
+        outcome.exit_status,
+        ExitStatus::Exited(0),
+        "exit={:?} stderr={}",
+        outcome.exit_status,
+        String::from_utf8_lossy(&outcome.stderr),
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&outcome.stdout).trim(),
+        workdir.to_string_lossy(),
     );
 }
 


### PR DESCRIPTION
Second milestone of Phase 2 (`docs/phase-2-plan.md` §9, M2). Stands up
the `brokkr-sandbox` crate's full public type surface plus the
`brokkr-sandboxd` runner binary, hooked together via a re-exec /
fd-passing IPC. The runner doesn't enter any namespaces yet — that's
M3–M8 — but the wiring is real, so subsequent milestones only need to
extend the runner's setup pipeline.

## What's in it

### Public API (`brokkr-sandbox/src/{config,error,outcome}.rs`)

Field-level docs flag which fields later milestones honour. Today, M2
honours `argv`, `env`, and `workdir`; everything else round-trips on
the wire so the API stays stable.

- `Sandbox` — host-side handle. `Sandbox::new(runner_path)` or
  `Sandbox::with_default_runner()` (discovers next to the worker exe
  with a `$PATH` fallback — resolves plan §11.2).
- `SandboxConfig`, `RootfsSpec`, `ResourceLimits`, `NetworkPolicy`,
  `DeterminismPolicy`, `StdioPolicy` — full config surface, all with
  `Serialize`/`Deserialize` (the config is also the IPC payload).
- `SandboxOutcome`, `ExitStatus` (`Exited` | `Signaled` |
  `OutOfMemory` | `Timeout`), `ResourceAccounting`,
  `SandboxTimings` — outcomes M3+ will populate.
- `SandboxError` (thiserror) with `Setup { step }`, `Unsupported`,
  `RunnerCrashed`, `Cgroup`, `Io`, `Json` variants.

### Crate layout

The plan (§3.2) had `brokkr-sandbox` and `brokkr-sandboxd` as
**separate** crates. I co-located them: `brokkr-sandboxd` is a
`[[bin]]` target inside `brokkr-sandbox`. This makes integration
tests find the binary via `env!("CARGO_BIN_EXE_brokkr-sandboxd")`
without any escargot / build-script gymnastics, and doesn't change
the runtime model (still re-exec'd through a separate process).
Worth a "is this OK or do you want them split?" call from a
reviewer.

### Re-exec / IPC (`host/{mod,ipc,linux}.rs`, `runner/{mod,exec}.rs`)

```
host                                 runner (brokkr-sandboxd)
─────────────────────────────────    ─────────────────────────────
pipe2(O_CLOEXEC)                     (post-fork, post-pre_exec)
spawn brokkr-sandboxd                read_to_end(fd 3) → JSON
  pre_exec: dup2(read, 3); close()   parse SandboxConfig
write JSON to write end              chdir(workdir) if set
drop write end → EOF on fd 3         execvpe(argv, env)
wait_with_output                     ── action runs ──
parse exit status                    ── action exits ──
```

The load-bearing detail: `pipe2(O_CLOEXEC)`. Without it, the runner
inherits a copy of its *own* write end through fork, `read_to_end`
on fd 3 never sees EOF, and the host deadlocks on
`wait_with_output`. With `O_CLOEXEC`, the inherited write end auto-
closes on `execve`. The fix took roughly 14 minutes of staring at
hung sandboxd processes; covered with a comment in `host/ipc.rs`.

### Unsafe / `unsafe_code` lint

The crate-level `#![allow(unsafe_code)]` overrides the workspace
deny. Two `unsafe` blocks, both with `SAFETY:` comments per
`CLAUDE.md` rule #2:

- `Command::pre_exec` hook in `host/linux.rs`. Only async-signal-
  safe operations (`dup2`, `close`) on fds we own.
- `std::fs::File::from_raw_fd(CONFIG_FD)` in `runner/exec.rs`. The
  host places the pipe's read end on fd 3 via `dup2` and never opens
  any other fd at that number.

The IPC writer side uses safe `File::from(OwnedFd)` (std `From`
impl).

### Dependencies

One new workspace dep: `nix = "0.29"` with
`features = ["fs", "process", "user"]`. Justification: `pipe2`,
`dup2`, `close`, `execvpe`, `OFlag`, `Errno → io::Error`. Rationale
matches `CLAUDE.md` rule #6 (mature crate, ~3M downloads/month,
recent commits, MIT). Beats vendoring libc bindings for every Linux
syscall we'll touch in M3–M8.

### Tests

`crates/brokkr-sandbox/tests/sandbox_smoke.rs` — 7 end-to-end smoke
tests covering the whole re-exec path:

| Test                           | Verifies                                |
|--------------------------------|-----------------------------------------|
| `echo_hello_runs`              | exit 0, stdout, stderr empty            |
| `false_exits_one`              | exit 1                                  |
| `nonexistent_argv0_returns_127`| runner detects exec failure, exits 127  |
| `empty_argv_is_a_setup_error`  | host-side validation                    |
| `env_is_passed_through`        | env round-trips through JSON + execvpe  |
| `workdir_is_honoured`          | runner chdirs before exec               |
| `timings_are_populated`        | `setup` and `execution` durations > 0   |

Plus 2 unit tests in `config.rs` (round-trip + defaults). Total: +9.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 35 passed (was 26; +9 new), 0
      failed, 1 ignored (Phase 1 soak)
- [x] Smoke tests pass both serially (`--test-threads=1`) and in
      parallel
- [x] Reviewer runs the smoke suite locally
- [x] Reviewer comments on the crate-split decision (one crate vs
      two)

## Notes

- Journal entry deferred until M1 (#21) merges — M1 seeds
  `docs/journal/phase-2.md` and adding M2 here would conflict. A
  follow-up doc PR will write the M2 retrospective.
- `Sandbox::with_default_runner` resolves plan open question §11.2.

## Phase 2 progress

- [x] M1 — host-check + install script (#21)
- [x] M2 — sandbox skeleton, re-exec, plain-spawn parity (this PR)
- [ ] M3 — mount namespace + pivot_root
- [ ] M4 — PID + user namespaces
- [ ] M5 — network namespace
- [ ] M6 — cgroups v2
- [ ] M7 — seccomp + caps
- [ ] M8 — determinism + wall-clock
- [ ] M9 — worker integration + defaults