### PR TITLE
feat(observability): add missing #[instrument] spans per issue #29

### DIFF
--- a/crates/brokkr-control/src/scheduler.rs
+++ b/crates/brokkr-control/src/scheduler.rs
@@ -47,6 +47,7 @@ impl Scheduler {
 
     /// Take ownership of the job receiver. Returns `None` after the first call;
     /// only one worker stream is supported in Phase 1.
+    #[tracing::instrument(name = "scheduler::take_receiver", skip(self))]
     pub async fn take_receiver(&self) -> Option<mpsc::UnboundedReceiver<bv1::Job>> {
         self.queue_rx.lock().await.take()
     }
@@ -149,6 +150,7 @@ impl Scheduler {
     }
 
     /// Worker-side entry: receive a job result and wake the matching waiter.
+    #[tracing::instrument(name = "scheduler::report", skip(self, result))]
     pub async fn report(&self, result: bv1::JobResult) -> Result<()> {
         let job_id = JobId::new(result.job_id.clone())
             .map_err(|e| anyhow!("invalid job_id in result: {}", e))?;

--- a/crates/brokkr-control/src/worker_service.rs
+++ b/crates/brokkr-control/src/worker_service.rs
@@ -32,6 +32,8 @@ impl WorkerService for WorkerServiceImpl {
         &self,
         _request: Request<RegisterWorkerRequest>,
     ) -> Result<Response<RegisterWorkerResponse>, Status> {
+        let span = tracing::info_span!("worker_service::register");
+        let _guard = span.enter();
         let worker_id = WorkerId::new(uuid::Uuid::new_v4().to_string())
             .map_err(|e| Status::internal(format!("invalid worker id: {e}")))?;
         Ok(Response::new(RegisterWorkerResponse {
@@ -47,6 +49,8 @@ impl WorkerService for WorkerServiceImpl {
         &self,
         request: Request<Streaming<WorkerStreamMessage>>,
     ) -> Result<Response<Self::StreamStream>, Status> {
+        let span = tracing::info_span!("worker_service::stream");
+        let _guard = span.enter();
         let mut inbound = request.into_inner();
         let scheduler = self.scheduler.clone();
         let mut job_rx = scheduler

--- a/crates/brokkr-sdk/src/client.rs
+++ b/crates/brokkr-sdk/src/client.rs
@@ -24,6 +24,7 @@ pub struct BrokkrClient {
 impl BrokkrClient {
     /// Connect to the control plane at `endpoint` (e.g.
     /// `http://127.0.0.1:7878`).
+    #[tracing::instrument(name = "client::connect", skip(endpoint))]
     pub async fn connect(endpoint: impl Into<String>) -> Result<Self> {
         let endpoint = endpoint.into();
         let channel = Endpoint::from_shared(endpoint.clone())

--- a/crates/brokkr-worker/src/worker.rs
+++ b/crates/brokkr-worker/src/worker.rs
@@ -28,6 +28,7 @@ pub struct WorkerConfig {
 
 /// Run the worker. Returns when the control plane closes the stream or an
 /// unrecoverable error occurs.
+#[tracing::instrument(name = "worker::run", skip(cfg))]
 pub async fn run_worker(cfg: WorkerConfig) -> Result<()> {
     let channel = Endpoint::from_shared(cfg.control_endpoint.clone())
         .with_context(|| format!("invalid endpoint {:?}", cfg.control_endpoint))?


### PR DESCRIPTION
Fixes jackthepunished/brokkr#29

## Summary

Adds missing  tracing spans to 6 uninstrumented public async functions in the hot path:

- `brokkr_worker::run_worker` → `worker::run`
- `WorkerServiceImpl::register` → manual `tracing::info_span!"worker_service::register"`
- `WorkerServiceImpl::stream` → manual `tracing::info_span!"worker_service::stream"`
- `Scheduler::take_receiver` → `scheduler::take_receiver`
- `Scheduler::report` → `scheduler::report`
- `BrokkrClient::connect` → `client::connect`

gRPC tonic handler methods (`register`, `stream`) use manual `info_span` per issue guidance since `#[instrument]` can't be applied to trait methods.

## Test plan
- [x] `cargo test --workspace --lib` — all lib tests pass
- [x] `cargo fmt && cargo clippy --all-targets -- -D warnings` — clean
- [ ] Integration tests (end-to-end) — known to be broken on this host due to `/bin/false` not existing; pre-existing failure unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced host compatibility checking with comprehensive Linux system requirement verification (kernel version, cgroups v2, seccomp, namespaces, memory peak support, and more).

* **Chores**
  * Added distributed tracing instrumentation to improve observability across worker, scheduler, and client components.

* **Refactor**
  * Reorganized host check module structure for better modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->