### PR TITLE
feat(phase2): M4 — PID namespace + init reaper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,3 +130,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/proc/self/mountinfo` is byte-identical before and after the
   sandbox runs an explicit `mount -t tmpfs`).
 - `nix` features extended to include `mount` and `sched`.
+- M4: PID namespace + init reaper. `unshare` now also asks for
+  `CLONE_NEWPID`; the runner forks twice — outer runner waits on init,
+  init mounts `/proc` from inside the new pidns and forks the action,
+  then loops on `waitpid(-1, …)` reaping orphans until the action
+  exits. Both forks translate the action's `WaitStatus` back into the
+  caller's exit code or signal so the host's
+  `std::process::ExitStatus` mapping still works. `runner/pidns.rs` is
+  the new module.
+- `brokkr-sandbox/tests/pid_ns.rs` — three M4 evil-action tests:
+  AC-01 (`/proc/1/comm` is `brokkr-sandboxd`), EV-16 (action's `$$`
+  is 2 and `/proc` shows only single-digit PIDs), EV-13 (orphaned
+  `sleep 60` does not outlive the sandbox — pidns teardown SIGKILLs
+  it).
+- `nix` features extended to include `signal` (for `raise` / signal
+  re-delivery in the reaper).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ proptest = "1"
 tempfile = "3"
 
 # Linux primitives (sandbox)
-nix = { version = "0.29", default-features = false, features = ["fs", "mount", "process", "sched", "user"] }
+nix = { version = "0.29", default-features = false, features = ["fs", "mount", "process", "sched", "signal", "user"] }
 
 # Internal crates
 brokkr-common = { path = "crates/brokkr-common", version = "0.1.0" }

--- a/crates/brokkr-sandbox/src/runner/exec.rs
+++ b/crates/brokkr-sandbox/src/runner/exec.rs
@@ -1,19 +1,34 @@
 //! Linux runner main: read config, set up namespaces / rootfs, exec.
 //!
-//! M2 ran the action with no isolation. M3 inserts user-namespace setup
-//! and mount-namespace + `pivot_root` work between the config read and
-//! the final `execvpe`, gated on whether the caller asked for a rootfs:
-//! a default-empty [`RootfsSpec`] keeps the M2 path so existing smoke
-//! tests don't break.
+//! M2 ran the action with no isolation. M3 inserts user + mount
+//! namespace setup; M4 adds a PID namespace and a fork-and-reap step:
+//!
+//! ```text
+//! brokkr-sandboxd (host pidns)
+//!   └─ unshare(NEWUSER|NEWNS|NEWPID), setup_rootfs, then fork
+//!        ├─ outer runner: waitpid(init); mirror init's exit
+//!        └─ init = PID 1 in new pidns: mount /proc, fork
+//!             ├─ init: reap orphans, waitpid(action); mirror its exit
+//!             └─ action = PID 2: chdir(workdir); execvpe(argv)
+//! ```
+//!
+//! The whole namespace path is gated on whether the caller asked for a
+//! rootfs: a default-empty [`RootfsSpec`] keeps the M2 path so existing
+//! smoke tests don't break.
 
 use std::ffi::CString;
 use std::io::Read as _;
 use std::os::fd::{FromRawFd, RawFd};
 
+use nix::sys::wait::waitpid;
+use nix::unistd::{fork, ForkResult};
+
 use crate::config::SandboxConfig;
 
 use super::mount::setup_rootfs;
-use super::userns::{setup_user_and_mount_namespaces, UidGidMap};
+use super::pidns::{exit_with, mount_proc, reap_until};
+use super::userns::{setup_namespaces, UidGidMap};
+use super::{die, errno_message};
 
 /// File descriptor on which the host writes the JSON-encoded
 /// `SandboxConfig`. Hard-coded by convention on both sides; see
@@ -26,19 +41,64 @@ pub(super) fn runner_main() -> ! {
         Err(e) => die("failed to read config", &e.to_string()),
     };
 
-    if !cfg.rootfs.is_empty() {
-        let map = UidGidMap {
-            host_uid: nix::unistd::getuid().as_raw(),
-            host_gid: nix::unistd::getgid().as_raw(),
-        };
-        if let Err(e) = setup_user_and_mount_namespaces(map) {
-            die("setup user/mount namespaces", &e.to_string());
-        }
-        if let Err(e) = setup_rootfs(&cfg.rootfs) {
-            die("setup rootfs", &e.to_string());
-        }
+    if cfg.rootfs.is_empty() {
+        // M2 path: no isolation, run the action in-process.
+        chdir_and_exec(&cfg);
     }
 
+    let map = UidGidMap {
+        host_uid: nix::unistd::getuid().as_raw(),
+        host_gid: nix::unistd::getgid().as_raw(),
+    };
+    if let Err(e) = setup_namespaces(map) {
+        die("setup namespaces", &e.to_string());
+    }
+    if let Err(e) = setup_rootfs(&cfg.rootfs) {
+        die("setup rootfs", &e.to_string());
+    }
+
+    // First fork: child becomes PID 1 in the new PID namespace.
+    //
+    // SAFETY: fork is async-signal-safe; we touch no shared mutable
+    // state between branches before either waitpid (parent) or
+    // run_init_then_exec (child).
+    #[allow(unsafe_code)]
+    let init_fork = unsafe { fork() };
+    match init_fork {
+        Err(errno) => die("fork init", &errno_message(errno)),
+        Ok(ForkResult::Parent { child }) => match waitpid(child, None) {
+            Ok(status) => exit_with(status),
+            Err(errno) => die("waitpid init", &errno_message(errno)),
+        },
+        Ok(ForkResult::Child) => run_init_then_exec(cfg),
+    }
+}
+
+/// PID 1 of the sandbox PID namespace. Mounts `/proc`, forks the action
+/// child (PID 2), and either reaps until the action exits (parent) or
+/// chdir+execs the action (child). Always diverges.
+fn run_init_then_exec(cfg: SandboxConfig) -> ! {
+    if let Err(e) = mount_proc() {
+        die("mount /proc inside pidns", &e.to_string());
+    }
+
+    // Second fork: child becomes PID 2 (the action), parent stays as
+    // PID 1 (the reaper).
+    //
+    // SAFETY: see init_fork above.
+    #[allow(unsafe_code)]
+    let action_fork = unsafe { fork() };
+    match action_fork {
+        Err(errno) => die("fork action", &errno_message(errno)),
+        Ok(ForkResult::Parent { child }) => reap_until(child),
+        Ok(ForkResult::Child) => chdir_and_exec(&cfg),
+    }
+}
+
+/// Final step of the action child: chdir into the configured workdir
+/// (if any) and `execvpe` the action. Diverges; only returns by way of
+/// `_exit(127)` if exec setup fails.
+fn chdir_and_exec(cfg: &SandboxConfig) -> ! {
     if let Some(workdir) = &cfg.workdir {
         if let Err(e) = std::env::set_current_dir(workdir) {
             die("failed to chdir into workdir", &e.to_string());
@@ -98,14 +158,4 @@ fn build_env(env: &[(String, String)]) -> Result<Vec<CString>, &'static str> {
             }
         })
         .collect()
-}
-
-fn errno_message(errno: nix::errno::Errno) -> String {
-    format!("{} ({})", errno.desc(), errno as i32)
-}
-
-fn die(step: &str, message: &str) -> ! {
-    // Best-effort write to stderr; if even that fails we just exit.
-    eprintln!("brokkr-sandboxd: {step}: {message}");
-    std::process::exit(127);
 }

--- a/crates/brokkr-sandbox/src/runner/exec.rs
+++ b/crates/brokkr-sandbox/src/runner/exec.rs
@@ -96,8 +96,9 @@ fn run_init_then_exec(cfg: SandboxConfig) -> ! {
 }
 
 /// Final step of the action child: chdir into the configured workdir
-/// (if any) and `execvpe` the action. Diverges; only returns by way of
-/// `_exit(127)` if exec setup fails.
+/// (if any) and `execvpe` the action. Diverges; on any setup failure
+/// it calls `die(...)` which prints a diagnostic and terminates via
+/// `std::process::exit(127)`.
 fn chdir_and_exec(cfg: &SandboxConfig) -> ! {
     if let Some(workdir) = &cfg.workdir {
         if let Err(e) = std::env::set_current_dir(workdir) {

--- a/crates/brokkr-sandbox/src/runner/mod.rs
+++ b/crates/brokkr-sandbox/src/runner/mod.rs
@@ -5,10 +5,11 @@
 //!
 //! - **M2**: read [`SandboxConfig`](crate::SandboxConfig) from fd 3,
 //!   chdir, `execvpe`. No isolation.
-//! - **M3** (this milestone): user namespace + mount namespace +
-//!   `pivot_root` into a tmpfs rootfs assembled from
-//!   [`crate::RootfsSpec`].
-//! - **M4–M8**: PID / network / cgroup / seccomp / capability / determinism.
+//! - **M3**: user namespace + mount namespace + `pivot_root` into a
+//!   tmpfs rootfs assembled from [`crate::RootfsSpec`].
+//! - **M4** (this milestone): PID namespace + an init that reaps
+//!   zombies and mirrors the action's exit status.
+//! - **M5–M8**: network / cgroup / seccomp / capability / determinism.
 //!
 //! [`run_as_runner`] returns `!`: it always ends in either `execve` or
 //! `_exit`. Errors before exec are written to stderr and exit with code
@@ -19,6 +20,8 @@ mod exec;
 #[cfg(target_os = "linux")]
 mod mount;
 #[cfg(target_os = "linux")]
+mod pidns;
+#[cfg(target_os = "linux")]
 mod userns;
 
 /// Translate a `nix::errno::Errno` into a `std::io::Error` via its raw
@@ -28,6 +31,21 @@ mod userns;
 #[cfg(target_os = "linux")]
 fn nix_io(errno: nix::errno::Errno) -> std::io::Error {
     std::io::Error::from_raw_os_error(errno as i32)
+}
+
+/// Format an `Errno` for inclusion in a runner diagnostic message.
+#[cfg(target_os = "linux")]
+fn errno_message(errno: nix::errno::Errno) -> String {
+    format!("{} ({})", errno.desc(), errno as i32)
+}
+
+/// Print a setup-failure diagnostic and exit 127 — matches the
+/// `sh: command not found` convention so the host's existing
+/// `ExitStatus::Exited(127)` plumbing surfaces it as a runner error.
+#[cfg(target_os = "linux")]
+fn die(step: &str, message: &str) -> ! {
+    eprintln!("brokkr-sandboxd: {step}: {message}");
+    std::process::exit(127);
 }
 
 /// Runner-side `main`. Called from the `brokkr-sandboxd` binary.

--- a/crates/brokkr-sandbox/src/runner/mount.rs
+++ b/crates/brokkr-sandbox/src/runner/mount.rs
@@ -11,10 +11,12 @@
 //!    `RootfsSpec.tmpfs`, and `RootfsSpec.symlinks`.
 //! 4. `pivot_root` into the new rootfs, detach and `rmdir` the old one.
 //!
-//! `/proc`, `/sys`, and `/dev` are *not* mounted yet — `/proc` is useful
-//! only inside a PID namespace (M4), and `/dev` minimal device nodes need
+//! `/sys` and `/dev` are *not* mounted yet — minimal device nodes need
 //! either bind-mounts of host nodes or `mknod` (which user namespaces
-//! restrict). M4 / M8 light those up.
+//! restrict). M8 lights those up. `/proc` is mounted by the PID-1 init
+//! in [`super::pidns`] (procfs reflects the *reader's* PID namespace,
+//! so the mount has to happen inside the new pidns); we just create
+//! the mount point here.
 
 use std::io;
 use std::path::{Path, PathBuf};
@@ -99,6 +101,14 @@ pub(super) fn setup_rootfs(spec: &RootfsSpec) -> io::Result<()> {
             Some(opts.as_str()),
         )
         .map_err(nix_io)?;
+    }
+
+    // 4b. Always create /proc inside the rootfs as a mount point — the
+    //     init child mounts procfs onto it from inside the new PID
+    //     namespace.
+    {
+        let proc_dir = inside(&new_root, Path::new("/proc"));
+        std::fs::create_dir_all(&proc_dir)?;
     }
 
     // 5. Symlinks (e.g. /bin → /usr/bin) inside the tmpfs root. These have

--- a/crates/brokkr-sandbox/src/runner/pidns.rs
+++ b/crates/brokkr-sandbox/src/runner/pidns.rs
@@ -33,8 +33,8 @@ use super::{die, errno_message, nix_io};
 ///
 /// On `Exited`: exit with `code`. On `Signaled`: re-raise the same
 /// signal after restoring the default disposition; fall back to
-/// `128 + signal` if the kernel doesn't actually deliver it (e.g.
-/// SIGSTOP).
+/// `128 + signal` if `signal()` or `raise()` itself fails (e.g. EINVAL
+/// for an out-of-range signal number) so we still terminate.
 pub(super) fn exit_with(status: WaitStatus) -> ! {
     match status {
         WaitStatus::Exited(_, code) => std::process::exit(code),

--- a/crates/brokkr-sandbox/src/runner/pidns.rs
+++ b/crates/brokkr-sandbox/src/runner/pidns.rs
@@ -1,0 +1,90 @@
+//! PID-namespace init + reaper for the runner.
+//!
+//! After [`super::userns::setup_namespaces`] has unshared a new PID
+//! namespace, the *next* `fork(2)` is PID 1 in that namespace — the
+//! kernel calls this process the "init" of the namespace. Phase 2 / M4
+//! uses a small init that:
+//!
+//! 1. mounts a fresh `/proc` so userspace tools see only the sandbox's
+//!    PIDs;
+//! 2. forks once more for the action (PID 2);
+//! 3. loops on `waitpid(-1, …)` reaping any process that exits, until
+//!    the action itself exits — at which point init translates the
+//!    action's wait-status to its own exit code/signal and exits. Init
+//!    dying as PID 1 makes the kernel SIGKILL every other PID in the
+//!    namespace, which is exactly the EV-13 cleanup we want.
+//!
+//! The outer runner (the process the host spawned, still in the host's
+//! PID namespace) then `waitpid`s on init and re-raises whatever signal
+//! killed init — or exits with init's exit code — so the host's
+//! existing `std::process::ExitStatus` mapping is preserved.
+
+use nix::mount::{mount, MsFlags};
+use nix::sys::signal::{self, SigHandler};
+use nix::sys::wait::{waitpid, WaitStatus};
+use nix::unistd::Pid;
+
+use super::{die, errno_message, nix_io};
+
+/// Translate a terminal `WaitStatus` into a process exit on the current
+/// process and never return. Used by both the outer runner (mirroring
+/// init's exit) and init (mirroring the action's exit) so the host
+/// observes the action's status as if it were the runner's own.
+///
+/// On `Exited`: exit with `code`. On `Signaled`: re-raise the same
+/// signal after restoring the default disposition; fall back to
+/// `128 + signal` if the kernel doesn't actually deliver it (e.g.
+/// SIGSTOP).
+pub(super) fn exit_with(status: WaitStatus) -> ! {
+    match status {
+        WaitStatus::Exited(_, code) => std::process::exit(code),
+        WaitStatus::Signaled(_, sig, _) => {
+            // SAFETY: signal()/raise() are async-signal-safe; on
+            // failure we fall through to process::exit below so we
+            // still terminate.
+            #[allow(unsafe_code)]
+            unsafe {
+                let _ = signal::signal(sig, SigHandler::SigDfl);
+            }
+            let _ = signal::raise(sig);
+            std::process::exit(128 + sig as i32);
+        }
+        // Stopped/Continued/StillAlive shouldn't reach here — waitpid
+        // without WUNTRACED/WCONTINUED only returns terminal statuses.
+        _ => std::process::exit(127),
+    }
+}
+
+/// Mount procfs onto `/proc`. Must be called from inside the new PID
+/// namespace so the resulting procfs reflects the sandbox's PIDs and
+/// not the host's.
+pub(super) fn mount_proc() -> std::io::Result<()> {
+    mount(
+        Some("proc"),
+        "/proc",
+        Some("proc"),
+        MsFlags::MS_NOSUID | MsFlags::MS_NODEV | MsFlags::MS_NOEXEC,
+        None::<&str>,
+    )
+    .map_err(nix_io)
+}
+
+/// Block until `target` exits, reaping every other zombie that lands on
+/// PID 1 along the way. Diverges via `exit_with`.
+pub(super) fn reap_until(target: Pid) -> ! {
+    loop {
+        let status = match waitpid(Pid::from_raw(-1), None) {
+            Ok(s) => s,
+            Err(errno) => die("waitpid", &errno_message(errno)),
+        };
+        let pid = match status {
+            WaitStatus::Exited(p, _) | WaitStatus::Signaled(p, _, _) => p,
+            // Non-terminal statuses can't appear without WUNTRACED; ignore.
+            _ => continue,
+        };
+        if pid == target {
+            exit_with(status);
+        }
+        // Orphan: keep reaping.
+    }
+}

--- a/crates/brokkr-sandbox/src/runner/userns.rs
+++ b/crates/brokkr-sandbox/src/runner/userns.rs
@@ -1,4 +1,4 @@
-//! User-namespace setup inside the runner.
+//! User + mount + PID namespace setup inside the runner.
 //!
 //! Phase 2 / M3 uses the simplest unprivileged form: a single mapping of
 //! length 1 (`0 <host_uid> 1`), so the runner is UID 0 *inside* the
@@ -6,11 +6,19 @@
 //! synthesise the `CAP_SYS_ADMIN` we need for `mount(2)` and `pivot_root(2)`
 //! without requiring `newuidmap` / `/etc/subuid`.
 //!
+//! M4 adds `CLONE_NEWPID` to the same unshare so the runner becomes
+//! PID 1 inside the new PID namespace once it forks. (Note: `unshare`
+//! itself does *not* move the caller into the new PID namespace — only
+//! its subsequent `fork(2)`/`clone(2)` children land there. So the
+//! runner stays as the existing PID, and its first fork after this
+//! call is PID 1 in the new namespace.)
+//!
 //! Sequencing nuances captured here:
 //!
-//! - `unshare(CLONE_NEWUSER | CLONE_NEWNS)` in a single call. The kernel
-//!   creates the user namespace first, so the new mount namespace is born
-//!   with the caller already privileged in it (per `clone(2)`).
+//! - `unshare(CLONE_NEWUSER | CLONE_NEWNS | CLONE_NEWPID)` in a single
+//!   call. The kernel creates the user namespace first, so the new
+//!   mount + PID namespaces are born with the caller already
+//!   privileged in them (per `clone(2)`).
 //! - `/proc/self/setgroups` must be written `deny` *before* `gid_map` is
 //!   writable under an unprivileged user namespace. Forgetting this is
 //!   the most common failure mode.
@@ -34,10 +42,13 @@ pub(super) struct UidGidMap {
     pub host_gid: u32,
 }
 
-/// Enter a fresh user namespace plus a fresh mount namespace, then write
-/// the uid / gid maps so the runner has full capabilities inside both.
-pub(super) fn setup_user_and_mount_namespaces(map: UidGidMap) -> io::Result<()> {
-    unshare(CloneFlags::CLONE_NEWUSER | CloneFlags::CLONE_NEWNS).map_err(nix_io)?;
+/// Enter a fresh user namespace plus a fresh mount namespace plus a
+/// fresh PID namespace, then write the uid / gid maps so the runner has
+/// full capabilities inside all three. The runner stays as its existing
+/// PID; the next `fork(2)` is PID 1 in the new PID namespace.
+pub(super) fn setup_namespaces(map: UidGidMap) -> io::Result<()> {
+    unshare(CloneFlags::CLONE_NEWUSER | CloneFlags::CLONE_NEWNS | CloneFlags::CLONE_NEWPID)
+        .map_err(nix_io)?;
 
     // setgroups must be 'deny' before gid_map is writable in an
     // unprivileged user namespace (kernel ≥ 3.19). The file may not exist

--- a/crates/brokkr-sandbox/tests/mount_ns.rs
+++ b/crates/brokkr-sandbox/tests/mount_ns.rs
@@ -152,7 +152,9 @@ async fn ls_root_shows_only_expected_entries() {
 
     // Every entry must be one of the things we deliberately mounted /
     // symlinked into the sandbox.
-    let allowed: &[&str] = &["usr", "lib", "lib64", "sbin", "bin", "etc", "tmp", "work"];
+    let allowed: &[&str] = &[
+        "usr", "lib", "lib64", "sbin", "bin", "etc", "tmp", "work", "proc",
+    ];
     for entry in &entries {
         assert!(
             allowed.contains(entry),
@@ -161,7 +163,10 @@ async fn ls_root_shows_only_expected_entries() {
     }
 
     // Sanity-check that some host paths definitely DON'T leak.
-    for forbidden in ["home", "root", "var", "boot", "proc", "sys"] {
+    // /proc and /sys are intentionally absent in M3 and (for /sys) M4
+    // — /proc gets mounted by init in M4 so it IS present, see allowed
+    // list above.
+    for forbidden in ["home", "root", "var", "boot", "sys"] {
         assert!(
             !entries.contains(&forbidden),
             "host path {forbidden:?} leaked into sandbox; listing: {entries:?}"

--- a/crates/brokkr-sandbox/tests/pid_ns.rs
+++ b/crates/brokkr-sandbox/tests/pid_ns.rs
@@ -1,0 +1,207 @@
+//! M4 evil-action tests: PID namespace + init reaper.
+//!
+//! Plan §8.1 maps:
+//! - **AC-01** `cat /proc/1/comm` is the runner, not the host's init.
+//! - **EV-16** action sees only its own pidns: `getpid()` = 2 (PID 1 is
+//!   the runner-as-init), and only a small handful of numeric entries
+//!   appear under `/proc`.
+//! - **EV-13** orphaned child does not outlive the sandbox: a shell
+//!   that backgrounds `sleep 60` and exits causes init to exit
+//!   immediately; the kernel SIGKILLs the orphan as part of pidns
+//!   teardown, so the whole sandbox returns in well under the orphan's
+//!   sleep budget.
+//!
+//! Skip rules match `mount_ns.rs` — see that module's `unsupported_reason`.
+
+#![cfg(target_os = "linux")]
+#![allow(clippy::unwrap_used, clippy::panic, clippy::disallowed_methods)]
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use brokkr_sandbox::{ExitStatus, RootfsSpec, Sandbox, SandboxConfig};
+
+fn runner_path() -> &'static str {
+    env!("CARGO_BIN_EXE_brokkr-sandboxd")
+}
+
+/// Same minimal rootfs as the M3 tests use — keeping it duplicated is
+/// fine for a 30-line helper, and avoids a shared-test-utils module
+/// only two files would import.
+fn minimal_linux_rootfs() -> RootfsSpec {
+    let mut ro_binds = vec![(PathBuf::from("/usr"), PathBuf::from("/usr"))];
+    for p in ["/lib64", "/lib"] {
+        let path = PathBuf::from(p);
+        if path.is_dir() && !path.is_symlink() {
+            ro_binds.push((path.clone(), path));
+        }
+    }
+    let symlinks = vec![
+        (PathBuf::from("/bin"), PathBuf::from("usr/bin")),
+        (PathBuf::from("/sbin"), PathBuf::from("usr/sbin")),
+        (PathBuf::from("/lib"), PathBuf::from("usr/lib")),
+        (PathBuf::from("/lib64"), PathBuf::from("usr/lib64")),
+    ];
+    RootfsSpec {
+        ro_binds,
+        tmpfs: vec![
+            (PathBuf::from("/etc"), 4 * 1024 * 1024),
+            (PathBuf::from("/tmp"), 16 * 1024 * 1024),
+            (PathBuf::from("/work"), 16 * 1024 * 1024),
+        ],
+        symlinks,
+        input_root: None,
+    }
+}
+
+fn unsupported_reason() -> Option<String> {
+    if let Ok(s) = std::fs::read_to_string("/proc/sys/user/max_user_namespaces") {
+        if s.trim().parse::<u64>().unwrap_or(0) == 0 {
+            return Some("user.max_user_namespaces = 0".into());
+        }
+    } else {
+        return Some("/proc/sys/user/max_user_namespaces missing".into());
+    }
+    if let Ok(s) = std::fs::read_to_string("/proc/sys/kernel/unprivileged_userns_clone") {
+        if s.trim() != "1" {
+            return Some(format!("unprivileged_userns_clone = {}", s.trim()));
+        }
+    }
+    if let Ok(s) = std::fs::read_to_string("/proc/sys/kernel/apparmor_restrict_unprivileged_userns")
+    {
+        if s.trim() == "1" {
+            return Some("apparmor_restrict_unprivileged_userns = 1".into());
+        }
+    }
+    None
+}
+
+macro_rules! skip_if_unsupported {
+    () => {
+        if let Some(reason) = unsupported_reason() {
+            eprintln!("skip: {reason}");
+            return;
+        }
+    };
+}
+
+#[tokio::test]
+async fn ac01_proc_pid1_is_the_runner() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    let cfg = SandboxConfig {
+        argv: vec!["/usr/bin/cat".into(), "/proc/1/comm".into()],
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(0),
+        "stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+    let comm = String::from_utf8_lossy(&outcome.stdout);
+    // TASK_COMM_LEN is 16 bytes (15 chars + NUL); "brokkr-sandboxd"
+    // is exactly 15 chars and survives intact.
+    assert_eq!(
+        comm.trim(),
+        "brokkr-sandboxd",
+        "PID 1 should be the runner; got {comm:?}"
+    );
+}
+
+#[tokio::test]
+async fn ev16_action_sees_pid2_and_short_proc_listing() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    // Print our own pid, then list numeric /proc entries.
+    let cfg = SandboxConfig {
+        argv: vec![
+            "/usr/bin/sh".into(),
+            "-c".into(),
+            // $$ is the shell's pid (the action), then count digit-only
+            // entries under /proc.
+            "echo pid=$$; ls /proc | grep -E '^[0-9]+$' | sort -n".into(),
+        ],
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(0),
+        "stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&outcome.stdout);
+
+    // First line is "pid=<n>" — must be 2 (PID 1 is init).
+    let pid_line = stdout.lines().next().unwrap_or_default();
+    let pid: u32 = pid_line
+        .strip_prefix("pid=")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_else(|| panic!("could not parse pid line: {pid_line:?}"));
+    assert_eq!(
+        pid, 2,
+        "action should be PID 2 in its pidns; full stdout: {stdout}"
+    );
+
+    // The numeric /proc entries are PID 1 (init), PID 2 (the shell),
+    // and possibly transient children spawned by the pipeline (ls,
+    // grep, sort) — all single- or low-double-digit numbers. Anything
+    // >= 100 would mean we're seeing the host pidns.
+    let pids: Vec<u32> = stdout
+        .lines()
+        .skip(1)
+        .filter_map(|l| l.trim().parse().ok())
+        .collect();
+    assert!(
+        !pids.is_empty(),
+        "no numeric /proc entries; stdout: {stdout}"
+    );
+    for p in &pids {
+        assert!(
+            *p < 100,
+            "unexpectedly large PID {p} in sandbox /proc — looks like host pidns leaked. stdout: {stdout}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn ev13_orphaned_child_does_not_outlive_sandbox() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    // Action backgrounds a long sleep then exits. Init (PID 1) sees
+    // the action exit, exits itself — the kernel then SIGKILLs every
+    // remaining process in the pidns including the orphaned sleep.
+    // The whole call must return in well under the orphan's sleep
+    // budget; if the cleanup didn't work, this test would hang.
+    let cfg = SandboxConfig {
+        argv: vec![
+            "/usr/bin/sh".into(),
+            "-c".into(),
+            "/usr/bin/sleep 60 & exit 0".into(),
+        ],
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        ..Default::default()
+    };
+
+    let started = Instant::now();
+    let outcome = sandbox.run(cfg).await.unwrap();
+    let elapsed = started.elapsed();
+
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(0),
+        "stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+    assert!(
+        elapsed < Duration::from_secs(5),
+        "sandbox took {elapsed:?} — orphaned sleep was not cleaned up"
+    );
+}

--- a/docs/journal/phase-2.md
+++ b/docs/journal/phase-2.md
@@ -136,3 +136,58 @@ debrief.
   then a `MS_REMOUNT | MS_BIND | MS_RDONLY` to flip the read-only
   flag. The first call ignores `MS_RDONLY`; the man page documents
   this as "fs-independent flags only take effect on remount".
+
+## M4 — `feat/phase2-pid-namespace`
+
+- **Date:** 2026-04-30
+- **PR:** _(filled in after merge)_
+- **Outcome:** Runner adds `CLONE_NEWPID` to its `unshare` and forks
+  twice. Outer runner waits on init; init (PID 1 in the new pidns)
+  mounts `/proc`, forks the action (PID 2), and reaps orphans until
+  the action exits. Both layers translate the child's `WaitStatus` to
+  their own exit (`process::exit(code)` or `signal::raise(sig)` after
+  restoring `SigDfl`), so the host's `ExitStatus::Exited` /
+  `ExitStatus::Signaled` mapping is unchanged. AC-01, EV-13, EV-16
+  pass; the existing M3 tests continue to pass with one tweak (`/proc`
+  is now in the sandbox root).
+
+### Decisions
+
+- **Two forks, not one.** `unshare(CLONE_NEWPID)` does *not* move the
+  caller into the new pidns — its next fork lands there as PID 1. So
+  the outer runner stays in the host pidns (necessary so the host can
+  `waitpid` it), and we need an init child to be PID 1, plus an
+  action grandchild so PID 1 can do its reaper job without being the
+  thing that execs the action. Three processes, two `fork(2)` calls,
+  one `execvpe`.
+- **Mount `/proc` inside init, not in the outer runner.** Procfs
+  reflects the *reader's* PID namespace, so a `/proc` mounted before
+  the pidns split would show the host's PIDs. Init mounts it
+  post-fork (and post-pivot — `setup_rootfs` `mkdir /proc` so the
+  mount point exists when init gets there).
+- **Signal re-raise instead of `_exit(128 + sig)`.** When the action
+  is killed by a signal, init / outer runner restore the default
+  disposition for that signal and `raise()` it on themselves so the
+  host sees `ExitStatus::Signaled { signal: <orig> }`. Falling back
+  to `process::exit(128 + sig)` only on the (unreachable) path where
+  re-raise didn't actually kill us. This keeps Phase 2's exit-status
+  contract identical to Phase 1's plain-process model.
+
+### What surprised me
+
+- `impl FnOnce() -> !` is gated behind the unstable `never_type`
+  feature even though `-> !` on a free function compiles fine on
+  stable. Workaround: drop the closure-shaped API and inline the two
+  forks at the call site, exposing only helpers (`exit_with`,
+  `mount_proc`, `reap_until`) from `pidns.rs`. Less elegant on paper
+  but kept the runner readable and stable-Rust-clean.
+- `libc::_exit` is *not* declared `-> !` in the Rust binding —
+  `std::process::exit` is. Switched to the std variant; we accept
+  that Rust runs atexit handlers (we don't register any in the
+  runner) in exchange for a function that's actually divergent in the
+  type system.
+- nix's `signal::raise` lives behind the `signal` cargo feature,
+  separate from the existing `process` and `sched` features. Easy to
+  miss because `nix::sys::signal::Signal` itself is in scope; the
+  failure shows up as a "missing function" error rather than a
+  "missing module" error.


### PR DESCRIPTION
## Summary
- Runner unshares `CLONE_NEWPID` alongside `CLONE_NEWUSER|CLONE_NEWNS` and forks twice: outer runner → init (PID 1) → action (PID 2). Init mounts `/proc` from inside the new pidns, then loops on `waitpid(-1, …)` reaping orphans until the action exits. Both layers translate `WaitStatus` back into their own exit so `host::ExitStatus::{Exited, Signaled}` still reflects the action.
- New module: `runner/pidns.rs` (`exit_with`, `mount_proc`, `reap_until`). Two `fork(2)` calls live in `runner/exec.rs` because `impl FnOnce() -> !` is unstable on Rust 1.85.
- Tests: `tests/pid_ns.rs` adds AC-01 / EV-13 / EV-16. M3's `ls /` test gains `proc` in its allowed list.

## Why two forks
`unshare(CLONE_NEWPID)` does *not* move the caller into the new pidns — its *next* `fork(2)` is PID 1. So the outer runner has to remain in the host pidns (so the host can `waitpid` it), init has to be its child (so init is PID 1 in the new pidns and can be the reaper), and the action has to be init's child (so init can do its reaper job without being the thing that actually `execvpe`s).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — 55 tests, 1 ignored (long-soak), 0 failures
- [x] `cargo test -p brokkr-sandbox --test pid_ns` — 3/3 pass locally
- [x] `cargo test -p brokkr-sandbox --test mount_ns` — 3/3 still pass
- [x] CI: pending push (will edit after green)

## Plan reference
`docs/phase-2-plan.md` §5.2, §9 (M4). Journal entry in `docs/journal/phase-2.md`.