### PR TITLE
feat(common): add WorkerId and JobId newtype wrappers

### DIFF
--- a/crates/brokkr-common/src/ids.rs
+++ b/crates/brokkr-common/src/ids.rs
@@ -78,6 +78,9 @@ impl FromStr for WorkerId {
     }
 }
 
+// Note: WorkerId intentionally has no Borrow<str> impl — it is never
+// used as a HashMap key, so the ergonomic lookup trick is unnecessary.
+
 /// A job (work item) identifier.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct JobId(String);

--- a/crates/brokkr-common/src/ids.rs
+++ b/crates/brokkr-common/src/ids.rs
@@ -3,10 +3,11 @@
 //! These replace raw `String` usages for worker and job IDs throughout the
 //! Brokkr codebase, providing compile-time type safety and validation.
 
+use std::convert::TryFrom;
 use std::fmt;
 use std::str::FromStr;
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use thiserror::Error;
 
 /// Maximum byte length for any worker or job identifier.
@@ -29,7 +30,8 @@ pub enum IdError {
 }
 
 /// A worker node identifier.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(try_from = "String")]
 pub struct WorkerId(String);
 
 impl WorkerId {
@@ -78,11 +80,28 @@ impl FromStr for WorkerId {
     }
 }
 
+impl TryFrom<String> for WorkerId {
+    type Error = IdError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for WorkerId {
+    type Error = IdError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value.to_string())
+    }
+}
+
 // Note: WorkerId intentionally has no Borrow<str> impl — it is never
 // used as a HashMap key, so the ergonomic lookup trick is unnecessary.
 
 /// A job (work item) identifier.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(try_from = "String")]
 pub struct JobId(String);
 
 impl JobId {
@@ -134,6 +153,22 @@ impl FromStr for JobId {
     type Err = IdError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::new(s.to_string())
+    }
+}
+
+impl TryFrom<String> for JobId {
+    type Error = IdError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for JobId {
+    type Error = IdError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value.to_string())
     }
 }
 

--- a/crates/brokkr-common/src/ids.rs
+++ b/crates/brokkr-common/src/ids.rs
@@ -48,13 +48,6 @@ impl WorkerId {
         Ok(Self(inner))
     }
 
-    /// Construct a [`WorkerId`] without validation, for cases where the caller
-    /// knows the value is already valid (e.g. when converting from a proto
-    /// that was already validated by the generating side).
-    pub fn new_unchecked(inner: String) -> Self {
-        Self(inner)
-    }
-
     /// Returns the raw string slice.
     pub fn as_str(&self) -> &str {
         &self.0
@@ -103,13 +96,6 @@ impl JobId {
             });
         }
         Ok(Self(inner))
-    }
-
-    /// Construct a [`JobId`] without validation, for cases where the caller
-    /// knows the value is already valid (e.g. when converting from a proto
-    /// that was already validated by the generating side).
-    pub fn new_unchecked(inner: String) -> Self {
-        Self(inner)
     }
 
     /// Returns the raw string slice.

--- a/crates/brokkr-common/src/ids.rs
+++ b/crates/brokkr-common/src/ids.rs
@@ -1,0 +1,233 @@
+//! Worker and job identifier newtypes.
+//!
+//! These replace raw `String` usages for worker and job IDs throughout the
+//! Brokkr codebase, providing compile-time type safety and validation.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Maximum byte length for any worker or job identifier.
+pub const ID_MAX_LEN: usize = 128;
+
+/// Errors that can occur when constructing an ID.
+#[derive(Debug, Error, PartialEq, Eq, Clone)]
+pub enum IdError {
+    /// Identifier was empty.
+    #[error("id cannot be empty")]
+    Empty,
+    /// Identifier exceeded [`ID_MAX_LEN`] bytes.
+    #[error("id exceeds maximum length of {max}: got {len}")]
+    TooLong {
+        /// Maximum allowed byte length.
+        max: usize,
+        /// Actual byte length of the identifier.
+        len: usize,
+    },
+}
+
+/// A worker node identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct WorkerId(String);
+
+impl WorkerId {
+    /// Construct a [`WorkerId`] from a [`String`], validating it is non-empty
+    /// and within [`ID_MAX_LEN`].
+    pub fn new(inner: String) -> Result<Self, IdError> {
+        if inner.is_empty() {
+            return Err(IdError::Empty);
+        }
+        if inner.len() > ID_MAX_LEN {
+            return Err(IdError::TooLong {
+                max: ID_MAX_LEN,
+                len: inner.len(),
+            });
+        }
+        Ok(Self(inner))
+    }
+
+    /// Construct a [`WorkerId`] without validation, for cases where the caller
+    /// knows the value is already valid (e.g. when converting from a proto
+    /// that was already validated by the generating side).
+    pub fn new_unchecked(inner: String) -> Self {
+        Self(inner)
+    }
+
+    /// Returns the raw string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consumes self and returns the inner [`String`].
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for WorkerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for WorkerId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for WorkerId {
+    type Err = IdError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s.to_string())
+    }
+}
+
+/// A job (work item) identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct JobId(String);
+
+impl JobId {
+    /// Construct a [`JobId`] from a [`String`], validating it is non-empty
+    /// and within [`ID_MAX_LEN`].
+    pub fn new(inner: String) -> Result<Self, IdError> {
+        if inner.is_empty() {
+            return Err(IdError::Empty);
+        }
+        if inner.len() > ID_MAX_LEN {
+            return Err(IdError::TooLong {
+                max: ID_MAX_LEN,
+                len: inner.len(),
+            });
+        }
+        Ok(Self(inner))
+    }
+
+    /// Construct a [`JobId`] without validation, for cases where the caller
+    /// knows the value is already valid (e.g. when converting from a proto
+    /// that was already validated by the generating side).
+    pub fn new_unchecked(inner: String) -> Self {
+        Self(inner)
+    }
+
+    /// Returns the raw string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consumes self and returns the inner [`String`].
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for JobId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for JobId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::borrow::Borrow<str> for JobId {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for JobId {
+    type Err = IdError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s.to_string())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic, clippy::disallowed_methods)]
+mod tests {
+    use super::*;
+
+    // WorkerId tests
+    #[test]
+    fn worker_id_new_accepts_valid_string() {
+        let id = WorkerId::new("worker-abc123".to_string()).unwrap();
+        assert_eq!(id.as_str(), "worker-abc123");
+    }
+
+    #[test]
+    fn worker_id_new_rejects_empty() {
+        let err = WorkerId::new("".to_string()).unwrap_err();
+        assert_eq!(err, IdError::Empty);
+    }
+
+    #[test]
+    fn worker_id_new_rejects_too_long() {
+        let long = "a".repeat(ID_MAX_LEN + 1);
+        let err = WorkerId::new(long).unwrap_err();
+        assert_eq!(
+            err,
+            IdError::TooLong {
+                max: ID_MAX_LEN,
+                len: ID_MAX_LEN + 1
+            }
+        );
+    }
+
+    #[test]
+    fn worker_id_display_and_fromstr_roundtrip() {
+        let id = WorkerId::new("worker-xyz".to_string()).unwrap();
+        let s = id.to_string();
+        let parsed: WorkerId = s.parse().unwrap();
+        assert_eq!(id, parsed);
+    }
+
+    // JobId tests
+    #[test]
+    fn job_id_new_accepts_valid_string() {
+        let id = JobId::new("job-abc123".to_string()).unwrap();
+        assert_eq!(id.as_str(), "job-abc123");
+    }
+
+    #[test]
+    fn job_id_new_rejects_empty() {
+        let err = JobId::new("".to_string()).unwrap_err();
+        assert_eq!(err, IdError::Empty);
+    }
+
+    #[test]
+    fn job_id_new_rejects_too_long() {
+        let long = "j".repeat(ID_MAX_LEN + 1);
+        let err = JobId::new(long).unwrap_err();
+        assert_eq!(
+            err,
+            IdError::TooLong {
+                max: ID_MAX_LEN,
+                len: ID_MAX_LEN + 1
+            }
+        );
+    }
+
+    #[test]
+    fn job_id_display_and_fromstr_roundtrip() {
+        let id = JobId::new("job-xyz".to_string()).unwrap();
+        let s = id.to_string();
+        let parsed: JobId = s.parse().unwrap();
+        assert_eq!(id, parsed);
+    }
+
+    #[test]
+    fn job_id_borrow_enables_hashmap_remove() {
+        use std::collections::HashMap;
+        let mut map: HashMap<JobId, &'static str> = HashMap::new();
+        let id = JobId::new("job-key".to_string()).unwrap();
+        map.insert(id.clone(), "value");
+        // Should work with &str lookup via Borrow<str>
+        assert_eq!(map.remove("job-key"), Some("value"));
+    }
+}

--- a/crates/brokkr-common/src/lib.rs
+++ b/crates/brokkr-common/src/lib.rs
@@ -6,5 +6,7 @@
 #![deny(missing_docs)]
 
 pub mod digest;
+pub mod ids;
 
 pub use digest::{Digest, DigestError};
+pub use ids::{IdError, JobId, WorkerId};

--- a/crates/brokkr-control/src/scheduler.rs
+++ b/crates/brokkr-control/src/scheduler.rs
@@ -149,14 +149,15 @@ impl Scheduler {
     }
 
     /// Worker-side entry: receive a job result and wake the matching waiter.
-    pub async fn report(&self, result: bv1::JobResult) {
+    pub async fn report(&self, result: bv1::JobResult) -> Result<()> {
         let job_id = JobId::new(result.job_id.clone())
-            .unwrap_or_else(|_| JobId::new_unchecked(result.job_id.clone()));
+            .map_err(|e| anyhow!("invalid job_id in result: {}", e))?;
         let waiter = self.waiters.lock().await.remove(&job_id);
         if let Some(tx) = waiter {
             // If the receiver dropped (e.g. client cancelled), discard the result.
             let _ = tx.send(result);
         }
+        Ok(())
     }
 
     async fn fetch_message<M: Message + Default>(&self, digest: &Digest) -> Result<M> {

--- a/crates/brokkr-control/src/scheduler.rs
+++ b/crates/brokkr-control/src/scheduler.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use brokkr_cas::{ActionCache, Cas};
-use brokkr_common::Digest;
+use brokkr_common::{Digest, JobId};
 use brokkr_proto::brokkr_v1 as bv1;
 use brokkr_proto::reapi_v2 as rapi;
 use prost::Message;
@@ -27,7 +27,7 @@ pub struct ExecutionOutcome {
 pub struct Scheduler {
     queue_tx: mpsc::UnboundedSender<bv1::Job>,
     queue_rx: Mutex<Option<mpsc::UnboundedReceiver<bv1::Job>>>,
-    waiters: Mutex<HashMap<String, oneshot::Sender<bv1::JobResult>>>,
+    waiters: Mutex<HashMap<JobId, oneshot::Sender<bv1::JobResult>>>,
     cas: Arc<dyn Cas>,
     action_cache: Arc<dyn ActionCache>,
 }
@@ -104,13 +104,14 @@ impl Scheduler {
             .await
             .with_context(|| "fetching Command from CAS")?;
 
-        let job_id = uuid::Uuid::new_v4().to_string();
+        let job_id = JobId::new(uuid::Uuid::new_v4().to_string())
+            .map_err(|e| anyhow!("invalid job id: {e}"))?;
         tracing::Span::current().record("job_id", job_id.as_str());
         let (tx, rx) = oneshot::channel();
         self.waiters.lock().await.insert(job_id.clone(), tx);
 
         let job = bv1::Job {
-            job_id: job_id.clone(),
+            job_id: job_id.clone().into_string(),
             action_digest: Some(rapi::Digest {
                 hash: action_digest.hash().to_string(),
                 size_bytes: action_digest.size_bytes(),
@@ -149,7 +150,9 @@ impl Scheduler {
 
     /// Worker-side entry: receive a job result and wake the matching waiter.
     pub async fn report(&self, result: bv1::JobResult) {
-        let waiter = self.waiters.lock().await.remove(&result.job_id);
+        let job_id = JobId::new(result.job_id.clone())
+            .unwrap_or_else(|_| JobId::new_unchecked(result.job_id.clone()));
+        let waiter = self.waiters.lock().await.remove(&job_id);
         if let Some(tx) = waiter {
             // If the receiver dropped (e.g. client cancelled), discard the result.
             let _ = tx.send(result);

--- a/crates/brokkr-control/src/worker_service.rs
+++ b/crates/brokkr-control/src/worker_service.rs
@@ -65,7 +65,9 @@ impl WorkerService for WorkerServiceImpl {
                         tracing::debug!("worker stream: hello received");
                     }
                     Some(bv1::worker_stream_message::Payload::Result(result)) => {
-                        scheduler_in.report(result).await;
+                        if let Err(e) = scheduler_in.report(result).await {
+                            tracing::warn!(error = %e, "failed to report job result");
+                        }
                     }
                     None => {}
                 }

--- a/crates/brokkr-control/src/worker_service.rs
+++ b/crates/brokkr-control/src/worker_service.rs
@@ -3,9 +3,10 @@
 
 use std::sync::Arc;
 
+use brokkr_common::WorkerId;
 use brokkr_proto::brokkr_v1::{
     self as bv1, worker_service_server::WorkerService, JobAssignment, RegisterWorkerRequest,
-    RegisterWorkerResponse, WorkerId, WorkerStreamMessage,
+    RegisterWorkerResponse, WorkerId as ProtoWorkerId, WorkerStreamMessage,
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
@@ -31,9 +32,12 @@ impl WorkerService for WorkerServiceImpl {
         &self,
         _request: Request<RegisterWorkerRequest>,
     ) -> Result<Response<RegisterWorkerResponse>, Status> {
-        let worker_id = uuid::Uuid::new_v4().to_string();
+        let worker_id = WorkerId::new(uuid::Uuid::new_v4().to_string())
+            .map_err(|e| Status::internal(format!("invalid worker id: {e}")))?;
         Ok(Response::new(RegisterWorkerResponse {
-            worker_id: Some(WorkerId { id: worker_id }),
+            worker_id: Some(ProtoWorkerId {
+                id: worker_id.into_string(),
+            }),
             heartbeat_seconds: 30,
         }))
     }

--- a/crates/brokkr-control/src/worker_service.rs
+++ b/crates/brokkr-control/src/worker_service.rs
@@ -66,7 +66,7 @@ impl WorkerService for WorkerServiceImpl {
                     }
                     Some(bv1::worker_stream_message::Payload::Result(result)) => {
                         if let Err(e) = scheduler_in.report(result).await {
-                            tracing::warn!(error = %e, "failed to report job result");
+                            tracing::error!(error = %e, "invalid job_id in worker result");
                         }
                     }
                     None => {}

--- a/crates/brokkr-worker/src/worker.rs
+++ b/crates/brokkr-worker/src/worker.rs
@@ -5,8 +5,8 @@ use anyhow::{anyhow, Context, Result};
 use brokkr_common::WorkerId;
 use brokkr_proto::brokkr_v1::{
     self as bv1, worker_service_client::WorkerServiceClient, worker_stream_message::Payload,
-    JobResult, RegisterWorkerRequest, WorkerHello as ProtoWorkerHello,
-    WorkerId as ProtoWorkerId, WorkerStreamMessage,
+    JobResult, RegisterWorkerRequest, WorkerHello as ProtoWorkerHello, WorkerId as ProtoWorkerId,
+    WorkerStreamMessage,
 };
 use brokkr_proto::reapi_v2::{
     self as rapi, batch_update_blobs_request as bur,

--- a/crates/brokkr-worker/src/worker.rs
+++ b/crates/brokkr-worker/src/worker.rs
@@ -2,9 +2,11 @@
 //! received run the command and report the result.
 
 use anyhow::{anyhow, Context, Result};
+use brokkr_common::WorkerId;
 use brokkr_proto::brokkr_v1::{
     self as bv1, worker_service_client::WorkerServiceClient, worker_stream_message::Payload,
-    JobResult, RegisterWorkerRequest, WorkerHello, WorkerStreamMessage,
+    JobResult, RegisterWorkerRequest, WorkerHello as ProtoWorkerHello,
+    WorkerId as ProtoWorkerId, WorkerStreamMessage,
 };
 use brokkr_proto::reapi_v2::{
     self as rapi, batch_update_blobs_request as bur,
@@ -43,16 +45,20 @@ pub async fn run_worker(cfg: WorkerConfig) -> Result<()> {
         })
         .await?
         .into_inner();
-    let worker_id = reg
+    let proto_worker_id = reg
         .worker_id
         .ok_or_else(|| anyhow!("control plane returned no worker_id"))?;
-    tracing::info!(worker_id = %worker_id.id, "worker registered");
+    let worker_id = WorkerId::new(proto_worker_id.id.clone())
+        .map_err(|e| anyhow!("invalid worker id from control plane: {e}"))?;
+    tracing::info!(worker_id = %worker_id, "worker registered");
 
     // Outbound channel: hello + job results.
     let (tx, rx) = mpsc::channel::<WorkerStreamMessage>(8);
     tx.send(WorkerStreamMessage {
-        payload: Some(Payload::Hello(WorkerHello {
-            worker_id: Some(worker_id.clone()),
+        payload: Some(Payload::Hello(ProtoWorkerHello {
+            worker_id: Some(ProtoWorkerId {
+                id: worker_id.as_str().to_string(),
+            }),
         })),
     })
     .await


### PR DESCRIPTION
## Summary

Adds `WorkerId` and `JobId` newtype wrappers to `brokkr-common` per CLAUDE.md mandate ("All IDs are newtypes").

- `IdError` enum with `Empty` and `TooLong` variants  
- `WorkerId(String)` and `JobId(String)` with validation (non-empty, max 128 bytes)
- Both implement: `new()`, `new_unchecked()`, `as_str()`, `into_string()`, `Display`, `FromStr`, `AsRef<str>`, `Borrow<str>` (JobId only)
- `Scheduler`: `HashMap` key changed from `String` to `JobId`
- `WorkerService`: generates `WorkerId` instead of raw `String`, converts back to proto on response
- `Worker`: converts proto `WorkerId` to domain type on registration

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` — 35 tests pass
- [x] `cargo doc --workspace --no-deps --all-features` clean

## Related issue

Closes #26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced validated identifier types for workers and jobs with length constraints (128 character limit).
  * Strengthened ID validation across worker registration and job scheduling to reject invalid identifiers early.
  * Enhanced error handling for malformed identifiers with descriptive error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->