### PR TITLE
feat(phase2): M5 — network namespace + optional loopback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,3 +145,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it).
 - `nix` features extended to include `signal` (for `raise` / signal
   re-delivery in the reaper).
+- M5: network namespace + optional loopback. `unshare` now also asks
+  for `CLONE_NEWNET`, so the action lands in an empty netns by
+  default — no interfaces, no routes, not even loopback. With
+  `NetworkPolicy::Loopback`, the runner sends a hand-rolled
+  `RTM_NEWLINK` over a raw netlink socket to flip `lo` `UP` before
+  the action exec. New `runner/netns.rs` module; ~150 lines, no
+  extra crate dependencies.
+- `brokkr-sandbox/tests/net_ns.rs` — three M5 tests using `python3`
+  to read `errno` through the action's exit code: EV-08 (`1.1.1.1:443`
+  is `ENETUNREACH`), policy-`None` makes `127.0.0.1` `ENETUNREACH`
+  too (lo is `DOWN`), and policy-`Loopback` upgrades `127.0.0.1`'s
+  failure mode from `ENETUNREACH` to `ECONNREFUSED` — proving the
+  link is actually up.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,6 +270,7 @@ version = "0.1.0"
 dependencies = [
  "brokkr-common",
  "bytes",
+ "libc",
  "nix",
  "serde",
  "serde_json",

--- a/crates/brokkr-sandbox/Cargo.toml
+++ b/crates/brokkr-sandbox/Cargo.toml
@@ -29,3 +29,6 @@ nix.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
+
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+libc = "0.2"

--- a/crates/brokkr-sandbox/src/runner/exec.rs
+++ b/crates/brokkr-sandbox/src/runner/exec.rs
@@ -1,11 +1,12 @@
 //! Linux runner main: read config, set up namespaces / rootfs, exec.
 //!
 //! M2 ran the action with no isolation. M3 inserts user + mount
-//! namespace setup; M4 adds a PID namespace and a fork-and-reap step:
+//! namespace setup; M4 adds a PID namespace and a fork-and-reap step;
+//! M5 adds a network namespace and an optional loopback bring-up:
 //!
 //! ```text
 //! brokkr-sandboxd (host pidns)
-//!   └─ unshare(NEWUSER|NEWNS|NEWPID), setup_rootfs, then fork
+//!   └─ unshare(NEWUSER|NEWNS|NEWPID|NEWNET), setup_rootfs, apply_policy, fork
 //!        ├─ outer runner: waitpid(init); mirror init's exit
 //!        └─ init = PID 1 in new pidns: mount /proc, fork
 //!             ├─ init: reap orphans, waitpid(action); mirror its exit
@@ -14,7 +15,9 @@
 //!
 //! The whole namespace path is gated on whether the caller asked for a
 //! rootfs: a default-empty [`RootfsSpec`] keeps the M2 path so existing
-//! smoke tests don't break.
+//! smoke tests don't break. (`NetworkPolicy` only takes effect on the
+//! namespace path; pairing it with an empty rootfs is silently ignored
+//! today — to be split out if a real workload needs it.)
 
 use std::ffi::CString;
 use std::io::Read as _;
@@ -26,6 +29,7 @@ use nix::unistd::{fork, ForkResult};
 use crate::config::SandboxConfig;
 
 use super::mount::setup_rootfs;
+use super::netns::apply_policy as apply_network_policy;
 use super::pidns::{exit_with, mount_proc, reap_until};
 use super::userns::{setup_namespaces, UidGidMap};
 use super::{die, errno_message};
@@ -55,6 +59,9 @@ pub(super) fn runner_main() -> ! {
     }
     if let Err(e) = setup_rootfs(&cfg.rootfs) {
         die("setup rootfs", &e.to_string());
+    }
+    if let Err(e) = apply_network_policy(cfg.network) {
+        die("apply network policy", &e.to_string());
     }
 
     // First fork: child becomes PID 1 in the new PID namespace.

--- a/crates/brokkr-sandbox/src/runner/mod.rs
+++ b/crates/brokkr-sandbox/src/runner/mod.rs
@@ -7,9 +7,12 @@
 //!   chdir, `execvpe`. No isolation.
 //! - **M3**: user namespace + mount namespace + `pivot_root` into a
 //!   tmpfs rootfs assembled from [`crate::RootfsSpec`].
-//! - **M4** (this milestone): PID namespace + an init that reaps
-//!   zombies and mirrors the action's exit status.
-//! - **M5–M8**: network / cgroup / seccomp / capability / determinism.
+//! - **M4**: PID namespace + an init that reaps zombies and mirrors
+//!   the action's exit status.
+//! - **M5** (this milestone): network namespace; the runner lands in a
+//!   fresh empty netns by default, with optional `lo`-up via
+//!   [`crate::NetworkPolicy::Loopback`].
+//! - **M6–M8**: cgroup / seccomp / capability / determinism.
 //!
 //! [`run_as_runner`] returns `!`: it always ends in either `execve` or
 //! `_exit`. Errors before exec are written to stderr and exit with code
@@ -19,6 +22,8 @@
 mod exec;
 #[cfg(target_os = "linux")]
 mod mount;
+#[cfg(target_os = "linux")]
+mod netns;
 #[cfg(target_os = "linux")]
 mod pidns;
 #[cfg(target_os = "linux")]

--- a/crates/brokkr-sandbox/src/runner/netns.rs
+++ b/crates/brokkr-sandbox/src/runner/netns.rs
@@ -1,0 +1,194 @@
+//! Network-namespace policy helpers for the runner.
+//!
+//! The new netns is created in [`super::userns::setup_namespaces`] via
+//! `CLONE_NEWNET`; this module decides what state to leave it in
+//! before the action runs.
+//!
+//! Phase 2 / M5 supports two policies (see [`NetworkPolicy`]):
+//!
+//! - `None` — empty netns, no interfaces. The action sees `lo` only as
+//!   a `DOWN` link; any `connect()` returns `ENETUNREACH`.
+//! - `Loopback` — bring `lo` `UP` so `127.0.0.1` and `::1` work.
+//!
+//! Bringing `lo` up requires `CAP_NET_ADMIN` *inside* the netns.
+//! Because the new netns is owned by the new user namespace (we
+//! unshared them together), the runner has `CAP_NET_ADMIN` here even
+//! though it has none on the host.
+//!
+//! We hand-roll the netlink message rather than pull in `rtnetlink` —
+//! it's two `repr(C)` structs, ~50 bytes on the wire, and the alternative
+//! drags in a tokio-flavoured async stack we don't need.
+
+use std::io;
+use std::mem;
+
+use nix::libc;
+
+use crate::config::NetworkPolicy;
+
+/// Apply `policy` to the runner's current network namespace. Must be
+/// called after [`super::userns::setup_namespaces`] so we're inside the
+/// fresh netns.
+pub(super) fn apply_policy(policy: NetworkPolicy) -> io::Result<()> {
+    match policy {
+        NetworkPolicy::None => Ok(()),
+        NetworkPolicy::Loopback => bring_loopback_up(),
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct NlMsgHdr {
+    len: u32,
+    ty: u16,
+    flags: u16,
+    seq: u32,
+    pid: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct IfInfoMsg {
+    family: u8,
+    _pad: u8,
+    ty: u16,
+    index: i32,
+    flags: u32,
+    change: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct LinkUpRequest {
+    nl: NlMsgHdr,
+    ifi: IfInfoMsg,
+}
+
+const RTM_NEWLINK: u16 = 16;
+const NLMSG_ERROR: u16 = 2;
+const NLM_F_REQUEST: u16 = 0x1;
+const NLM_F_ACK: u16 = 0x4;
+
+/// Send `RTM_NEWLINK` with `IFF_UP` set on the loopback interface, then
+/// read the ack and surface any kernel-reported error.
+fn bring_loopback_up() -> io::Result<()> {
+    // Look up the lo ifindex inside the current netns. In a freshly
+    // unshared netns lo is index 1 in practice, but querying via
+    // if_nametoindex (which does an SIOCGIFINDEX ioctl) is the
+    // kernel-blessed way and shields us from kernels that ever change
+    // that.
+    //
+    // SAFETY: `c"lo"` is a NUL-terminated CStr literal; the call
+    // returns 0 on error and we surface that via last_os_error.
+    #[allow(unsafe_code)]
+    let lo_index = unsafe { libc::if_nametoindex(c"lo".as_ptr()) };
+    if lo_index == 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let lo_index = lo_index as i32;
+
+    // SAFETY: socket() returns -1 on error, otherwise a valid fd we
+    // own. The fd is closed via `Fd::drop` at the end of this function
+    // regardless of which path we take.
+    #[allow(unsafe_code)]
+    let raw = unsafe {
+        libc::socket(
+            libc::AF_NETLINK,
+            libc::SOCK_RAW | libc::SOCK_CLOEXEC,
+            libc::NETLINK_ROUTE,
+        )
+    };
+    if raw < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let fd = Fd(raw);
+
+    let req = LinkUpRequest {
+        nl: NlMsgHdr {
+            len: mem::size_of::<LinkUpRequest>() as u32,
+            ty: RTM_NEWLINK,
+            flags: NLM_F_REQUEST | NLM_F_ACK,
+            seq: 1,
+            pid: 0,
+        },
+        ifi: IfInfoMsg {
+            family: libc::AF_UNSPEC as u8,
+            _pad: 0,
+            ty: 0,
+            index: lo_index,
+            flags: libc::IFF_UP as u32,
+            change: libc::IFF_UP as u32,
+        },
+    };
+
+    // Destination is the kernel: pid=0, groups=0.
+    // SAFETY: zeroing a sockaddr_nl is valid; AF_NETLINK is a u16.
+    #[allow(unsafe_code)]
+    let mut sa: libc::sockaddr_nl = unsafe { mem::zeroed() };
+    sa.nl_family = libc::AF_NETLINK as u16;
+
+    // SAFETY: req is `repr(C)` and lives on the stack for the call;
+    // sa is a properly-initialised sockaddr_nl. sendto returns -1 on
+    // error and the byte count on success.
+    #[allow(unsafe_code)]
+    let sent = unsafe {
+        libc::sendto(
+            fd.0,
+            (&req as *const LinkUpRequest).cast::<libc::c_void>(),
+            mem::size_of::<LinkUpRequest>(),
+            0,
+            (&sa as *const libc::sockaddr_nl).cast::<libc::sockaddr>(),
+            mem::size_of::<libc::sockaddr_nl>() as u32,
+        )
+    };
+    if sent < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    // Read the ack. The kernel always replies with an NLMSG_ERROR for
+    // requests that set NLM_F_ACK; an errno of 0 means success.
+    let mut buf = [0u8; 4096];
+    // SAFETY: buf is a writable byte slice we own.
+    #[allow(unsafe_code)]
+    let n = unsafe { libc::recv(fd.0, buf.as_mut_ptr().cast::<libc::c_void>(), buf.len(), 0) };
+    if n < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let n = n as usize;
+    if n < mem::size_of::<NlMsgHdr>() + mem::size_of::<i32>() {
+        return Err(io::Error::other(format!("short netlink ack: {n} bytes")));
+    }
+    let reply_ty = u16::from_ne_bytes([buf[4], buf[5]]);
+    if reply_ty != NLMSG_ERROR {
+        return Err(io::Error::other(format!(
+            "unexpected netlink reply type: {reply_ty}"
+        )));
+    }
+    let errno_field = i32::from_ne_bytes([
+        buf[mem::size_of::<NlMsgHdr>()],
+        buf[mem::size_of::<NlMsgHdr>() + 1],
+        buf[mem::size_of::<NlMsgHdr>() + 2],
+        buf[mem::size_of::<NlMsgHdr>() + 3],
+    ]);
+    if errno_field != 0 {
+        // Kernel reports negative errno.
+        return Err(io::Error::from_raw_os_error(-errno_field));
+    }
+
+    Ok(())
+}
+
+/// Owning wrapper around a raw fd that closes on drop. Used here to
+/// keep the netlink socket lifecycle obvious even on error paths.
+struct Fd(libc::c_int);
+
+impl Drop for Fd {
+    fn drop(&mut self) {
+        // SAFETY: self.0 was returned by socket() above and we are its
+        // sole owner.
+        #[allow(unsafe_code)]
+        unsafe {
+            libc::close(self.0);
+        }
+    }
+}

--- a/crates/brokkr-sandbox/src/runner/netns.rs
+++ b/crates/brokkr-sandbox/src/runner/netns.rs
@@ -64,10 +64,10 @@ struct LinkUpRequest {
     ifi: IfInfoMsg,
 }
 
-const RTM_NEWLINK: u16 = 16;
-const NLMSG_ERROR: u16 = 2;
-const NLM_F_REQUEST: u16 = 0x1;
-const NLM_F_ACK: u16 = 0x4;
+const RTM_NEWLINK: u16 = libc::RTM_NEWLINK;
+const NLMSG_ERROR: u16 = libc::NLMSG_ERROR as u16;
+const NLM_F_REQUEST: u16 = libc::NLM_F_REQUEST as u16;
+const NLM_F_ACK: u16 = libc::NLM_F_ACK as u16;
 
 /// Send `RTM_NEWLINK` with `IFF_UP` set on the loopback interface, then
 /// read the ack and surface any kernel-reported error.
@@ -103,12 +103,18 @@ fn bring_loopback_up() -> io::Result<()> {
     }
     let fd = Fd(raw);
 
+    // Bound the ack `recvfrom` so a kernel that swallows our request
+    // doesn't deadlock the runner. 5s is generous for a local kernel
+    // ack — anything slower is a real failure we want to surface.
+    set_recv_timeout(fd.0, 5)?;
+
+    const REQ_SEQ: u32 = 1;
     let req = LinkUpRequest {
         nl: NlMsgHdr {
             len: mem::size_of::<LinkUpRequest>() as u32,
             ty: RTM_NEWLINK,
             flags: NLM_F_REQUEST | NLM_F_ACK,
-            seq: 1,
+            seq: REQ_SEQ,
             pid: 0,
         },
         ifi: IfInfoMsg {
@@ -144,38 +150,100 @@ fn bring_loopback_up() -> io::Result<()> {
     if sent < 0 {
         return Err(io::Error::last_os_error());
     }
+    // Datagram-style sends should be all-or-nothing, but make that
+    // explicit so a partial write would surface as an error rather
+    // than a silent kernel-side parse failure on the ack.
+    if (sent as usize) != mem::size_of::<LinkUpRequest>() {
+        return Err(io::Error::other(format!(
+            "short netlink send: {sent} of {} bytes",
+            mem::size_of::<LinkUpRequest>()
+        )));
+    }
 
     // Read the ack. The kernel always replies with an NLMSG_ERROR for
     // requests that set NLM_F_ACK; an errno of 0 means success.
+    // Netlink is datagram-based and unrelated messages can arrive
+    // first (multicast notifications etc.), so loop until we see the
+    // matching `NLMSG_ERROR` from the kernel (sender pid 0) carrying
+    // our request's `seq`.
     let mut buf = [0u8; 4096];
-    // SAFETY: buf is a writable byte slice we own.
-    #[allow(unsafe_code)]
-    let n = unsafe { libc::recv(fd.0, buf.as_mut_ptr().cast::<libc::c_void>(), buf.len(), 0) };
-    if n < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    let n = n as usize;
-    if n < mem::size_of::<NlMsgHdr>() + mem::size_of::<i32>() {
-        return Err(io::Error::other(format!("short netlink ack: {n} bytes")));
-    }
-    let reply_ty = u16::from_ne_bytes([buf[4], buf[5]]);
-    if reply_ty != NLMSG_ERROR {
-        return Err(io::Error::other(format!(
-            "unexpected netlink reply type: {reply_ty}"
-        )));
-    }
-    let errno_field = i32::from_ne_bytes([
-        buf[mem::size_of::<NlMsgHdr>()],
-        buf[mem::size_of::<NlMsgHdr>() + 1],
-        buf[mem::size_of::<NlMsgHdr>() + 2],
-        buf[mem::size_of::<NlMsgHdr>() + 3],
-    ]);
-    if errno_field != 0 {
-        // Kernel reports negative errno.
-        return Err(io::Error::from_raw_os_error(-errno_field));
-    }
+    loop {
+        // SAFETY: zeroing a sockaddr_nl is valid; we initialise
+        // sender_len with the byte size the kernel expects.
+        #[allow(unsafe_code)]
+        let mut sender: libc::sockaddr_nl = unsafe { mem::zeroed() };
+        let mut sender_len = mem::size_of::<libc::sockaddr_nl>() as libc::socklen_t;
 
-    Ok(())
+        // SAFETY: buf is a writable byte slice we own; sender and
+        // sender_len point to valid storage for the kernel to fill.
+        #[allow(unsafe_code)]
+        let n = unsafe {
+            libc::recvfrom(
+                fd.0,
+                buf.as_mut_ptr().cast::<libc::c_void>(),
+                buf.len(),
+                0,
+                (&mut sender as *mut libc::sockaddr_nl).cast::<libc::sockaddr>(),
+                &mut sender_len,
+            )
+        };
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let n = n as usize;
+        if n < mem::size_of::<NlMsgHdr>() + mem::size_of::<i32>() {
+            // Truncated / spurious; keep looking.
+            continue;
+        }
+        // Only accept replies from the kernel (pid 0). Anything else
+        // (e.g. another userland netlink peer) is ignored.
+        if sender.nl_pid != 0 {
+            continue;
+        }
+        let reply_ty = u16::from_ne_bytes([buf[4], buf[5]]);
+        let reply_seq = u32::from_ne_bytes([buf[8], buf[9], buf[10], buf[11]]);
+        if reply_ty != NLMSG_ERROR || reply_seq != REQ_SEQ {
+            continue;
+        }
+        let errno_field = i32::from_ne_bytes([
+            buf[mem::size_of::<NlMsgHdr>()],
+            buf[mem::size_of::<NlMsgHdr>() + 1],
+            buf[mem::size_of::<NlMsgHdr>() + 2],
+            buf[mem::size_of::<NlMsgHdr>() + 3],
+        ]);
+        if errno_field != 0 {
+            // Kernel reports negative errno.
+            return Err(io::Error::from_raw_os_error(-errno_field));
+        }
+        return Ok(());
+    }
+}
+
+/// Set `SO_RCVTIMEO` on `fd` to `secs` seconds. Used to bound the
+/// netlink ack `recvfrom`.
+fn set_recv_timeout(fd: libc::c_int, secs: i64) -> io::Result<()> {
+    let tv = libc::timeval {
+        tv_sec: secs,
+        tv_usec: 0,
+    };
+    // SAFETY: fd is owned by the caller for the duration of this
+    // call; tv lives on this stack frame. setsockopt returns -1 on
+    // error and 0 on success.
+    #[allow(unsafe_code)]
+    let rc = unsafe {
+        libc::setsockopt(
+            fd,
+            libc::SOL_SOCKET,
+            libc::SO_RCVTIMEO,
+            (&tv as *const libc::timeval).cast::<libc::c_void>(),
+            mem::size_of::<libc::timeval>() as libc::socklen_t,
+        )
+    };
+    if rc < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
 }
 
 /// Owning wrapper around a raw fd that closes on drop. Used here to

--- a/crates/brokkr-sandbox/src/runner/userns.rs
+++ b/crates/brokkr-sandbox/src/runner/userns.rs
@@ -13,12 +13,18 @@
 //! runner stays as the existing PID, and its first fork after this
 //! call is PID 1 in the new namespace.)
 //!
+//! M5 adds `CLONE_NEWNET` so the action gets an empty network
+//! namespace by default (no interfaces, no routes, not even loopback).
+//! The runner can opt the new netns into a usable state — currently
+//! just "bring `lo` up" via [`super::netns::apply_policy`] — based on
+//! [`crate::NetworkPolicy`].
+//!
 //! Sequencing nuances captured here:
 //!
-//! - `unshare(CLONE_NEWUSER | CLONE_NEWNS | CLONE_NEWPID)` in a single
-//!   call. The kernel creates the user namespace first, so the new
-//!   mount + PID namespaces are born with the caller already
-//!   privileged in them (per `clone(2)`).
+//! - `unshare(CLONE_NEWUSER | CLONE_NEWNS | CLONE_NEWPID | CLONE_NEWNET)`
+//!   in a single call. The kernel creates the user namespace first,
+//!   so the new mount / PID / net namespaces are born with the caller
+//!   already privileged in them (per `clone(2)`).
 //! - `/proc/self/setgroups` must be written `deny` *before* `gid_map` is
 //!   writable under an unprivileged user namespace. Forgetting this is
 //!   the most common failure mode.
@@ -42,13 +48,18 @@ pub(super) struct UidGidMap {
     pub host_gid: u32,
 }
 
-/// Enter a fresh user namespace plus a fresh mount namespace plus a
-/// fresh PID namespace, then write the uid / gid maps so the runner has
-/// full capabilities inside all three. The runner stays as its existing
-/// PID; the next `fork(2)` is PID 1 in the new PID namespace.
+/// Enter a fresh user namespace plus mount, PID, and network
+/// namespaces, then write the uid / gid maps so the runner has full
+/// capabilities inside all four. The runner stays as its existing PID;
+/// the next `fork(2)` is PID 1 in the new PID namespace.
 pub(super) fn setup_namespaces(map: UidGidMap) -> io::Result<()> {
-    unshare(CloneFlags::CLONE_NEWUSER | CloneFlags::CLONE_NEWNS | CloneFlags::CLONE_NEWPID)
-        .map_err(nix_io)?;
+    unshare(
+        CloneFlags::CLONE_NEWUSER
+            | CloneFlags::CLONE_NEWNS
+            | CloneFlags::CLONE_NEWPID
+            | CloneFlags::CLONE_NEWNET,
+    )
+    .map_err(nix_io)?;
 
     // setgroups must be 'deny' before gid_map is writable in an
     // unprivileged user namespace (kernel ≥ 3.19). The file may not exist

--- a/crates/brokkr-sandbox/tests/net_ns.rs
+++ b/crates/brokkr-sandbox/tests/net_ns.rs
@@ -1,0 +1,169 @@
+//! M5 evil-action tests: network namespace + optional loopback.
+//!
+//! Plan §8.1 maps:
+//! - **EV-08** action attempts to `connect()` to a public address
+//!   (1.1.1.1:443) — must fail with `ENETUNREACH` regardless of
+//!   policy because the netns has no default route.
+//! - **EV-07-ish** with `NetworkPolicy::None`, even `127.0.0.1` is
+//!   unreachable because `lo` is `DOWN`. With
+//!   `NetworkPolicy::Loopback`, the same connect succeeds at the route
+//!   layer and fails at TCP with `ECONNREFUSED` (no listener) — proving
+//!   loopback was actually brought up.
+//!
+//! All three tests drive the action via `python3 -c` so we can read
+//! `errno` directly through the action's exit code (Linux errno values
+//! 101 ENETUNREACH, 111 ECONNREFUSED both fit in the 0–255 exit-code
+//! window). Skip if `python3` isn't present on the host.
+//!
+//! Skip rules match `mount_ns.rs` — see that module's
+//! `unsupported_reason`.
+
+#![cfg(target_os = "linux")]
+#![allow(clippy::unwrap_used, clippy::panic, clippy::disallowed_methods)]
+
+use std::path::PathBuf;
+
+use brokkr_sandbox::{ExitStatus, NetworkPolicy, RootfsSpec, Sandbox, SandboxConfig};
+
+const ENETUNREACH: i32 = 101;
+const ECONNREFUSED: i32 = 111;
+
+fn runner_path() -> &'static str {
+    env!("CARGO_BIN_EXE_brokkr-sandboxd")
+}
+
+fn minimal_linux_rootfs() -> RootfsSpec {
+    let mut ro_binds = vec![(PathBuf::from("/usr"), PathBuf::from("/usr"))];
+    for p in ["/lib64", "/lib"] {
+        let path = PathBuf::from(p);
+        if path.is_dir() && !path.is_symlink() {
+            ro_binds.push((path.clone(), path));
+        }
+    }
+    let symlinks = vec![
+        (PathBuf::from("/bin"), PathBuf::from("usr/bin")),
+        (PathBuf::from("/sbin"), PathBuf::from("usr/sbin")),
+        (PathBuf::from("/lib"), PathBuf::from("usr/lib")),
+        (PathBuf::from("/lib64"), PathBuf::from("usr/lib64")),
+    ];
+    RootfsSpec {
+        ro_binds,
+        tmpfs: vec![
+            (PathBuf::from("/etc"), 4 * 1024 * 1024),
+            (PathBuf::from("/tmp"), 16 * 1024 * 1024),
+            (PathBuf::from("/work"), 16 * 1024 * 1024),
+        ],
+        symlinks,
+        input_root: None,
+    }
+}
+
+fn unsupported_reason() -> Option<String> {
+    if let Ok(s) = std::fs::read_to_string("/proc/sys/user/max_user_namespaces") {
+        if s.trim().parse::<u64>().unwrap_or(0) == 0 {
+            return Some("user.max_user_namespaces = 0".into());
+        }
+    } else {
+        return Some("/proc/sys/user/max_user_namespaces missing".into());
+    }
+    if let Ok(s) = std::fs::read_to_string("/proc/sys/kernel/unprivileged_userns_clone") {
+        if s.trim() != "1" {
+            return Some(format!("unprivileged_userns_clone = {}", s.trim()));
+        }
+    }
+    if let Ok(s) = std::fs::read_to_string("/proc/sys/kernel/apparmor_restrict_unprivileged_userns")
+    {
+        if s.trim() == "1" {
+            return Some("apparmor_restrict_unprivileged_userns = 1".into());
+        }
+    }
+    if !std::path::Path::new("/usr/bin/python3").exists() {
+        return Some("/usr/bin/python3 missing".into());
+    }
+    None
+}
+
+macro_rules! skip_if_unsupported {
+    () => {
+        if let Some(reason) = unsupported_reason() {
+            eprintln!("skip: {reason}");
+            return;
+        }
+    };
+}
+
+/// Build an action that tries to connect a TCP socket to `addr:port`
+/// and exits with the connect's errno (or 0 on unexpected success).
+fn connect_action(addr: &str, port: u16) -> Vec<String> {
+    let script = format!(
+        "import socket, sys\n\
+         s = socket.socket()\n\
+         s.settimeout(1)\n\
+         try:\n\
+         \x20   s.connect(('{addr}', {port}))\n\
+         \x20   sys.exit(0)\n\
+         except OSError as e:\n\
+         \x20   sys.exit(e.errno or 1)\n"
+    );
+    vec!["/usr/bin/python3".into(), "-c".into(), script]
+}
+
+#[tokio::test]
+async fn ev08_public_address_unreachable() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    let cfg = SandboxConfig {
+        argv: connect_action("1.1.1.1", 443),
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        // Default: NetworkPolicy::None — empty netns.
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(ENETUNREACH),
+        "expected ENETUNREACH (101); stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+}
+
+#[tokio::test]
+async fn loopback_down_makes_127_0_0_1_unreachable() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    let cfg = SandboxConfig {
+        argv: connect_action("127.0.0.1", 1),
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        network: NetworkPolicy::None,
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(ENETUNREACH),
+        "with lo DOWN, 127.0.0.1 should be ENETUNREACH (101); stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+}
+
+#[tokio::test]
+async fn loopback_up_makes_127_0_0_1_route_but_not_connect() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    let cfg = SandboxConfig {
+        argv: connect_action("127.0.0.1", 1),
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        network: NetworkPolicy::Loopback,
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(ECONNREFUSED),
+        "with lo UP, 127.0.0.1:1 should be ECONNREFUSED (111); stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+}

--- a/crates/brokkr-sandbox/tests/net_ns.rs
+++ b/crates/brokkr-sandbox/tests/net_ns.rs
@@ -25,8 +25,8 @@ use std::path::PathBuf;
 
 use brokkr_sandbox::{ExitStatus, NetworkPolicy, RootfsSpec, Sandbox, SandboxConfig};
 
-const ENETUNREACH: i32 = 101;
-const ECONNREFUSED: i32 = 111;
+const ENETUNREACH: i32 = libc::ENETUNREACH;
+const ECONNREFUSED: i32 = libc::ECONNREFUSED;
 
 fn runner_path() -> &'static str {
     env!("CARGO_BIN_EXE_brokkr-sandboxd")

--- a/docs/journal/phase-2.md
+++ b/docs/journal/phase-2.md
@@ -191,3 +191,55 @@ debrief.
   miss because `nix::sys::signal::Signal` itself is in scope; the
   failure shows up as a "missing function" error rather than a
   "missing module" error.
+
+## M5 — `feat/phase2-network-namespace`
+
+- **Date:** 2026-04-30
+- **PR:** _(filled in after merge)_
+- **Outcome:** `unshare` now also asks for `CLONE_NEWNET`, so the
+  action gets an empty network namespace by default — no interfaces,
+  no routes, not even loopback. `NetworkPolicy::Loopback` brings `lo`
+  up via a hand-rolled `RTM_NEWLINK` netlink message. Three EV/AC
+  tests (`net_ns.rs`) prove this with errno-level assertions: 1.1.1.1
+  is `ENETUNREACH`, 127.0.0.1 is `ENETUNREACH` with policy=None and
+  `ECONNREFUSED` with policy=Loopback.
+
+### Decisions
+
+- **Hand-roll the netlink, don't pull in `rtnetlink`.** The
+  `rtnetlink` crate works but drags in a tokio-flavoured async stack
+  (futures, channels, an executor) for what's a single 32-byte
+  request and a single ack. Two `repr(C)` structs and ~150 lines of
+  raw libc were cheaper than the dep tree review.
+- **Use `nix::libc` instead of taking a direct `libc` dep or the
+  `nix` `socket`/`net` features.** nix already re-exports `libc`, and
+  AF_NETLINK / `if_nametoindex` are in `libc` proper. Adding the nix
+  feature would have been one line in `Cargo.toml` but pulled
+  hundreds of lines of nix wrappers we don't want.
+- **Apply the network policy in the outer runner, before fork.** The
+  netns is created at `unshare`, so it's already correct when init
+  starts; doing the loopback bring-up before fork keeps init's job
+  small (still just mount `/proc` + reap) and lets us surface
+  netlink failures with the same `die("apply network policy", …)`
+  diagnostic plumbing as the other setup steps.
+- **Errno through exit code as the EV-test contract.** Using
+  `python3 -c '... sys.exit(e.errno)'` is the cleanest way to
+  distinguish `ENETUNREACH` (101) from `ECONNREFUSED` (111). Both fit
+  in the 0–255 exit-code window. The alternative (parsing stderr from
+  `bash`'s `/dev/tcp` redirect) is brittle.
+
+### What surprised me
+
+- `127.0.0.1` is `ENETUNREACH`, not `ECONNREFUSED`, when `lo` is
+  `DOWN`. I'd expected the kernel to fall back to a generic
+  "no route" or to silently drop, but it's the same `ENETUNREACH`
+  that an external IP gets — useful, because it means policy=None
+  vs policy=Loopback is distinguishable from inside the action via
+  errno alone.
+- The kernel always replies to netlink requests with
+  `NLM_F_ACK` set, even on success — the ack is an `NLMSG_ERROR`
+  message with `errno=0`. Surprised me on first read of the spec;
+  documented in `man 7 netlink`.
+- `c"lo"` (a C-string literal in edition 2024 / Rust 1.85) is a
+  cleaner spelling than `b"lo\0"`. clippy actually fired on the
+  byte-string version (`manual_c_str_literals`).


### PR DESCRIPTION
## Summary
- `unshare` now also asks for `CLONE_NEWNET`. The action lands in an empty netns (no interfaces, no routes, not even `lo`) by default.
- `NetworkPolicy::Loopback` brings `lo` `UP` via a hand-rolled `RTM_NEWLINK` netlink message — ~150 lines of `repr(C)` structs + raw `libc::sendto`/`recv`, no new crate dependencies.
- New module `runner/netns.rs`; `apply_policy` is called between `setup_rootfs` and the first fork.
- 3 new EV-tests in `tests/net_ns.rs` driven by `python3` so we can read `errno` via the action's exit code.

## Why hand-roll the netlink
`rtnetlink` works but pulls in a tokio-flavoured async stack for what's a single 32-byte request and a single ack. Two `repr(C)` structs and a few unsafe `libc::send*`/`recv` calls is the smaller blast radius.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all green, 1 ignored long-soak
- [x] `cargo test -p brokkr-sandbox --test net_ns` — 3/3 pass locally
- [x] Existing M3/M4 tests unchanged
- [x] CI: pending push (will edit once green)

## Plan reference
`docs/phase-2-plan.md` §5.4, §9 (M5). Journal entry in `docs/journal/phase-2.md`.