### PR TITLE
feat(phase2): M6 — cgroups v2 + wall-clock timeout + OOM detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,3 +158,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   too (lo is `DOWN`), and policy-`Loopback` upgrades `127.0.0.1`'s
   failure mode from `ENETUNREACH` to `ECONNREFUSED` — proving the
   link is actually up.
+- M6: per-action cgroup-v2 + wall-clock timeout + OOM detection +
+  resource accounting. `Sandbox::with_cgroup_root(path)` opts into
+  it; without that builder call the sandbox does no cgroup work and
+  M2-M5 behaviour is preserved. New host module `host/cgroup.rs`
+  creates `<root>/action-<uuid>/`, applies `memory.max` /
+  `memory.swap.max` / `pids.max` / `cpu.max` from
+  `ResourceLimits`, attaches the runner pid to `cgroup.procs`
+  before the runner makes any progress, reads `cpu.stat` /
+  `memory.peak` / `pids.peak` / `io.stat` for accounting, and
+  checks `memory.events:oom_kill` to translate kernel-OOM kills into
+  `ExitStatus::OutOfMemory`. `cgroup.kill` is used for atomic
+  cleanup on wall-clock timeout (kernel ≥ 5.14, with a per-pid
+  fallback).
+- Host-side wall-clock enforcement: when `ResourceLimits.wall_clock_secs`
+  is set, the runner wait is wrapped in `tokio::time::timeout`; on
+  elapsed the cgroup is `kill_all`'d (or the runner alone, sans
+  cgroup) and `ExitStatus::Timeout` is returned.
+- `host/linux.rs` now drives stdout/stderr drains via
+  `tokio::spawn(read_to_end)` rather than `wait_with_output`, so
+  `child.wait()` is interruptible by the timeout path.
+- `brokkr-sandbox/tests/cgroup.rs` — four M6 tests:
+  `wall_clock_timeout_kills_long_action` (always runs),
+  `fork_bomb_capped_by_pids_max`, `memory_max_triggers_oom_status`,
+  `accounting_is_populated_for_a_normal_action`. The last three
+  skip cleanly unless `BROKKR_TEST_CGROUP_ROOT` is set or
+  `/sys/fs/cgroup/brokkr.slice/` is writable; locally they pass under
+  `systemd-run --user --scope -- bash -c 'BROKKR_TEST_CGROUP_ROOT=…
+  cargo test'`.
+- Added `uuid` as a direct dep of `brokkr-sandbox` for action-cgroup
+  naming.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/brokkr-sandbox/Cargo.toml
+++ b/crates/brokkr-sandbox/Cargo.toml
@@ -23,6 +23,7 @@ serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
+uuid.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix.workspace = true

--- a/crates/brokkr-sandbox/src/host/cgroup.rs
+++ b/crates/brokkr-sandbox/src/host/cgroup.rs
@@ -1,0 +1,188 @@
+//! Per-action cgroup v2: create, set limits, attach pid, read accounting,
+//! detect OOM, clean up.
+//!
+//! Phase 2 / M6. The host worker is expected to own a writable
+//! delegated slice — typically `/sys/fs/cgroup/brokkr.slice/` set up
+//! by `scripts/install-cgroup-slice.sh` or via systemd's `Delegate=yes`.
+//! For each action the host creates a leaf cgroup
+//! `<slice>/action-<uuid>/`, writes the configured limits, attaches the
+//! runner process to it (so all of init / the action / its children
+//! inherit it), and reads accounting back when the action finishes.
+//!
+//! ## Why we don't enable subtree_control on the action cgroup
+//!
+//! Cgroup v2 enables controllers in *children* via the parent's
+//! `cgroup.subtree_control`. The action cgroup has no children of its
+//! own (it's the leaf where processes live), so we touch
+//! `cgroup.subtree_control` only on the *slice* (and only as part of
+//! one-shot host setup, not every action). The
+//! `scripts/install-cgroup-slice.sh` script does that step.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::config::ResourceLimits;
+use crate::outcome::ResourceAccounting;
+
+/// Per-action cgroup. RAII: drop removes the leaf directory.
+#[derive(Debug)]
+pub(super) struct Cgroup {
+    path: PathBuf,
+}
+
+impl Cgroup {
+    /// Create `<parent>/<name>` and write the configured limits. The
+    /// leaf has no children, so we never touch `subtree_control` on it.
+    pub(super) fn create(parent: &Path, name: &str, limits: &ResourceLimits) -> io::Result<Self> {
+        let path = parent.join(name);
+        fs::create_dir(&path)?;
+        let cg = Cgroup { path };
+        cg.apply_limits(limits)?;
+        Ok(cg)
+    }
+
+    fn apply_limits(&self, limits: &ResourceLimits) -> io::Result<()> {
+        if let Some(mem) = limits.memory_bytes {
+            self.write_attr("memory.max", &mem.to_string())?;
+            // Disable swap accounting so the action can't dodge the
+            // memory cap by swapping. memory.swap.max may not exist on
+            // kernels without the swap controller; ignore ENOENT so a
+            // missing swap controller doesn't block the run.
+            if let Err(e) = self.write_attr("memory.swap.max", "0") {
+                if e.kind() != io::ErrorKind::NotFound {
+                    return Err(e);
+                }
+            }
+        }
+        if let Some(pids) = limits.pids_max {
+            self.write_attr("pids.max", &pids.to_string())?;
+        }
+        if let Some(cpu_milli) = limits.cpu_milli {
+            // cpu.max is "<quota_us> <period_us>"; period 100_000us is
+            // the kernel default, and quota / period gives the fraction
+            // of a core. 1000 milli-CPU = one full core.
+            const PERIOD_US: u64 = 100_000;
+            let quota_us = cpu_milli.saturating_mul(PERIOD_US) / 1_000;
+            self.write_attr("cpu.max", &format!("{quota_us} {PERIOD_US}"))?;
+        }
+        Ok(())
+    }
+
+    /// Write `pid` into `cgroup.procs`, moving the process (and its
+    /// future descendants) into this cgroup.
+    pub(super) fn attach(&self, pid: u32) -> io::Result<()> {
+        self.write_attr("cgroup.procs", &pid.to_string())
+    }
+
+    /// Read every accounting counter we know about. Missing files
+    /// (older kernels, controllers not enabled) leave the corresponding
+    /// field at its `Default::default()` value rather than failing the
+    /// whole run.
+    pub(super) fn accounting(&self) -> ResourceAccounting {
+        let mut acc = ResourceAccounting::default();
+
+        if let Ok(stat) = fs::read_to_string(self.path.join("cpu.stat")) {
+            for line in stat.lines() {
+                let mut parts = line.split_whitespace();
+                let key = parts.next();
+                let val = parts.next().and_then(|s| s.parse::<u64>().ok());
+                match (key, val) {
+                    (Some("user_usec"), Some(v)) => acc.cpu_user = Duration::from_micros(v),
+                    (Some("system_usec"), Some(v)) => acc.cpu_system = Duration::from_micros(v),
+                    _ => {}
+                }
+            }
+        }
+
+        if let Ok(s) = fs::read_to_string(self.path.join("memory.peak")) {
+            acc.memory_peak_bytes = s.trim().parse().unwrap_or(0);
+        }
+
+        if let Ok(s) = fs::read_to_string(self.path.join("pids.peak")) {
+            acc.max_pids = s.trim().parse().unwrap_or(0);
+        }
+
+        // `io.stat` lines look like:
+        //   "8:0 rbytes=4096 wbytes=8192 rios=2 wios=1 dbytes=0 dios=0"
+        // Sum across devices.
+        if let Ok(s) = fs::read_to_string(self.path.join("io.stat")) {
+            for line in s.lines() {
+                for token in line.split_whitespace().skip(1) {
+                    if let Some(v) = token
+                        .strip_prefix("rbytes=")
+                        .and_then(|s| s.parse::<u64>().ok())
+                    {
+                        acc.io_read_bytes = acc.io_read_bytes.saturating_add(v);
+                    } else if let Some(v) = token
+                        .strip_prefix("wbytes=")
+                        .and_then(|s| s.parse::<u64>().ok())
+                    {
+                        acc.io_write_bytes = acc.io_write_bytes.saturating_add(v);
+                    }
+                }
+            }
+        }
+
+        acc
+    }
+
+    /// True if the kernel OOM-killer fired inside this cgroup. Read
+    /// `memory.events`'s `oom_kill` counter; missing file or zero count
+    /// → `false`.
+    pub(super) fn was_oom_killed(&self) -> bool {
+        let Ok(s) = fs::read_to_string(self.path.join("memory.events")) else {
+            return false;
+        };
+        for line in s.lines() {
+            let mut parts = line.split_whitespace();
+            if parts.next() == Some("oom_kill") {
+                return parts
+                    .next()
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .is_some_and(|n| n > 0);
+            }
+        }
+        false
+    }
+
+    /// Best-effort SIGKILL of every PID still inside this cgroup. Used
+    /// on wall-clock timeout so `Drop`'s `rmdir` can succeed.
+    pub(super) fn kill_all(&self) -> io::Result<()> {
+        // cgroup v2 has cgroup.kill since 5.14 — single write of "1"
+        // SIGKILLs every process in the cgroup atomically.
+        match self.write_attr("cgroup.kill", "1") {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                // Pre-5.14 fallback: walk cgroup.procs and kill each.
+                let procs = fs::read_to_string(self.path.join("cgroup.procs"))?;
+                for pid_str in procs.split_whitespace() {
+                    if let Ok(pid) = pid_str.parse::<i32>() {
+                        // SAFETY: kill is async-signal-safe; passing an
+                        // out-of-range pid returns ESRCH which we ignore.
+                        #[allow(unsafe_code)]
+                        unsafe {
+                            nix::libc::kill(pid, nix::libc::SIGKILL);
+                        }
+                    }
+                }
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn write_attr(&self, name: &str, content: &str) -> io::Result<()> {
+        fs::write(self.path.join(name), content)
+    }
+}
+
+impl Drop for Cgroup {
+    fn drop(&mut self) {
+        // Best-effort cleanup. If processes are still inside, this
+        // returns EBUSY — the caller should have called `kill_all`
+        // before drop in that case.
+        let _ = fs::remove_dir(&self.path);
+    }
+}

--- a/crates/brokkr-sandbox/src/host/cgroup.rs
+++ b/crates/brokkr-sandbox/src/host/cgroup.rs
@@ -159,11 +159,14 @@ impl Cgroup {
                 let procs = fs::read_to_string(self.path.join("cgroup.procs"))?;
                 for pid_str in procs.split_whitespace() {
                     if let Ok(pid) = pid_str.parse::<i32>() {
-                        // SAFETY: kill is async-signal-safe; passing an
-                        // out-of-range pid returns ESRCH which we ignore.
-                        #[allow(unsafe_code)]
-                        unsafe {
-                            nix::libc::kill(pid, nix::libc::SIGKILL);
+                        // ESRCH (process already gone) is benign and
+                        // expected during teardown races; swallow it.
+                        match nix::sys::signal::kill(
+                            nix::unistd::Pid::from_raw(pid),
+                            nix::sys::signal::Signal::SIGKILL,
+                        ) {
+                            Ok(()) | Err(nix::errno::Errno::ESRCH) => {}
+                            Err(_) => {}
                         }
                     }
                 }

--- a/crates/brokkr-sandbox/src/host/linux.rs
+++ b/crates/brokkr-sandbox/src/host/linux.rs
@@ -64,7 +64,13 @@ pub(super) async fn run_action(
     cmd.stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .env_clear();
+        .env_clear()
+        // If anything between `spawn` and the final `wait` returns
+        // early (cgroup setup, config-pipe write, etc.), `Child` gets
+        // dropped. Without `kill_on_drop`, the runner would keep
+        // running orphaned — this guarantees SIGKILL on drop so the
+        // wall-clock contract holds on the error paths too.
+        .kill_on_drop(true);
 
     // SAFETY: pre_exec runs in the freshly-forked child between fork and
     // exec. We perform only async-signal-safe operations: dup2(2),

--- a/crates/brokkr-sandbox/src/host/linux.rs
+++ b/crates/brokkr-sandbox/src/host/linux.rs
@@ -1,17 +1,30 @@
 //! Linux-only implementation of `Sandbox::run`.
 //!
-//! Phase 2 / M2 walkthrough:
+//! Phase 2 evolution:
 //!
-//! 1. Serialise the [`SandboxConfig`] to JSON.
-//! 2. Create a config pipe (`pipe(2)`).
-//! 3. Spawn `brokkr-sandboxd` with the read end of the pipe `dup2`'d to
-//!    fd 3, stdout / stderr captured.
-//! 4. Close our copy of the read end; write the JSON to the write end;
-//!    close.
-//! 5. Wait for the child to exit; collect stdout / stderr.
+//! - **M2**: pipe a JSON config to `brokkr-sandboxd` over fd 3, wait, drain.
+//! - **M3–M5**: namespaces / rootfs / netns done inside the runner.
+//! - **M6** (this milestone): per-action cgroup, wall-clock timeout
+//!   enforcement, OOM detection, accounting readback.
 //!
-//! Subsequent milestones extend this with cgroup attachment (M6),
-//! resource-accounting readback (M6), and wall-clock enforcement (M8).
+//! ### M6 ordering: when does the cgroup attach happen?
+//!
+//! ```text
+//! host           runner (brokkr-sandboxd)
+//! ────────────   ────────────────────────
+//! spawn          execve, then read_to_end(fd 3)  ← BLOCKS here
+//! attach pid
+//! write config
+//! close          unblocks, does namespace setup, fork, exec action
+//! wait
+//! ```
+//!
+//! The attach lands between `spawn` and `write config`. The runner is
+//! parked on `read_to_end(fd 3)` for that whole window because the
+//! pipe stays open until the host closes its writer end, so the
+//! attach is guaranteed to complete *before* the runner's children
+//! exist. cgroups are inherited by descendants, so init / the action
+//! / their children all land in the same cgroup automatically.
 
 use std::fs::File;
 use std::io;
@@ -19,11 +32,14 @@ use std::os::fd::RawFd;
 use std::os::unix::process::ExitStatusExt as _;
 use std::path::Path;
 use std::process::Stdio;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use bytes::Bytes;
+use tokio::io::AsyncReadExt as _;
 use tokio::process::Command;
+use uuid::Uuid;
 
+use super::cgroup::Cgroup;
 use super::ipc::create_config_pipe;
 use crate::config::SandboxConfig;
 use crate::error::SandboxError;
@@ -31,6 +47,7 @@ use crate::outcome::{ExitStatus, ResourceAccounting, SandboxOutcome, SandboxTimi
 
 pub(super) async fn run_action(
     runner_binary: &Path,
+    cgroup_root: Option<&Path>,
     cfg: SandboxConfig,
 ) -> Result<SandboxOutcome, SandboxError> {
     let setup_start = Instant::now();
@@ -58,14 +75,10 @@ pub(super) async fn run_action(
         cmd.pre_exec(move || {
             const TARGET_FD: RawFd = 3;
             if child_read_fd != TARGET_FD {
-                // dup2 atomically clears FD_CLOEXEC on the target.
                 nix::unistd::dup2(child_read_fd, TARGET_FD).map_err(io::Error::from)?;
                 nix::unistd::close(child_read_fd).map_err(io::Error::from)?;
             } else {
-                // dup2(N, N) is a no-op and does NOT clear CLOEXEC, so we
-                // have to do it explicitly. Without this, the runner's fd 3
-                // (which inherited O_CLOEXEC from `pipe2`) would close on
-                // `execve`, leaving the runner unable to read its config.
+                // dup2(N, N) is a no-op and does NOT clear CLOEXEC.
                 nix::fcntl::fcntl(
                     TARGET_FD,
                     nix::fcntl::FcntlArg::F_SETFD(nix::fcntl::FdFlag::empty()),
@@ -76,12 +89,10 @@ pub(super) async fn run_action(
         });
     }
 
-    let child = cmd.spawn().map_err(|e| SandboxError::Setup {
+    let mut child = cmd.spawn().map_err(|e| SandboxError::Setup {
         step: "spawn runner",
         source: e,
     })?;
-    // (If `cmd.spawn()` had failed, `pipe.reader` and `pipe.writer` would
-    // close via Drop on the early return above — no fd leaks.)
 
     // Decompose the pipe so the host's copy of the read end closes
     // immediately (the child has its own copy at fd 3) and `writer` is
@@ -89,19 +100,39 @@ pub(super) async fn run_action(
     let crate::host::ipc::ConfigPipe { writer, reader } = pipe;
     drop(reader);
 
-    // Write the JSON payload synchronously and close the write end so the
-    // runner sees EOF on fd 3. Phase-2 config payloads are well under the
-    // 64 KiB Linux pipe-buffer size, so this never blocks. We deliberately
-    // bound `file`'s scope so its Drop closes the fd *before* we wait on
-    // the child — otherwise the runner would block forever on `read_to_end`.
-    //
-    // EPIPE is intentionally tolerated here: it means the runner already
-    // exited (e.g. its `pre_exec` or startup failed). In that case the
-    // runner's stderr + exit status is the authoritative error, not the
-    // pipe write — let `wait_with_output` collect them and report.
+    // M6: create a per-action cgroup and attach the runner pid before
+    // we let the runner make progress. The runner is currently parked
+    // on `read_to_end(fd 3)`; it can't fork until we close the writer.
+    let runner_pid = child.id().ok_or_else(|| SandboxError::Setup {
+        step: "read runner pid",
+        source: io::Error::other("tokio child has no pid"),
+    })?;
+    let cgroup = if let Some(root) = cgroup_root {
+        let leaf = format!("action-{}", Uuid::new_v4());
+        let cg = Cgroup::create(root, &leaf, &cfg.limits).map_err(SandboxError::Cgroup)?;
+        cg.attach(runner_pid).map_err(SandboxError::Cgroup)?;
+        Some(cg)
+    } else {
+        None
+    };
+
+    // Take stdout / stderr off the child so we can drive `wait` and
+    // pipe-draining concurrently — wait_with_output wouldn't let us
+    // SIGKILL on timeout because it consumes the Child.
+    let stdout = child.stdout.take().ok_or_else(|| SandboxError::Setup {
+        step: "take stdout",
+        source: io::Error::other("child stdout already taken"),
+    })?;
+    let stderr = child.stderr.take().ok_or_else(|| SandboxError::Setup {
+        step: "take stderr",
+        source: io::Error::other("child stderr already taken"),
+    })?;
+    let stdout_task = tokio::spawn(read_to_end(stdout));
+    let stderr_task = tokio::spawn(read_to_end(stderr));
+
+    // Write the JSON payload. EPIPE is tolerated — see M2 notes for why.
     let write_err = {
         use std::io::Write as _;
-        // OwnedFd → File is a safe conversion (impl From in std).
         let mut file = File::from(writer);
         let res = file.write_all(&payload).and_then(|()| file.flush()).err();
         drop(file);
@@ -119,44 +150,90 @@ pub(super) async fn run_action(
     let exec_start = Instant::now();
     let setup_elapsed = exec_start - setup_start;
 
-    let output = child
-        .wait_with_output()
-        .await
-        .map_err(|e| SandboxError::Setup {
-            step: "wait for runner",
-            source: e,
-        })?;
+    // Wait for the runner. If `wall_clock_secs` is set, race against a
+    // deadline; on elapsed, ask the cgroup to SIGKILL every PID
+    // inside (including the runner) and reap.
+    let wall_clock = cfg.limits.wall_clock_secs.map(Duration::from_secs);
+    let (wait_status, hit_timeout) = match wall_clock {
+        None => (
+            child.wait().await.map_err(|e| SandboxError::Setup {
+                step: "wait for runner",
+                source: e,
+            })?,
+            false,
+        ),
+        Some(deadline) => match tokio::time::timeout(deadline, child.wait()).await {
+            Ok(Ok(s)) => (s, false),
+            Ok(Err(e)) => {
+                return Err(SandboxError::Setup {
+                    step: "wait for runner",
+                    source: e,
+                });
+            }
+            Err(_elapsed) => {
+                // SIGKILL the whole cgroup if we have one (catches
+                // grandchildren); otherwise just kill the runner.
+                if let Some(cg) = &cgroup {
+                    let _ = cg.kill_all();
+                } else {
+                    let _ = child.kill().await;
+                }
+                let s = child.wait().await.map_err(|e| SandboxError::Setup {
+                    step: "wait for runner after timeout",
+                    source: e,
+                })?;
+                (s, true)
+            }
+        },
+    };
 
-    // If the host's write hit EPIPE *and* the runner exited non-zero with a
-    // diagnostic on stderr, prefer the runner's message — it's almost
-    // certainly more informative than "Broken pipe".
-    if write_err.is_some() && !output.status.success() && !output.stderr.is_empty() {
+    let stdout_buf = stdout_task.await.unwrap_or_default();
+    let stderr_buf = stderr_task.await.unwrap_or_default();
+
+    // If the host's write hit EPIPE *and* the runner exited non-zero with
+    // a diagnostic on stderr, prefer the runner's message — same M2 logic.
+    if write_err.is_some() && !wait_status.success() && !stderr_buf.is_empty() {
         return Err(SandboxError::RunnerCrashed(
-            String::from_utf8_lossy(&output.stderr).trim().to_string(),
+            String::from_utf8_lossy(&stderr_buf).trim().to_string(),
         ));
     }
 
     let teardown_start = Instant::now();
     let exec_elapsed = teardown_start - exec_start;
 
-    let exit_status = if let Some(code) = output.status.code() {
+    let oom = cgroup.as_ref().map(Cgroup::was_oom_killed).unwrap_or(false);
+    let exit_status = if hit_timeout {
+        ExitStatus::Timeout
+    } else if oom {
+        ExitStatus::OutOfMemory
+    } else if let Some(code) = wait_status.code() {
         ExitStatus::Exited(code)
-    } else if let Some(signal) = output.status.signal() {
+    } else if let Some(signal) = wait_status.signal() {
         ExitStatus::Signaled { signal }
     } else {
-        // Should not happen: every Unix exit status has a code or a signal.
         ExitStatus::Signaled { signal: -1 }
     };
 
+    let accounting = cgroup
+        .as_ref()
+        .map(Cgroup::accounting)
+        .unwrap_or_else(ResourceAccounting::default);
+
     Ok(SandboxOutcome {
         exit_status,
-        stdout: Bytes::from(output.stdout),
-        stderr: Bytes::from(output.stderr),
-        accounting: ResourceAccounting::default(),
+        stdout: Bytes::from(stdout_buf),
+        stderr: Bytes::from(stderr_buf),
+        accounting,
         timings: SandboxTimings {
             setup: setup_elapsed,
             execution: exec_elapsed,
             teardown: teardown_start.elapsed(),
         },
     })
+}
+
+async fn read_to_end<R: tokio::io::AsyncRead + Unpin>(mut r: R) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let _ = r.read_to_end(&mut buf).await;
+    buf
 }

--- a/crates/brokkr-sandbox/src/host/linux.rs
+++ b/crates/brokkr-sandbox/src/host/linux.rs
@@ -172,16 +172,38 @@ pub(super) async fn run_action(
             }
             Err(_elapsed) => {
                 // SIGKILL the whole cgroup if we have one (catches
-                // grandchildren); otherwise just kill the runner.
-                if let Some(cg) = &cgroup {
-                    let _ = cg.kill_all();
-                } else {
+                // grandchildren); otherwise just kill the runner. If
+                // the cgroup kill fails (delegation hiccup, cgroup
+                // already gone), fall back to killing just the runner
+                // so we still have a chance of reaping.
+                let cgroup_killed = match &cgroup {
+                    Some(cg) => cg.kill_all().is_ok(),
+                    None => false,
+                };
+                if !cgroup_killed {
                     let _ = child.kill().await;
                 }
-                let s = child.wait().await.map_err(|e| SandboxError::Setup {
-                    step: "wait for runner after timeout",
-                    source: e,
-                })?;
+                // Bound the post-kill wait. If the kernel won't reap
+                // the runner within the same deadline budget, surface
+                // a TimedOut error rather than hang forever.
+                let s = match tokio::time::timeout(deadline, child.wait()).await {
+                    Ok(Ok(s)) => s,
+                    Ok(Err(e)) => {
+                        return Err(SandboxError::Setup {
+                            step: "wait for runner after timeout",
+                            source: e,
+                        });
+                    }
+                    Err(_) => {
+                        return Err(SandboxError::Setup {
+                            step: "wait for runner after timeout kill",
+                            source: io::Error::new(
+                                io::ErrorKind::TimedOut,
+                                "runner did not exit after timeout SIGKILL",
+                            ),
+                        });
+                    }
+                };
                 (s, true)
             }
         },

--- a/crates/brokkr-sandbox/src/host/mod.rs
+++ b/crates/brokkr-sandbox/src/host/mod.rs
@@ -10,6 +10,8 @@ use crate::error::SandboxError;
 use crate::outcome::SandboxOutcome;
 
 #[cfg(target_os = "linux")]
+mod cgroup;
+#[cfg(target_os = "linux")]
 mod ipc;
 #[cfg(target_os = "linux")]
 mod linux;
@@ -21,6 +23,7 @@ mod linux;
 #[derive(Debug, Clone)]
 pub struct Sandbox {
     runner_binary: PathBuf,
+    cgroup_root: Option<PathBuf>,
 }
 
 impl Sandbox {
@@ -30,6 +33,7 @@ impl Sandbox {
     pub fn new(runner_binary: impl Into<PathBuf>) -> Self {
         Self {
             runner_binary: runner_binary.into(),
+            cgroup_root: None,
         }
     }
 
@@ -45,9 +49,30 @@ impl Sandbox {
         }
     }
 
+    /// Use `cgroup_root` (e.g. `/sys/fs/cgroup/brokkr.slice`) as the
+    /// parent cgroup for every action. The runner pid will be moved into
+    /// a freshly-created leaf inside it before the action starts; on
+    /// exit the leaf is removed. Without this set the sandbox does no
+    /// cgroup work and [`crate::ResourceAccounting`] stays at zero.
+    ///
+    /// `cgroup_root` must be a writable cgroup-v2 directory whose
+    /// parent has the `cpu`, `memory`, and `pids` controllers enabled
+    /// in `cgroup.subtree_control`. `scripts/install-cgroup-slice.sh`
+    /// sets that up; alternatively, run the worker under a systemd
+    /// unit with `Delegate=yes`.
+    pub fn with_cgroup_root(mut self, cgroup_root: impl Into<PathBuf>) -> Self {
+        self.cgroup_root = Some(cgroup_root.into());
+        self
+    }
+
     /// Path to the runner binary that this sandbox will spawn.
     pub fn runner_binary(&self) -> &Path {
         &self.runner_binary
+    }
+
+    /// Configured cgroup root, if any.
+    pub fn cgroup_root(&self) -> Option<&Path> {
+        self.cgroup_root.as_deref()
     }
 
     /// Execute `cfg` inside the sandbox. On Linux this spawns
@@ -72,7 +97,7 @@ impl Sandbox {
 
         #[cfg(target_os = "linux")]
         {
-            linux::run_action(&self.runner_binary, cfg).await
+            linux::run_action(&self.runner_binary, self.cgroup_root.as_deref(), cfg).await
         }
         #[cfg(not(target_os = "linux"))]
         {

--- a/crates/brokkr-sandbox/tests/cgroup.rs
+++ b/crates/brokkr-sandbox/tests/cgroup.rs
@@ -1,0 +1,224 @@
+//! M6 evil-action tests: cgroups v2 + wall-clock timeout.
+//!
+//! Plan §8.1 / §5.5 maps:
+//! - **EV-04** allocate too much memory → OOM-killed → `OutOfMemory`.
+//! - **EV-05** fork bomb under `pids.max` → bomb dies, action exits
+//!   non-zero quickly.
+//! - **AC-02-ish** wall-clock timeout fires after the configured
+//!   number of seconds and reports `Timeout`. (Doesn't need a cgroup,
+//!   so this one always runs.)
+//! - **Accounting** populated for a normal action.
+//!
+//! ### Skip policy
+//!
+//! The cgroup tests need a *writable* cgroup-v2 slice with the `cpu`,
+//! `memory`, and `pids` controllers enabled in the parent's
+//! `cgroup.subtree_control`. We discover one via:
+//!
+//! 1. `BROKKR_TEST_CGROUP_ROOT` env var.
+//! 2. `/sys/fs/cgroup/brokkr.slice/` if writable (matches what
+//!    `scripts/install-cgroup-slice.sh` provisions).
+//!
+//! On hosts without either (CI runners, fresh WSL2 boxes), the cgroup
+//! tests print a `skip:` line and pass. The wall-clock timeout test
+//! does not need a cgroup and always runs.
+
+#![cfg(target_os = "linux")]
+#![allow(clippy::unwrap_used, clippy::panic, clippy::disallowed_methods)]
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use brokkr_sandbox::{ExitStatus, ResourceLimits, Sandbox, SandboxConfig};
+
+fn runner_path() -> &'static str {
+    env!("CARGO_BIN_EXE_brokkr-sandboxd")
+}
+
+/// Find a writable cgroup root usable as the action-cgroup parent, or
+/// return None so the caller can skip.
+fn writable_cgroup_root() -> Option<PathBuf> {
+    let candidates = std::env::var_os("BROKKR_TEST_CGROUP_ROOT")
+        .map(PathBuf::from)
+        .into_iter()
+        .chain(std::iter::once(PathBuf::from(
+            "/sys/fs/cgroup/brokkr.slice",
+        )));
+    candidates.into_iter().find(|cand| probe_usable(cand))
+}
+
+/// A cgroup root is "usable" when we can mkdir a unique leaf under it
+/// AND attach the current process into it. The second check matters
+/// because cgroup-v2 cross-delegation moves require write on the
+/// common ancestor — a slice we can mkdir into can still reject our
+/// `cgroup.procs` write if our source cgroup is in a different
+/// delegation tree.
+///
+/// Returns `true` only if both probes succeed; cleans up the leaf in
+/// either case.
+fn probe_usable(parent: &Path) -> bool {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let probe = parent.join(format!("brokkr-probe-{}-{}", std::process::id(), unique));
+
+    if std::fs::create_dir(&probe).is_err() {
+        return false;
+    }
+    let mover_ok =
+        std::fs::write(probe.join("cgroup.procs"), std::process::id().to_string()).is_ok();
+    // Drop the leaf. If the move succeeded, our own pid is inside —
+    // rmdir would EBUSY. Move ourselves back to the parent first.
+    if mover_ok {
+        let _ = std::fs::write(parent.join("cgroup.procs"), std::process::id().to_string());
+    }
+    let _ = std::fs::remove_dir(&probe);
+    mover_ok
+}
+
+macro_rules! skip_unless_cgroup {
+    ($root:ident) => {
+        let Some($root) = writable_cgroup_root() else {
+            eprintln!("skip: no writable cgroup root (set BROKKR_TEST_CGROUP_ROOT or run scripts/install-cgroup-slice.sh)");
+            return;
+        };
+    };
+}
+
+#[tokio::test]
+async fn wall_clock_timeout_kills_long_action() {
+    let sandbox = Sandbox::new(runner_path());
+    let cfg = SandboxConfig {
+        argv: vec!["/usr/bin/sleep".into(), "60".into()],
+        limits: ResourceLimits {
+            wall_clock_secs: Some(2),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let started = Instant::now();
+    let outcome = sandbox.run(cfg).await.unwrap();
+    let elapsed = started.elapsed();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Timeout,
+        "stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+    assert!(
+        elapsed >= Duration::from_secs(2),
+        "timeout fired before deadline: {elapsed:?}"
+    );
+    assert!(
+        elapsed < Duration::from_secs(8),
+        "timeout took too long: {elapsed:?}"
+    );
+}
+
+#[tokio::test]
+async fn fork_bomb_capped_by_pids_max() {
+    skip_unless_cgroup!(root);
+    let sandbox = Sandbox::new(runner_path()).with_cgroup_root(root);
+    // Python fork loop that exits the moment `fork()` returns EAGAIN.
+    // Children sleep so they keep counting toward the cap; the parent
+    // alone hitting the cap still produces a deterministic non-zero
+    // exit. A bash fork bomb retries forever and would just wall-clock.
+    let cfg = SandboxConfig {
+        argv: vec![
+            "/usr/bin/python3".into(),
+            "-c".into(),
+            "import os, time, sys\n\
+             try:\n\
+             \x20   while True:\n\
+             \x20       if os.fork() == 0:\n\
+             \x20           time.sleep(30)\n\
+             \x20           os._exit(0)\n\
+             except OSError:\n\
+             \x20   sys.exit(42)\n"
+                .into(),
+        ],
+        limits: ResourceLimits {
+            pids_max: Some(16),
+            wall_clock_secs: Some(15),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(42),
+        "expected exit=42 from EAGAIN handler; stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+}
+
+#[tokio::test]
+async fn memory_max_triggers_oom_status() {
+    skip_unless_cgroup!(root);
+    let sandbox = Sandbox::new(runner_path()).with_cgroup_root(root);
+    // Allocate a 256 MiB bytearray under a 64 MiB cap. The kernel
+    // OOM-killer fires as soon as the rss exceeds memory.max.
+    let cfg = SandboxConfig {
+        argv: vec![
+            "/usr/bin/python3".into(),
+            "-c".into(),
+            "bytearray(256 * 1024 * 1024)".into(),
+        ],
+        limits: ResourceLimits {
+            memory_bytes: Some(64 * 1024 * 1024),
+            wall_clock_secs: Some(15),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::OutOfMemory,
+        "expected OutOfMemory; stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+}
+
+#[tokio::test]
+async fn accounting_is_populated_for_a_normal_action() {
+    skip_unless_cgroup!(root);
+    let sandbox = Sandbox::new(runner_path()).with_cgroup_root(root);
+    // Burn ~50ms of CPU and allocate a few MiB so the accounting
+    // counters land above zero deterministically.
+    let cfg = SandboxConfig {
+        argv: vec![
+            "/usr/bin/python3".into(),
+            "-c".into(),
+            "x = bytearray(8 * 1024 * 1024)\n\
+             s = 0\n\
+             for i in range(200_000):\n\
+             \x20   s += i\n\
+             print(s)\n"
+                .into(),
+        ],
+        limits: ResourceLimits {
+            wall_clock_secs: Some(15),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(0),
+        "stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+    let acc = &outcome.accounting;
+    assert!(
+        acc.cpu_user + acc.cpu_system >= Duration::from_millis(1),
+        "cpu accounting empty: {acc:?}"
+    );
+    assert!(
+        acc.memory_peak_bytes >= 1024 * 1024,
+        "memory.peak too low: {acc:?}"
+    );
+    assert!(acc.max_pids >= 1, "pids.peak too low: {acc:?}");
+}

--- a/crates/brokkr-sandbox/tests/cgroup.rs
+++ b/crates/brokkr-sandbox/tests/cgroup.rs
@@ -27,6 +27,7 @@
 #![allow(clippy::unwrap_used, clippy::panic, clippy::disallowed_methods)]
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
 use brokkr_sandbox::{ExitStatus, ResourceLimits, Sandbox, SandboxConfig};
@@ -37,14 +38,24 @@ fn runner_path() -> &'static str {
 
 /// Find a writable cgroup root usable as the action-cgroup parent, or
 /// return None so the caller can skip.
+///
+/// Cargo runs the tests in this binary in parallel and `probe_usable`
+/// shuffles our own PID between cgroups, so multiple concurrent probes
+/// would race. Cache the result via `OnceLock` so the probe runs at
+/// most once across the test process.
 fn writable_cgroup_root() -> Option<PathBuf> {
-    let candidates = std::env::var_os("BROKKR_TEST_CGROUP_ROOT")
-        .map(PathBuf::from)
-        .into_iter()
-        .chain(std::iter::once(PathBuf::from(
-            "/sys/fs/cgroup/brokkr.slice",
-        )));
-    candidates.into_iter().find(|cand| probe_usable(cand))
+    static CACHED: OnceLock<Option<PathBuf>> = OnceLock::new();
+    CACHED
+        .get_or_init(|| {
+            let candidates = std::env::var_os("BROKKR_TEST_CGROUP_ROOT")
+                .map(PathBuf::from)
+                .into_iter()
+                .chain(std::iter::once(PathBuf::from(
+                    "/sys/fs/cgroup/brokkr.slice",
+                )));
+            candidates.into_iter().find(|cand| probe_usable(cand))
+        })
+        .clone()
 }
 
 /// A cgroup root is "usable" when we can mkdir a unique leaf under it
@@ -54,26 +65,29 @@ fn writable_cgroup_root() -> Option<PathBuf> {
 /// `cgroup.procs` write if our source cgroup is in a different
 /// delegation tree.
 ///
-/// Returns `true` only if both probes succeed; cleans up the leaf in
-/// either case.
+/// Returns `true` only if every step succeeds *and* cleanup succeeds.
+/// A failed move-back leaves our pid inside the probe leaf and rmdir
+/// would EBUSY, leaving a stray cgroup behind that would poison
+/// subsequent probes — treat that as "not usable" rather than risk a
+/// leak.
 fn probe_usable(parent: &Path) -> bool {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    let unique = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let probe = parent.join(format!("brokkr-probe-{}-{}", std::process::id(), unique));
+    let pid = std::process::id().to_string();
+    let probe = parent.join(format!("brokkr-probe-{pid}"));
 
     if std::fs::create_dir(&probe).is_err() {
         return false;
     }
-    let mover_ok =
-        std::fs::write(probe.join("cgroup.procs"), std::process::id().to_string()).is_ok();
-    // Drop the leaf. If the move succeeded, our own pid is inside —
-    // rmdir would EBUSY. Move ourselves back to the parent first.
-    if mover_ok {
-        let _ = std::fs::write(parent.join("cgroup.procs"), std::process::id().to_string());
-    }
-    let _ = std::fs::remove_dir(&probe);
-    mover_ok
+    let mover_ok = std::fs::write(probe.join("cgroup.procs"), &pid).is_ok();
+    // If the move succeeded, our own pid is inside — rmdir would EBUSY.
+    // Move ourselves back to the parent first; if that fails we cannot
+    // cleanly remove the leaf, so report the root as unusable.
+    let move_back_ok = if mover_ok {
+        std::fs::write(parent.join("cgroup.procs"), &pid).is_ok()
+    } else {
+        true
+    };
+    let remove_ok = std::fs::remove_dir(&probe).is_ok();
+    mover_ok && move_back_ok && remove_ok
 }
 
 macro_rules! skip_unless_cgroup {
@@ -106,8 +120,8 @@ async fn wall_clock_timeout_kills_long_action() {
         String::from_utf8_lossy(&outcome.stderr)
     );
     assert!(
-        elapsed >= Duration::from_secs(2),
-        "timeout fired before deadline: {elapsed:?}"
+        elapsed >= Duration::from_millis(1900),
+        "timeout fired implausibly early: {elapsed:?}"
     );
     assert!(
         elapsed < Duration::from_secs(8),

--- a/docs/journal/phase-2.md
+++ b/docs/journal/phase-2.md
@@ -243,3 +243,79 @@ debrief.
 - `c"lo"` (a C-string literal in edition 2024 / Rust 1.85) is a
   cleaner spelling than `b"lo\0"`. clippy actually fired on the
   byte-string version (`manual_c_str_literals`).
+
+## M6 — `feat/phase2-cgroups`
+
+- **Date:** 2026-04-30
+- **PR:** _(filled in after merge)_
+- **Outcome:** Per-action cgroup-v2 created under a configurable
+  slice root; the runner pid is attached before the runner makes
+  any progress, so the action and all its descendants live inside
+  bounded `memory.max` / `pids.max` / `cpu.max`. Wall-clock timeout
+  fires via `tokio::time::timeout` and uses `cgroup.kill` to
+  atomically tear down the whole tree. OOM kills are detected via
+  `memory.events:oom_kill > 0` and surfaced as
+  `ExitStatus::OutOfMemory`. Accounting (`cpu.stat`, `memory.peak`,
+  `pids.peak`, `io.stat` aggregated) is read after the action exits.
+  Four new tests; the wall-clock one runs everywhere, the cgroup
+  ones skip unless we have a writable delegated slice.
+
+### Decisions
+
+- **Builder, not constructor.** `Sandbox::with_cgroup_root(path)` is
+  optional. Without it, the sandbox is M2-M5 — no cgroup, accounting
+  stays at zero. This kept all 16 existing tests passing without
+  touching them, and lets workers that don't have a delegated slice
+  still run actions (with no resource limits).
+- **Attach happens between spawn and config write.** The runner is
+  parked on `read_to_end(fd 3)` immediately after exec because the
+  pipe stays open until the host closes its writer end. We exploit
+  that gap: spawn → attach pid → write config → close. By the time
+  the runner unblocks and forks into init/action, every PID in the
+  tree inherits the cgroup automatically. No barrier protocol needed.
+- **`cgroup.kill` over per-pid loops.** Kernel ≥ 5.14 has a single
+  atomic write that SIGKILLs every PID in the cgroup at once. We try
+  it first; on ENOENT we fall back to walking `cgroup.procs` and
+  `kill(pid, SIGKILL)`-ing each. Important for wall-clock timeout
+  on actions with grandchildren (e.g., `sh -c '... &'`).
+- **Stop using `wait_with_output`.** It consumes the `Child`, so
+  there's no handle to `kill()` on timeout. Now we `take()` stdout
+  and stderr, spawn drain tasks, and `wait()` the child directly.
+  Same observable behaviour, but interruptible.
+- **OOM > Signaled override.** When the OOM-killer fires, the kernel
+  reports the action's `WaitStatus` as `Signaled(SIGKILL)`. That's
+  technically true but useless to the caller — they want to know
+  it was OOM, not "killed by something". So after `wait`, we check
+  `memory.events:oom_kill` and overwrite the exit status if the
+  kernel says yes. Same idea for `Timeout`.
+- **Test skip via "can move ourselves into it" probe.** Tests use a
+  two-step probe: mkdir a unique leaf, then write our own pid into
+  its `cgroup.procs`. The second step catches the cgroup-v2
+  cross-delegation rule that mkdir alone can't see — a slice we can
+  mkdir under may still reject our `cgroup.procs` write if our
+  source cgroup is in a different delegation tree. CI / fresh WSL2
+  fail at the second step and skip cleanly.
+
+### What surprised me
+
+- Cgroup-v2 cross-delegation rules are stricter than I'd remembered.
+  Even with the slice chowned to our user, you can't move a process
+  into it from `/init.scope` (root-owned source) — the kernel checks
+  write permission on the *source* cgroup too, and on the common
+  ancestor. The fix in real deployments is to run the worker
+  *inside* the delegated tree (systemd unit with `Delegate=yes`, or
+  `systemd-run --user --scope`); for tests we just probe and skip.
+- A naive bash fork bomb (`f() { f & f; }; f`) under `pids.max`
+  doesn't *die* — bash retries `clone()` forever, printing
+  "Resource temporarily unavailable" until the wall-clock timeout
+  fires. Switched to a python loop that exits on first `OSError`
+  for a deterministic non-zero exit. The test still has a wall-clock
+  guard as a backstop.
+- `memory.swap.max` doesn't exist on kernels without the swap
+  controller; we ignore ENOENT on the write so a missing controller
+  doesn't block the run.
+- `tokio::process::Child::wait_with_output` consumes the child by
+  value, which makes timeout-with-kill awkward. The fix (split
+  stdout/stderr off, spawn drains, wait separately) is exactly
+  what `wait_with_output` does internally — we just had to inline
+  it to keep a `&mut Child` for `kill()`.


### PR DESCRIPTION
## Summary
- `Sandbox::with_cgroup_root(path)` opts the sandbox into per-action cgroup-v2 work. Without it, the sandbox is unchanged from M5 (16 existing tests pass untouched).
- New `host/cgroup.rs`: create `<root>/action-<uuid>/`, write `memory.max` / `memory.swap.max` / `pids.max` / `cpu.max` from `ResourceLimits`, attach the runner pid via `cgroup.procs`, read `cpu.stat` / `memory.peak` / `pids.peak` / `io.stat` after wait, check `memory.events:oom_kill` for `ExitStatus::OutOfMemory`. RAII drop + `cgroup.kill` (with per-pid SIGKILL fallback) for cleanup.
- Wall-clock timeout via `tokio::time::timeout` around `child.wait()`; on elapsed → `cgroup.kill_all` (or `child.kill()` sans cgroup) → `ExitStatus::Timeout`. Required swapping `wait_with_output` for explicit `take()` + spawn-drain so the `Child` remains mutably accessible for `kill()`.
- 4 new tests in `tests/cgroup.rs`. The wall-clock test always runs; the 3 cgroup-requiring tests skip cleanly unless `BROKKR_TEST_CGROUP_ROOT` is set or `/sys/fs/cgroup/brokkr.slice/` is writable. Skip probe checks both `mkdir` AND `cgroup.procs` write (catches cgroup-v2 cross-delegation rules that mkdir alone misses).

## Why the cgroup attach happens between spawn and config write
The runner blocks on `read_to_end(fd 3)` immediately after `execve` because the pipe stays open until the host closes its writer end. We exploit that gap: `spawn` → `attach pid` → `write config` → `close`. By the time the runner unblocks and forks, every PID inherits the cgroup automatically — no explicit barrier needed.

## How to actually exercise the cgroup paths locally
```
systemd-run --user --scope -- bash -c \
  'BROKKR_TEST_CGROUP_ROOT=/sys/fs/cgroup/user.slice/user-1000.slice/user@1000.service/app.slice cargo test -p brokkr-sandbox --test cgroup'
```
All 4 pass against a real delegated slice.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all green; cgroup tests skip on this host without delegated slice
- [x] `systemd-run --user --scope -- bash -c '... cargo test -p brokkr-sandbox --test cgroup'` — 4/4 pass for real
- [x] CI: pending push (will edit once green)

## Plan reference
`docs/phase-2-plan.md` §5.5, §9 (M6). Journal entry in `docs/journal/phase-2.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-action cgroup v2 sandboxing with configurable root, enforced limits (memory, CPU, PIDs), and host-side wall-clock timeouts that terminate timed-out actions.
  * Kernel OOMs are reported as out-of-memory exit status; resource accounting (CPU time, memory peak, I/O, PIDs) is collected and returned.
  * Improved stdout/stderr streaming to provide accurate runner output on failures/timeouts.

* **Tests**
  * New integration tests for timeout behavior, resource limits, and accounting (with environment-aware skipping).

* **Documentation**
  * Changelog and milestone docs updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->