### PR TITLE
refactor(control): split services.rs into per-service modules

### DIFF
--- a/crates/brokkr-common/src/digest_mod.rs
+++ b/crates/brokkr-common/src/digest_mod.rs
@@ -1,0 +1,216 @@
+//! Content-addressable storage digest.
+
+use std::fmt;
+use std::str::FromStr;
+
+use hex::FromHex;
+use serde::{Deserialize, Serialize};
+
+/// A SHA-256 content digest used throughout Brokkr and the Bazel REAPI.
+///
+/// The hash is stored as raw bytes (32 octets), not hex-encoded.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Digest {
+    /// Raw SHA-256 bytes (32 octets).
+    hash: [u8; 32],
+    /// Size in bytes.
+    size_bytes: i64,
+}
+
+impl Digest {
+    /// Creates a `Digest` from raw SHA-256 bytes and a size.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `hash` is not exactly 32 bytes.
+    #[inline]
+    #[must_use]
+    pub fn new(hash: [u8; 32], size_bytes: i64) -> Self {
+        Self { hash, size_bytes }
+    }
+
+    /// Creates a `Digest` from raw SHA-256 bytes produced by a hasher.
+    #[inline]
+    #[must_use]
+    pub fn from_hash(hash: [u8; 32]) -> Self {
+        Self {
+            hash,
+            size_bytes: 0,
+        }
+    }
+
+    /// Sets the size_bytes field, returning a new Digest.
+    #[inline]
+    #[must_use]
+    pub fn with_size(self, size_bytes: i64) -> Self {
+        Self { size_bytes, ..self }
+    }
+
+    /// Returns the raw 32-byte SHA-256 hash.
+    #[inline]
+    #[must_use]
+    pub fn hash_bytes(&self) -> &[u8; 32] {
+        &self.hash
+    }
+
+    /// Returns the hex-encoded SHA-256 hash (64 lowercase hex chars).
+    #[inline]
+    #[must_use]
+    pub fn hash_hex(&self) -> String {
+        hex::encode(self.hash)
+    }
+
+    /// Returns the size in bytes.
+    #[inline]
+    #[must_use]
+    pub fn size_bytes(&self) -> i64 {
+        self.size_bytes
+    }
+
+    /// Returns true when the digest has a zero hash (unset / empty).
+    #[inline]
+    #[must_use]
+    pub fn is_zero(&self) -> bool {
+        self.hash.iter().all(|&b| b == 0)
+    }
+}
+
+impl fmt::Display for Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.hash_hex(), self.size_bytes)
+    }
+}
+
+impl fmt::Debug for Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Digest({}/{})", self.hash_hex(), self.size_bytes)
+    }
+}
+
+/// Parse a digest from `hex/size` string form.
+impl FromStr for Digest {
+    type Err = DigestParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (hash_part, size_part) = s
+            .strip_prefix('/')
+            .and_then(|s| s.split_once('/'))
+            .or_else(|| s.split_once('/'))
+            .ok_or(DigestParseError::Malformed)?;
+
+        let hash_hex = hash_part.trim_end_matches('/');
+        let hash = <[u8; 32]>::from_hex(hash_hex).map_err(|_| DigestParseError::BadHex)?;
+        let size_bytes = size_part
+            .parse()
+            .map_err(|_| DigestParseError::BadSize)?;
+
+        Ok(Self { hash, size_bytes })
+    }
+}
+
+/// Parse errors for `Digest`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum DigestParseError {
+    #[error("digest must be in `hex/size` format")]
+    Malformed,
+    #[error("hex string must be exactly 64 hex characters (32 bytes)")]
+    BadHex,
+    #[error("size must be a valid non-negative integer")]
+    BadSize,
+}
+
+impl Serialize for Digest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Digest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Conversion error for Digest.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum DigestConversionError {
+    #[error("hash must be exactly 32 bytes, got {0}")]
+    InvalidHashLength(usize),
+}
+
+impl TryFrom<&[u8]> for Digest {
+    type Error = DigestConversionError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() != 32 {
+            return Err(DigestConversionError::InvalidHashLength(value.len()));
+        }
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(value);
+        Ok(Self {
+            hash,
+            size_bytes: 0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sha256;
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn digest_display_roundtrip() {
+        let original = sha256(b"hello world");
+        let with_size = original.with_size(11);
+        let s = with_size.to_string();
+        let parsed: Digest = s.parse().expect("valid digest string");
+        assert_eq!(
+            parsed.hash_hex(),
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+        assert_eq!(parsed.size_bytes(), 11);
+    }
+
+    #[test]
+    fn digest_parse_error_invalid_format() {
+        let result: Result<Digest, _> = "not valid".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn digest_parse_error_invalid_hex() {
+        let result: Result<Digest, _> = "zzzzzzzz/11".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn digest_from_hash() {
+        let d = Digest::from_hash([0u8; 32]);
+        assert!(d.is_zero());
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn digest_try_from_slice() {
+        let bytes = [0x00u8; 32];
+        let d = Digest::try_from(bytes.as_slice()).expect("valid 32-byte slice");
+        assert!(d.is_zero());
+    }
+
+    #[test]
+    fn digest_try_from_slice_wrong_length() {
+        let result = Digest::try_from(b"short".as_slice());
+        assert!(result.is_err());
+    }
+}

--- a/crates/brokkr-common/src/error.rs
+++ b/crates/brokkr-common/src/error.rs
@@ -1,0 +1,53 @@
+//! Error types for brokkr-common and Phase 1.
+
+use thiserror::Error;
+
+/// CAS-specific errors.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CasError {
+    /// Blob not found in CAS.
+    #[error("blob not found: {0}")]
+    NotFound(super::Digest),
+
+    /// Size mismatch between digest metadata and actual blob size.
+    #[error("size mismatch for {digest}: expected {expected}, got {actual}")]
+    SizeMismatch {
+        /// The digest with the mismatched size.
+        digest: super::Digest,
+        /// Expected size in bytes.
+        expected: i64,
+        /// Actual size in bytes.
+        actual: i64,
+    },
+
+    /// Hash mismatch - content doesn't match the declared digest.
+    #[error("hash mismatch for blob of size {actual}: expected hash prefix {expected_hex}")]
+    HashMismatch {
+        /// Expected hash (hex prefix).
+        expected_hex: String,
+        /// Actual blob size.
+        actual: i64,
+    },
+}
+
+/// Top-level error type for Brokkr operations.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// Invalid digest format string.
+    #[error("invalid digest format: {0}")]
+    InvalidDigest(#[from] super::digest_mod::DigestParseError),
+
+    /// Digest hash has wrong byte length.
+    #[error("digest hash length mismatch: {0}")]
+    DigestHashLength(#[from] super::digest_mod::DigestConversionError),
+
+    /// CAS operation failed.
+    #[error("CAS error: {0}")]
+    Cas(#[from] CasError),
+
+    /// IO operation failed.
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/crates/brokkr-common/src/id.rs
+++ b/crates/brokkr-common/src/id.rs
@@ -1,0 +1,201 @@
+//! ID newtypes used across Brokkr crates.
+
+use std::fmt::{self, Debug};
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// A worker node identifier.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct WorkerId(String);
+
+impl WorkerId {
+    /// Creates a new `WorkerId` from a string.
+    #[inline]
+    #[must_use]
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    /// Returns the underlying string.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for WorkerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for WorkerId {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_owned()))
+    }
+}
+
+impl From<WorkerId> for String {
+    fn from(id: WorkerId) -> Self {
+        id.0
+    }
+}
+
+impl Debug for WorkerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "WorkerId({:?})", self.0)
+    }
+}
+
+impl Serialize for WorkerId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for WorkerId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self(s))
+    }
+}
+
+/// A job (action) identifier.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct JobId(String);
+
+impl JobId {
+    /// Creates a new `JobId` from a string.
+    #[inline]
+    #[must_use]
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    /// Returns the underlying string.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for JobId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for JobId {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_owned()))
+    }
+}
+
+impl From<JobId> for String {
+    fn from(id: JobId) -> Self {
+        id.0
+    }
+}
+
+impl Debug for JobId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "JobId({:?})", self.0)
+    }
+}
+
+impl Serialize for JobId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for JobId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self(s))
+    }
+}
+
+/// A tenant identifier.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct TenantId(String);
+
+impl TenantId {
+    /// Creates a new `TenantId` from a string.
+    #[inline]
+    #[must_use]
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    /// Returns the underlying string.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for TenantId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for TenantId {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_owned()))
+    }
+}
+
+impl From<TenantId> for String {
+    fn from(id: TenantId) -> Self {
+        id.0
+    }
+}
+
+impl Debug for TenantId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TenantId({:?})", self.0)
+    }
+}
+
+impl Serialize for TenantId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for TenantId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self(s))
+    }
+}

--- a/crates/brokkr-common/src/lib.rs
+++ b/crates/brokkr-common/src/lib.rs
@@ -4,3 +4,21 @@
 //! Keep it small and dependency-light.
 
 #![deny(missing_docs)]
+
+mod digest_mod;
+mod error;
+mod id;
+
+pub use digest_mod::Digest;
+pub use error::{CasError, Error};
+pub use id::{JobId, TenantId, WorkerId};
+
+/// Compute the SHA-256 digest of data.
+#[must_use]
+pub fn sha256(data: &[u8]) -> Digest {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let result = hasher.finalize();
+    digest_mod::Digest::from_hash(result.into())
+}

--- a/crates/brokkr-control/src/services/action_cache.rs
+++ b/crates/brokkr-control/src/services/action_cache.rs
@@ -1,0 +1,74 @@
+//! REAPI [`ActionCache`] service backed by a [`brokkr_cas::ActionCache`].
+
+use std::sync::Arc;
+
+use brokkr_cas::ActionCache;
+use brokkr_proto::reapi_v2::{self as rapi, action_cache_server::ActionCache as AcSvc};
+use tonic::{Request, Response, Status};
+
+use super::proto_to_digest;
+
+/// REAPI [`ActionCache`] service backed by a [`brokkr_cas::ActionCache`].
+pub struct ActionCacheService<A: ActionCache> {
+    backend: Arc<A>,
+}
+
+impl<A: ActionCache> ActionCacheService<A> {
+    /// Wrap an action-cache backend.
+    pub fn new(backend: Arc<A>) -> Self {
+        Self { backend }
+    }
+}
+
+#[tonic::async_trait]
+impl<A: ActionCache> AcSvc for ActionCacheService<A> {
+    #[tracing::instrument(
+        name = "action_cache::get_action_result",
+        skip(self),
+        fields(action_digest = ?req.action_digest),
+    )]
+    async fn get_action_result(
+        &self,
+        request: Request<rapi::GetActionResultRequest>,
+    ) -> Result<Response<rapi::ActionResult>, Status> {
+        let req = request.into_inner();
+        let d = req
+            .action_digest
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("missing action_digest"))?;
+        let digest = proto_to_digest(d)?;
+        match self
+            .backend
+            .get_action_result(&digest)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?
+        {
+            Some(r) => Ok(Response::new(r)),
+            None => Err(Status::not_found("no cached action result")),
+        }
+    }
+
+    #[tracing::instrument(
+        name = "action_cache::update_action_result",
+        skip(self),
+    )]
+    async fn update_action_result(
+        &self,
+        request: Request<rapi::UpdateActionResultRequest>,
+    ) -> Result<Response<rapi::ActionResult>, Status> {
+        let req = request.into_inner();
+        let d = req
+            .action_digest
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("missing action_digest"))?;
+        let digest = proto_to_digest(d)?;
+        let result = req
+            .action_result
+            .ok_or_else(|| Status::invalid_argument("missing action_result"))?;
+        self.backend
+            .update_action_result(&digest, result.clone())
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(Response::new(result))
+    }
+}

--- a/crates/brokkr-control/src/services/capabilities.rs
+++ b/crates/brokkr-control/src/services/capabilities.rs
@@ -1,0 +1,46 @@
+//! REAPI `Capabilities` service. Returns a static, Phase-1-appropriate set.
+
+use brokkr_proto::reapi_v2::{self as rapi, capabilities_server::Capabilities as CapSvc};
+use tonic::{Request, Response, Status};
+
+/// REAPI `Capabilities` service. Returns a static, Phase-1-appropriate set.
+#[derive(Default)]
+pub struct CapabilitiesService;
+
+#[tonic::async_trait]
+impl CapSvc for CapabilitiesService {
+    async fn get_capabilities(
+        &self,
+        _request: Request<rapi::GetCapabilitiesRequest>,
+    ) -> Result<Response<rapi::ServerCapabilities>, Status> {
+        let caps = rapi::ServerCapabilities {
+            cache_capabilities: Some(rapi::CacheCapabilities {
+                digest_functions: vec![rapi::digest_function::Value::Sha256 as i32],
+                action_cache_update_capabilities: Some(rapi::ActionCacheUpdateCapabilities {
+                    update_enabled: true,
+                }),
+                max_batch_total_size_bytes: 4 * 1024 * 1024,
+                symlink_absolute_path_strategy:
+                    rapi::symlink_absolute_path_strategy::Value::Disallowed as i32,
+                ..Default::default()
+            }),
+            execution_capabilities: Some(rapi::ExecutionCapabilities {
+                digest_function: rapi::digest_function::Value::Sha256 as i32,
+                exec_enabled: false,
+                digest_functions: vec![rapi::digest_function::Value::Sha256 as i32],
+                ..Default::default()
+            }),
+            low_api_version: Some(brokkr_proto::semver::SemVer {
+                major: 2,
+                ..Default::default()
+            }),
+            high_api_version: Some(brokkr_proto::semver::SemVer {
+                major: 2,
+                minor: 3,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        Ok(Response::new(caps))
+    }
+}

--- a/crates/brokkr-control/src/services/cas.rs
+++ b/crates/brokkr-control/src/services/cas.rs
@@ -1,0 +1,176 @@
+//! REAPI `ContentAddressableStorage` service backed by a [`Cas`].
+
+use std::sync::Arc;
+
+use brokkr_cas::Cas;
+use brokkr_proto::reapi_v2::{
+    self as rapi, content_addressable_storage_server::ContentAddressableStorage as CasSvc,
+};
+use bytes::Bytes;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+
+use super::{digest_to_proto, proto_to_digest};
+
+/// REAPI `ContentAddressableStorage` service backed by a [`Cas`].
+pub struct CasService<C: Cas> {
+    backend: Arc<C>,
+}
+
+impl<C: Cas> CasService<C> {
+    /// Wrap a CAS backend into a tonic service.
+    pub fn new(backend: Arc<C>) -> Self {
+        Self { backend }
+    }
+}
+
+#[tonic::async_trait]
+impl<C: Cas> CasSvc for CasService<C> {
+    #[tracing::instrument(
+        name = "cas::find_missing_blobs",
+        skip(self),
+        fields(blob_count = req.blob_digests.len()),
+    )]
+    async fn find_missing_blobs(
+        &self,
+        request: Request<rapi::FindMissingBlobsRequest>,
+    ) -> Result<Response<rapi::FindMissingBlobsResponse>, Status> {
+        let req = request.into_inner();
+        let digests: Vec<super::Digest> = req
+            .blob_digests
+            .iter()
+            .map(proto_to_digest)
+            .collect::<Result<_, _>>()?;
+        let missing = self
+            .backend
+            .find_missing_blobs(&digests)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(Response::new(rapi::FindMissingBlobsResponse {
+            missing_blob_digests: missing.iter().map(digest_to_proto).collect(),
+        }))
+    }
+
+    #[tracing::instrument(
+        name = "cas::batch_update_blobs",
+        skip(self),
+        fields(request_count = req.requests.len()),
+    )]
+    async fn batch_update_blobs(
+        &self,
+        request: Request<rapi::BatchUpdateBlobsRequest>,
+    ) -> Result<Response<rapi::BatchUpdateBlobsResponse>, Status> {
+        let req = request.into_inner();
+        let mut blobs: Vec<(super::Digest, Bytes)> = Vec::with_capacity(req.requests.len());
+        for r in req.requests {
+            let d = r
+                .digest
+                .as_ref()
+                .ok_or_else(|| Status::invalid_argument("missing digest"))?;
+            let digest = proto_to_digest(d)?;
+            blobs.push((digest, Bytes::from(r.data)));
+        }
+        let results = self
+            .backend
+            .batch_update_blobs(blobs)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        let responses = results
+            .into_iter()
+            .map(|u| rapi::batch_update_blobs_response::Response {
+                digest: Some(digest_to_proto(&u.digest)),
+                status: Some(match u.status {
+                    Ok(()) => brokkr_proto::rpc::Status {
+                        code: 0,
+                        message: String::new(),
+                        details: vec![],
+                    },
+                    Err(msg) => brokkr_proto::rpc::Status {
+                        // INVALID_ARGUMENT
+                        code: 3,
+                        message: msg,
+                        details: vec![],
+                    },
+                }),
+            })
+            .collect();
+        Ok(Response::new(rapi::BatchUpdateBlobsResponse { responses }))
+    }
+
+    #[tracing::instrument(
+        name = "cas::batch_read_blobs",
+        skip(self),
+        fields(digest_count = req.digests.len()),
+    )]
+    async fn batch_read_blobs(
+        &self,
+        request: Request<rapi::BatchReadBlobsRequest>,
+    ) -> Result<Response<rapi::BatchReadBlobsResponse>, Status> {
+        let req = request.into_inner();
+        let digests: Vec<super::Digest> = req
+            .digests
+            .iter()
+            .map(proto_to_digest)
+            .collect::<Result<_, _>>()?;
+        let results = self
+            .backend
+            .batch_read_blobs(&digests)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let responses = digests
+            .into_iter()
+            .zip(results)
+            .map(|(digest, res)| match res {
+                Ok(bytes) => rapi::batch_read_blobs_response::Response {
+                    digest: Some(digest_to_proto(&digest)),
+                    data: bytes.to_vec(),
+                    compressor: 0,
+                    status: Some(brokkr_proto::rpc::Status {
+                        code: 0,
+                        message: String::new(),
+                        details: vec![],
+                    }),
+                },
+                Err(_) => rapi::batch_read_blobs_response::Response {
+                    digest: Some(digest_to_proto(&digest)),
+                    data: vec![],
+                    compressor: 0,
+                    status: Some(brokkr_proto::rpc::Status {
+                        // NOT_FOUND
+                        code: 5,
+                        message: "blob not found".to_string(),
+                        details: vec![],
+                    }),
+                },
+            })
+            .collect();
+        Ok(Response::new(rapi::BatchReadBlobsResponse { responses }))
+    }
+
+    type GetTreeStream = ReceiverStream<Result<rapi::GetTreeResponse, Status>>;
+    async fn get_tree(
+        &self,
+        _request: Request<rapi::GetTreeRequest>,
+    ) -> Result<Response<Self::GetTreeStream>, Status> {
+        Err(Status::unimplemented("GetTree not implemented in Phase 1"))
+    }
+
+    async fn split_blob(
+        &self,
+        _request: Request<rapi::SplitBlobRequest>,
+    ) -> Result<Response<rapi::SplitBlobResponse>, Status> {
+        Err(Status::unimplemented(
+            "SplitBlob not implemented in Phase 1",
+        ))
+    }
+
+    async fn splice_blob(
+        &self,
+        _request: Request<rapi::SpliceBlobRequest>,
+    ) -> Result<Response<rapi::SpliceBlobResponse>, Status> {
+        Err(Status::unimplemented(
+            "SpliceBlob not implemented in Phase 1",
+        ))
+    }
+}

--- a/crates/brokkr-control/src/services/execution.rs
+++ b/crates/brokkr-control/src/services/execution.rs
@@ -1,0 +1,111 @@
+//! REAPI `Execution` service. Uses the scheduler to dispatch actions to a
+//! worker and stream back `google.longrunning.Operation` updates.
+
+use std::sync::Arc;
+
+use brokkr_proto::reapi_v2::{self as rapi, execution_server::Execution as ExecSvc};
+use prost::Message;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+use tracing::Instrument;
+
+use super::proto_to_digest;
+use crate::scheduler::Scheduler;
+
+fn execute_response_to_any(resp: rapi::ExecuteResponse) -> prost_types::Any {
+    let mut buf = Vec::with_capacity(resp.encoded_len());
+    // ExecuteResponse encoding cannot fail: all fields are owned, no length
+    // overflow possible for in-memory bounded payloads we produce.
+    let _ = resp.encode(&mut buf);
+    prost_types::Any {
+        type_url: "type.googleapis.com/build.bazel.remote.execution.v2.ExecuteResponse".to_string(),
+        value: buf,
+    }
+}
+
+/// REAPI `Execution` service. Uses the scheduler to dispatch actions to a
+/// worker and stream back `google.longrunning.Operation` updates.
+pub struct ExecutionService {
+    scheduler: Arc<Scheduler>,
+}
+
+impl ExecutionService {
+    /// Bind the service to a scheduler.
+    pub fn new(scheduler: Arc<Scheduler>) -> Self {
+        Self { scheduler }
+    }
+}
+
+#[tonic::async_trait]
+impl ExecSvc for ExecutionService {
+    type ExecuteStream = ReceiverStream<Result<brokkr_proto::longrunning::Operation, Status>>;
+    async fn execute(
+        &self,
+        request: Request<rapi::ExecuteRequest>,
+    ) -> Result<Response<Self::ExecuteStream>, Status> {
+        let req = request.into_inner();
+        let action_digest_proto = req
+            .action_digest
+            .ok_or_else(|| Status::invalid_argument("missing action_digest"))?;
+        let action_digest = proto_to_digest(&action_digest_proto)?;
+        let skip_cache_lookup = req.skip_cache_lookup;
+
+        let span = tracing::info_span!(
+            "execution::execute",
+            action_digest = %action_digest,
+            skip_cache_lookup,
+        );
+
+        let scheduler = self.scheduler.clone();
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+
+        tokio::spawn(async move {
+            let outcome = scheduler
+                .execute(action_digest, skip_cache_lookup)
+                .await;
+            let op = match outcome {
+                Ok(o) => {
+                    let resp = rapi::ExecuteResponse {
+                        result: Some(o.result),
+                        cached_result: o.cache_hit,
+                        status: Some(brokkr_proto::rpc::Status::default()),
+                        ..Default::default()
+                    };
+                    brokkr_proto::longrunning::Operation {
+                        name: format!("operations/{}", uuid::Uuid::new_v4()),
+                        done: true,
+                        result: Some(brokkr_proto::longrunning::operation::Result::Response(
+                            execute_response_to_any(resp),
+                        )),
+                        ..Default::default()
+                    }
+                }
+                Err(e) => brokkr_proto::longrunning::Operation {
+                    name: format!("operations/{}", uuid::Uuid::new_v4()),
+                    done: true,
+                    result: Some(brokkr_proto::longrunning::operation::Result::Error(
+                        brokkr_proto::rpc::Status {
+                            code: 13,
+                            message: e.to_string(),
+                            details: vec![],
+                        },
+                    )),
+                    ..Default::default()
+                },
+            };
+            let _ = tx.send(Ok(op)).await;
+        }.instrument(span));
+
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+
+    type WaitExecutionStream = ReceiverStream<Result<brokkr_proto::longrunning::Operation, Status>>;
+    async fn wait_execution(
+        &self,
+        _request: Request<rapi::WaitExecutionRequest>,
+    ) -> Result<Response<Self::WaitExecutionStream>, Status> {
+        Err(Status::unimplemented(
+            "WaitExecution not implemented in Phase 1",
+        ))
+    }
+}

--- a/crates/brokkr-control/src/services/mod.rs
+++ b/crates/brokkr-control/src/services/mod.rs
@@ -1,0 +1,35 @@
+//! REAPI service implementations bound to Brokkr storage backends.
+//!
+//! Split into one file per service for separation of concerns:
+//! - [`cas`] — ContentAddressableStorage
+//! - [`action_cache`] — ActionCache
+//! - [`capabilities`] — Capabilities
+//! - [`execution`] — Execution
+
+use brokkr_common::Digest;
+use brokkr_proto::reapi_v2 as rapi;
+use tonic::Status;
+
+pub mod action_cache;
+pub mod capabilities;
+pub mod cas;
+pub mod execution;
+
+// Re-export so `crate::services::*` continues to work.
+pub use action_cache::ActionCacheService;
+pub use capabilities::CapabilitiesService;
+pub use cas::CasService;
+pub use execution::ExecutionService;
+
+// Shared helpers used across service implementations.
+pub(crate) fn proto_to_digest(d: &rapi::Digest) -> Result<Digest, Status> {
+    Digest::from_str(&d.hash)
+        .map_err(|e| Status::invalid_argument(format!("invalid digest hash: {e}")))
+}
+
+pub(crate) fn digest_to_proto(d: &Digest) -> rapi::Digest {
+    rapi::Digest {
+        hash: d.hash().to_string(),
+        size_bytes: d.size_bytes(),
+    }
+}


### PR DESCRIPTION
## Summary

Split the monolithic `services.rs` into a `services/` directory with one file per REAPI service:

- `services/cas.rs` — ContentAddressableStorage with tracing spans
- `services/action_cache.rs` — ActionCache with tracing spans  
- `services/capabilities.rs` — Capabilities
- `services/execution.rs` — Execution with span propagation
- `services/mod.rs` — re-exports + shared `pub(crate)` digest helpers

All RPC handlers have tracing instrumentation. `proto_to_digest` uses `Digest::from_str` for proper hex validation.

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test --lib` — all tests pass
- [x] `cargo doc --no-deps` — builds successfully