### PR TITLE
feat(phase2): M9 — wire sandbox into brokkr-worker (re-land)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   produce byte-identical stdout under `brokkr_defaults`). Same
   unprivileged-userns skip policy as the other namespace-path
   evil tests.
+- M9: `brokkr-worker` runs actions through the sandbox by default.
+  New `Runner` enum (`Plain` vs `Sandboxed(Box<SandboxRunner>)`)
+  in `brokkr-worker::runner`; `SandboxTemplate::brokkr_default()`
+  encodes the worker's defaults (minimal usrmerge rootfs, no
+  network, `DeterminismPolicy::brokkr_defaults()` for hostname /
+  TZ / env scrubbing, no resource limits). `run_command` accepts
+  `&Runner` and dispatches; signal-kill / OOM / wall-clock are
+  mapped to shell-convention exit codes (`128+sig`, `137`, `124`)
+  so the existing `ActionResult.exit_code` plumbing carries the
+  information.
+- M9: `WorkerConfig.runner` field. Default is `Runner::Plain` so
+  in-process test fixtures don't need the `brokkr-sandboxd`
+  binary; the CLI `brokkr-worker` builds a `Runner::Sandboxed`
+  unless `--no-sandbox` is passed.
+- M9: `brokkr-worker` CLI flags — `--no-sandbox` (Phase 1
+  fallback, logs a warning), `--sandbox-runner PATH`,
+  `--sandbox-cgroup-root PATH`, `--sandbox-wall-clock-secs N`,
+  `--sandbox-memory-bytes N`, `--sandbox-pids-max N`. The default
+  sandboxed mode probes the host (`host_check::run`) at startup
+  and refuses to start if the host can't run the sandbox; the
+  error message points at `--check-host` and `--no-sandbox`.
+- `brokkr-worker/tests/sandbox_e2e.rs` — four M9 tests:
+  `/bin/echo "hello world"` round-trips through the sandbox
+  runner; hostname inside is `brokkr-sandbox`; `/etc/shadow` is
+  not visible (rootfs allowlist works); the `Plain` runner is
+  still Phase-1 compatible. Resolves `brokkr-sandboxd` via
+  `current_exe()` since `CARGO_BIN_EXE_*` only sets for the
+  owning crate's tests. Same unprivileged-userns skip macro as
+  the other namespace-path tests.
 
 ## Phase 3 (in progress)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "hex",
  "prost",
  "sha2",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-stream",

--- a/crates/brokkr-control/tests/common/mod.rs
+++ b/crates/brokkr-control/tests/common/mod.rs
@@ -25,7 +25,7 @@ use brokkr_proto::reapi_v2::{
     content_addressable_storage_server::ContentAddressableStorageServer,
     execution_server::ExecutionServer,
 };
-use brokkr_worker::{run_worker, WorkerConfig};
+use brokkr_worker::{run_worker, Runner, WorkerConfig};
 use tokio::net::TcpListener;
 use tonic::transport::Server;
 
@@ -62,9 +62,14 @@ pub async fn boot_cluster() -> (String, tempfile::TempDir) {
 
     let worker_endpoint = endpoint.clone();
     tokio::spawn(async move {
+        // Phase 1 fixtures intentionally use Runner::Plain — the
+        // sandbox path is exercised separately by the brokkr-worker
+        // sandbox-mode integration tests, which require the
+        // brokkr-sandboxd binary and an unprivileged userns.
         let cfg = WorkerConfig {
             control_endpoint: worker_endpoint,
             hostname: "test-worker".to_string(),
+            runner: Runner::Plain,
         };
         let _ = run_worker(cfg).await;
     });

--- a/crates/brokkr-worker/Cargo.toml
+++ b/crates/brokkr-worker/Cargo.toml
@@ -32,3 +32,6 @@ tokio-stream.workspace = true
 tonic.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/brokkr-worker/src/lib.rs
+++ b/crates/brokkr-worker/src/lib.rs
@@ -10,4 +10,5 @@
 pub mod runner;
 pub mod worker;
 
+pub use runner::{default_rootfs, Runner, SandboxRunner, SandboxTemplate};
 pub use worker::{run_worker, WorkerConfig};

--- a/crates/brokkr-worker/src/main.rs
+++ b/crates/brokkr-worker/src/main.rs
@@ -1,10 +1,11 @@
 //! `brokkr-worker` daemon entrypoint.
 
+use std::path::PathBuf;
 use std::process::ExitCode;
 
-use anyhow::Result;
-use brokkr_sandbox::checks;
-use brokkr_worker::{run_worker, WorkerConfig};
+use anyhow::{anyhow, Result};
+use brokkr_sandbox::{checks, ResourceLimits, Sandbox};
+use brokkr_worker::{run_worker, Runner, SandboxRunner, SandboxTemplate, WorkerConfig};
 use clap::Parser;
 
 #[derive(Debug, Parser)]
@@ -19,6 +20,39 @@ struct Args {
     /// allowed). See `docs/phase-2-plan.md` §10.3.
     #[arg(long)]
     check_host: bool,
+
+    /// Disable the Phase 2 sandbox. The worker runs actions as plain
+    /// child processes — Phase 1 parity. Useful for development hosts
+    /// that lack unprivileged user namespaces or cgroup delegation.
+    /// Logs a loud warning at startup.
+    #[arg(long)]
+    no_sandbox: bool,
+
+    /// Path to the `brokkr-sandboxd` runner binary. Defaults to a
+    /// lookup adjacent to the worker binary, then `$PATH`.
+    #[arg(long)]
+    sandbox_runner: Option<PathBuf>,
+
+    /// Per-action cgroup parent. Typically
+    /// `/sys/fs/cgroup/brokkr.slice` (created by
+    /// `scripts/install-cgroup-slice.sh`) or a systemd-delegated
+    /// slice. When omitted, the sandbox runs without resource limits
+    /// or accounting.
+    #[arg(long)]
+    sandbox_cgroup_root: Option<PathBuf>,
+
+    /// Default per-action wall-clock timeout, in seconds. Per-action
+    /// `Platform` properties may override this in a later milestone.
+    #[arg(long)]
+    sandbox_wall_clock_secs: Option<u64>,
+
+    /// Default per-action memory cap, in bytes. `0` = unlimited.
+    #[arg(long)]
+    sandbox_memory_bytes: Option<u64>,
+
+    /// Default per-action `pids.max`. `0` = unlimited.
+    #[arg(long)]
+    sandbox_pids_max: Option<u64>,
 }
 
 fn main() -> ExitCode {
@@ -49,11 +83,59 @@ fn main() -> ExitCode {
 }
 
 async fn run_daemon(args: Args) -> Result<()> {
+    let runner = build_runner(&args)?;
     let cfg = WorkerConfig {
         control_endpoint: args.control,
         hostname: hostname_or("worker".to_string()),
+        runner,
     };
     run_worker(cfg).await
+}
+
+fn build_runner(args: &Args) -> Result<Runner> {
+    if args.no_sandbox {
+        tracing::warn!(
+            "starting with --no-sandbox: actions will run as plain host \
+             processes with no isolation. This is Phase 1 parity and is \
+             intended for development only."
+        );
+        return Ok(Runner::Plain);
+    }
+
+    // Probe the host before doing anything else; surface a useful
+    // error so deployers know to run `scripts/install-cgroup-slice.sh`
+    // or check `brokkr-worker --check-host`.
+    let report = checks::run();
+    if !report.is_functional() {
+        return Err(anyhow!(
+            "brokkr-worker: host is not sandbox-capable. Run \
+             `brokkr-worker --check-host` for details, or pass \
+             `--no-sandbox` to bypass the sandbox (Phase 1 fallback)."
+        ));
+    }
+
+    let sandbox = match &args.sandbox_runner {
+        Some(path) => Sandbox::new(path),
+        None => Sandbox::with_default_runner()
+            .map_err(|e| anyhow!("locating brokkr-sandboxd runner: {e}"))?,
+    };
+    let sandbox = match &args.sandbox_cgroup_root {
+        Some(root) => sandbox.with_cgroup_root(root),
+        None => sandbox,
+    };
+
+    let mut template = SandboxTemplate::brokkr_default();
+    template.limits = ResourceLimits {
+        wall_clock_secs: args.sandbox_wall_clock_secs,
+        memory_bytes: args.sandbox_memory_bytes.filter(|n| *n != 0),
+        pids_max: args.sandbox_pids_max.filter(|n| *n != 0),
+        ..Default::default()
+    };
+
+    Ok(Runner::Sandboxed(Box::new(SandboxRunner {
+        sandbox,
+        template,
+    })))
 }
 
 fn run_check_host() -> ExitCode {

--- a/crates/brokkr-worker/src/runner.rs
+++ b/crates/brokkr-worker/src/runner.rs
@@ -1,9 +1,28 @@
-//! Phase 1 action runner: spawns the command as a plain child process and
-//! captures stdout/stderr/exit. Phase 2 replaces this with the sandboxed
-//! variant in `brokkr-sandbox`.
+//! Action runner — either Phase 1 plain-process spawn or the Phase 2
+//! sandboxed variant.
+//!
+//! The worker holds a [`Runner`] per its [`crate::WorkerConfig`]:
+//!
+//! - [`Runner::Plain`] reproduces Phase 1: `tokio::process::Command`
+//!   directly against the host. No isolation. Kept for hosts that
+//!   can't run the sandbox (no unprivileged userns, no cgroup
+//!   delegation) and for in-process integration tests that pre-date
+//!   the sandbox crate.
+//! - [`Runner::Sandboxed`] wraps a [`brokkr_sandbox::Sandbox`] plus a
+//!   per-action template ([`SandboxTemplate`]) — the worker's default
+//!   rootfs allowlist, resource limits, network policy, and
+//!   determinism knobs. Each `run_command` call clones the template,
+//!   overlays the REAPI `Command`'s argv / env / working_directory,
+//!   and feeds the result through `Sandbox::run`.
+
+use std::path::PathBuf;
 
 use anyhow::{anyhow, Result};
 use brokkr_proto::reapi_v2 as rapi;
+use brokkr_sandbox::{
+    DeterminismPolicy, ExitStatus, NetworkPolicy, ResourceLimits, RootfsSpec, Sandbox,
+    SandboxConfig,
+};
 use bytes::Bytes;
 use sha2::{Digest as _, Sha256};
 use tokio::process::Command;
@@ -11,7 +30,9 @@ use tokio::process::Command;
 /// Outcome of running a `Command`.
 #[derive(Debug)]
 pub struct RunOutcome {
-    /// Process exit code (negative means killed by signal on Unix).
+    /// Process exit code (negative means killed by signal on Unix; on
+    /// the sandbox path, signal-kill is mapped to `128 + signal`,
+    /// timeout to `124`, OOM to `137`).
     pub exit_code: i32,
     /// Captured stdout.
     pub stdout: Bytes,
@@ -19,12 +40,107 @@ pub struct RunOutcome {
     pub stderr: Bytes,
 }
 
-/// Run a REAPI [`Command`](rapi::Command) as a child process.
+/// Strategy for running one action.
 ///
-/// Phase 1 ignores `command.environment_variables` overrides beyond merging
-/// them into the spawned process; no chdir, no input materialization. The
-/// happy path for `brokk run --command "echo hello"` requires nothing more.
-pub async fn run_command(command: &rapi::Command) -> Result<RunOutcome> {
+/// `Sandboxed` carries a `Box` because [`SandboxRunner`] embeds a
+/// [`SandboxTemplate`] with three `Vec`s and a `RootfsSpec` — boxing
+/// it keeps the enum compact and silences clippy's
+/// `large_enum_variant` lint.
+#[derive(Debug, Clone)]
+pub enum Runner {
+    /// Phase 1 fallback — no isolation. The action is spawned as a
+    /// child of the worker via `tokio::process::Command`.
+    Plain,
+    /// Phase 2 sandbox via `brokkr-sandbox`.
+    Sandboxed(Box<SandboxRunner>),
+}
+
+/// Bundle of a sandbox handle plus the per-action template applied to
+/// every job. The template's `argv` / `env` / `workdir` are clobbered
+/// per action; everything else is the worker-level default.
+#[derive(Debug, Clone)]
+pub struct SandboxRunner {
+    /// The sandbox handle — points at `brokkr-sandboxd` and
+    /// optionally a cgroup root.
+    pub sandbox: Sandbox,
+    /// Per-action template.
+    pub template: SandboxTemplate,
+}
+
+/// Default knobs applied to every action a worker runs through the
+/// sandbox. The REAPI `Command`'s argv / env override the
+/// corresponding fields; the rest are constant for the worker's
+/// lifetime.
+#[derive(Debug, Clone)]
+pub struct SandboxTemplate {
+    /// Rootfs layout — ro bind allowlist, tmpfs mounts, symlinks.
+    pub rootfs: RootfsSpec,
+    /// Per-action cgroup limits (memory, pids, cpu, wall-clock).
+    pub limits: ResourceLimits,
+    /// Network namespace policy.
+    pub network: NetworkPolicy,
+    /// Determinism guards (hostname, TZ, env scrubbing).
+    pub determinism: DeterminismPolicy,
+    /// Working directory inside the sandbox.
+    pub workdir: PathBuf,
+}
+
+impl SandboxTemplate {
+    /// The worker's default Phase 2 template: minimal usrmerge rootfs
+    /// (host `/usr` ro-bound, tmpfs `/etc` / `/tmp` / `/work`),
+    /// no network, `brokkr_defaults` determinism, no resource limits
+    /// (the deployer is expected to set memory/pids/timeout via CLI).
+    pub fn brokkr_default() -> Self {
+        Self {
+            rootfs: default_rootfs(),
+            limits: ResourceLimits::default(),
+            network: NetworkPolicy::None,
+            determinism: DeterminismPolicy::brokkr_defaults(),
+            workdir: PathBuf::from("/work"),
+        }
+    }
+}
+
+/// Build the worker's default rootfs: ro-bind the host's `/usr` and
+/// (if they're real directories on this host) `/lib` / `/lib64`,
+/// tmpfs-mount `/etc` / `/tmp` / `/work`, and create the standard
+/// usrmerge symlinks (`/bin` → `usr/bin`, etc.).
+pub fn default_rootfs() -> RootfsSpec {
+    let mut ro_binds = vec![(PathBuf::from("/usr"), PathBuf::from("/usr"))];
+    for p in ["/lib64", "/lib"] {
+        let path = PathBuf::from(p);
+        if path.is_dir() && !path.is_symlink() {
+            ro_binds.push((path.clone(), path));
+        }
+    }
+    RootfsSpec {
+        ro_binds,
+        tmpfs: vec![
+            (PathBuf::from("/etc"), 4 * 1024 * 1024),
+            (PathBuf::from("/tmp"), 64 * 1024 * 1024),
+            (PathBuf::from("/work"), 64 * 1024 * 1024),
+        ],
+        symlinks: vec![
+            (PathBuf::from("/bin"), PathBuf::from("usr/bin")),
+            (PathBuf::from("/sbin"), PathBuf::from("usr/sbin")),
+            (PathBuf::from("/lib"), PathBuf::from("usr/lib")),
+            (PathBuf::from("/lib64"), PathBuf::from("usr/lib64")),
+        ],
+        input_root: None,
+    }
+}
+
+/// Run `command` via the configured `runner`. Dispatch is a thin
+/// branch — both arms produce the same `RunOutcome` shape so the
+/// worker's job handling stays runner-agnostic.
+pub async fn run_command(runner: &Runner, command: &rapi::Command) -> Result<RunOutcome> {
+    match runner {
+        Runner::Plain => run_plain(command).await,
+        Runner::Sandboxed(s) => run_sandboxed(s, command).await,
+    }
+}
+
+async fn run_plain(command: &rapi::Command) -> Result<RunOutcome> {
     let mut argv = command.arguments.iter();
     let argv0 = argv
         .next()
@@ -43,6 +159,63 @@ pub async fn run_command(command: &rapi::Command) -> Result<RunOutcome> {
         exit_code,
         stdout: Bytes::from(output.stdout),
         stderr: Bytes::from(output.stderr),
+    })
+}
+
+async fn run_sandboxed(runner: &SandboxRunner, command: &rapi::Command) -> Result<RunOutcome> {
+    if command.arguments.is_empty() {
+        return Err(anyhow!("Command.arguments is empty"));
+    }
+    let env: Vec<(String, String)> = command
+        .environment_variables
+        .iter()
+        .map(|ev| (ev.name.clone(), ev.value.clone()))
+        .collect();
+
+    // REAPI's working_directory is relative to the input root. Phase 2
+    // doesn't materialise the input root yet (Phase 3 FUSE), so if the
+    // caller specified one we honour it as a sandbox-relative path
+    // under workdir; otherwise we land in the template's default
+    // workdir.
+    let workdir = if command.working_directory.is_empty() {
+        runner.template.workdir.clone()
+    } else {
+        runner.template.workdir.join(&command.working_directory)
+    };
+
+    let cfg = SandboxConfig {
+        argv: command.arguments.clone(),
+        env,
+        workdir: Some(workdir),
+        stdin: Default::default(),
+        rootfs: runner.template.rootfs.clone(),
+        limits: runner.template.limits,
+        network: runner.template.network,
+        determinism: runner.template.determinism.clone(),
+        retained_caps: Vec::new(),
+        extra_seccomp_allow: Vec::new(),
+    };
+
+    let outcome = runner
+        .sandbox
+        .run(cfg)
+        .await
+        .map_err(|e| anyhow!("sandbox: {e}"))?;
+
+    let exit_code = match outcome.exit_status {
+        ExitStatus::Exited(c) => c,
+        // Mirror common shell conventions so action callers can read
+        // the exit code meaningfully even without the structured
+        // ExitStatus (which Phase 2 doesn't propagate beyond the
+        // worker — REAPI ActionResult only carries i32).
+        ExitStatus::Signaled { signal } => 128 + signal,
+        ExitStatus::OutOfMemory => 137,
+        ExitStatus::Timeout => 124,
+    };
+    Ok(RunOutcome {
+        exit_code,
+        stdout: outcome.stdout,
+        stderr: outcome.stderr,
     })
 }
 

--- a/crates/brokkr-worker/src/worker.rs
+++ b/crates/brokkr-worker/src/worker.rs
@@ -15,7 +15,7 @@ use brokkr_proto::reapi_v2::{
 use tokio::sync::mpsc;
 use tonic::transport::{Channel, Endpoint};
 
-use crate::runner::{proto_digest, run_command, RunOutcome};
+use crate::runner::{proto_digest, run_command, RunOutcome, Runner};
 
 /// Worker daemon configuration.
 #[derive(Debug, Clone)]
@@ -24,6 +24,22 @@ pub struct WorkerConfig {
     pub control_endpoint: String,
     /// Hostname to advertise (informational).
     pub hostname: String,
+    /// How to actually execute each action. Defaults to
+    /// [`Runner::Plain`] so in-process tests don't need to build the
+    /// `brokkr-sandboxd` runner binary; the CLI binary
+    /// (`brokkr-worker`) overrides this to [`Runner::Sandboxed`]
+    /// unless `--no-sandbox` is passed.
+    pub runner: Runner,
+}
+
+impl Default for WorkerConfig {
+    fn default() -> Self {
+        Self {
+            control_endpoint: "http://127.0.0.1:7878".to_string(),
+            hostname: "worker".to_string(),
+            runner: Runner::Plain,
+        }
+    }
 }
 
 /// Run the worker. Returns when the control plane closes the stream or an
@@ -72,7 +88,7 @@ pub async fn run_worker(cfg: WorkerConfig) -> Result<()> {
         let Some(job) = assignment.job else { continue };
         let job_id = job.job_id.clone();
         let mut cas_for_job = cas.clone();
-        let report = match handle_job(&mut cas_for_job, job).await {
+        let report = match handle_job(&cfg.runner, &mut cas_for_job, job).await {
             Ok(r) => JobResult {
                 job_id: job_id.clone(),
                 result: Some(r),
@@ -101,7 +117,7 @@ pub async fn run_worker(cfg: WorkerConfig) -> Result<()> {
 
 #[tracing::instrument(
     name = "worker::run_action",
-    skip(cas, job),
+    skip(runner, cas, job),
     fields(
         job_id = %job.job_id,
         argv0 = tracing::field::Empty,
@@ -109,6 +125,7 @@ pub async fn run_worker(cfg: WorkerConfig) -> Result<()> {
     ),
 )]
 async fn handle_job(
+    runner: &Runner,
     cas: &mut ContentAddressableStorageClient<Channel>,
     job: bv1::Job,
 ) -> Result<rapi::ActionResult> {
@@ -120,7 +137,7 @@ async fn handle_job(
         exit_code,
         stdout,
         stderr,
-    } = run_command(&command).await?;
+    } = run_command(runner, &command).await?;
     tracing::Span::current().record("exit_code", exit_code);
 
     // Phase 1 stdout/stderr policy: upload to CAS and reference by digest;

--- a/crates/brokkr-worker/tests/sandbox_e2e.rs
+++ b/crates/brokkr-worker/tests/sandbox_e2e.rs
@@ -1,0 +1,156 @@
+//! Phase 2 / M9 worker-sandbox integration test.
+//!
+//! Exercises [`brokkr_worker::runner::Runner::Sandboxed`] end-to-end:
+//! a fake REAPI `Command` is fed through the worker's runner
+//! abstraction, which spawns `brokkr-sandboxd`, sets up namespaces,
+//! and runs the action. We assert exit code, stdout, and that the
+//! sandbox isolation actually fired (hostname inside is the
+//! configured value, not the host's).
+//!
+//! ### Skip policy
+//!
+//! Same as the M3+ evil-action tests: hosts without unprivileged
+//! user namespaces (or with AppArmor's userns restriction enabled)
+//! skip cleanly. The Phase 1 in-process integration tests don't
+//! depend on this — they use `Runner::Plain`.
+
+#![cfg(target_os = "linux")]
+#![allow(clippy::unwrap_used, clippy::panic, clippy::disallowed_methods)]
+
+use std::path::PathBuf;
+
+use brokkr_proto::reapi_v2 as rapi;
+use brokkr_sandbox::Sandbox;
+use brokkr_worker::runner::{run_command, RunOutcome};
+use brokkr_worker::{Runner, SandboxRunner, SandboxTemplate};
+
+/// Locate the `brokkr-sandboxd` binary alongside the test binary.
+/// `CARGO_BIN_EXE_brokkr-sandboxd` is only set for tests in the
+/// crate that owns the `[[bin]]` target, so we resolve it via
+/// `current_exe`: integration tests live in `target/<profile>/deps/`,
+/// and the runner binary is its sibling at `target/<profile>/`.
+fn runner_binary() -> PathBuf {
+    let exe = std::env::current_exe().unwrap();
+    let target_profile = exe.parent().unwrap().parent().unwrap();
+    let runner = target_profile.join("brokkr-sandboxd");
+    assert!(
+        runner.is_file(),
+        "brokkr-sandboxd not built at {runner:?} — \
+         run `cargo build -p brokkr-sandbox --bin brokkr-sandboxd` first"
+    );
+    runner
+}
+
+fn unsupported_reason() -> Option<String> {
+    if let Ok(s) = std::fs::read_to_string("/proc/sys/user/max_user_namespaces") {
+        if s.trim().parse::<u64>().unwrap_or(0) == 0 {
+            return Some("user.max_user_namespaces = 0".into());
+        }
+    } else {
+        return Some("/proc/sys/user/max_user_namespaces missing".into());
+    }
+    if let Ok(s) = std::fs::read_to_string("/proc/sys/kernel/unprivileged_userns_clone") {
+        if s.trim() != "1" {
+            return Some(format!("unprivileged_userns_clone = {}", s.trim()));
+        }
+    }
+    if let Ok(s) = std::fs::read_to_string("/proc/sys/kernel/apparmor_restrict_unprivileged_userns")
+    {
+        if s.trim() == "1" {
+            return Some("apparmor_restrict_unprivileged_userns = 1".into());
+        }
+    }
+    None
+}
+
+macro_rules! skip_if_unsupported {
+    () => {
+        if let Some(reason) = unsupported_reason() {
+            eprintln!("skip: {reason}");
+            return;
+        }
+    };
+}
+
+fn sandboxed_runner() -> Runner {
+    let sandbox = Sandbox::new(runner_binary());
+    Runner::Sandboxed(Box::new(SandboxRunner {
+        sandbox,
+        template: SandboxTemplate::brokkr_default(),
+    }))
+}
+
+#[tokio::test]
+async fn echo_hello_world_runs_inside_sandbox() {
+    skip_if_unsupported!();
+    let runner = sandboxed_runner();
+    let command = rapi::Command {
+        arguments: vec!["/bin/echo".into(), "hello world".into()],
+        ..Default::default()
+    };
+    let RunOutcome {
+        exit_code,
+        stdout,
+        stderr,
+    } = run_command(&runner, &command).await.unwrap();
+    assert_eq!(exit_code, 0, "stderr={}", String::from_utf8_lossy(&stderr));
+    assert_eq!(stdout.as_ref(), b"hello world\n");
+}
+
+#[tokio::test]
+async fn hostname_inside_sandbox_is_brokkr_sandbox() {
+    // Confirms the worker's brokkr_default template propagates
+    // DeterminismPolicy::brokkr_defaults() into the runner, which
+    // calls sethostname inside the new UTS namespace.
+    skip_if_unsupported!();
+    let runner = sandboxed_runner();
+    let command = rapi::Command {
+        arguments: vec!["/bin/hostname".into()],
+        ..Default::default()
+    };
+    let outcome = run_command(&runner, &command).await.unwrap();
+    assert_eq!(
+        outcome.exit_code,
+        0,
+        "stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&outcome.stdout).trim(),
+        "brokkr-sandbox",
+    );
+}
+
+#[tokio::test]
+async fn host_etc_shadow_is_not_visible_inside_sandbox() {
+    // Smoke: the worker's default rootfs really does isolate the
+    // host filesystem. If `/etc/shadow` were leaking, `cat` would
+    // succeed and print the host's password hashes — the worker is
+    // misconfigured.
+    skip_if_unsupported!();
+    let runner = sandboxed_runner();
+    let command = rapi::Command {
+        arguments: vec!["/bin/cat".into(), "/etc/shadow".into()],
+        ..Default::default()
+    };
+    let outcome = run_command(&runner, &command).await.unwrap();
+    assert_ne!(
+        outcome.exit_code, 0,
+        "the sandbox let /etc/shadow through — bind allowlist is too wide"
+    );
+}
+
+#[tokio::test]
+async fn plain_runner_remains_phase1_compatible() {
+    // Phase 1 fallback path is unaffected: same RunOutcome shape, no
+    // sandbox dependency. Useful for in-process integration tests
+    // (boot_cluster fixture) and for hosts where the sandbox can't
+    // run.
+    let command = rapi::Command {
+        arguments: vec!["/bin/echo".into(), "phase1".into()],
+        ..Default::default()
+    };
+    let outcome = run_command(&Runner::Plain, &command).await.unwrap();
+    assert_eq!(outcome.exit_code, 0);
+    assert_eq!(outcome.stdout.as_ref(), b"phase1\n");
+}

--- a/docs/journal/phase-2.md
+++ b/docs/journal/phase-2.md
@@ -468,3 +468,84 @@ debrief.
   hostname change, no env injection. The worker has to explicitly
   pick `brokkr_defaults()` to get the locked-down behaviour. Means
   every existing test still passes without touching its config.
+
+## M9 — `feat/phase2-worker-integration-and-defaults`
+
+- **Date:** 2026-05-14
+- **PR:** _(filled in after merge)_
+- **Outcome:** `brokkr-worker` runs actions through `brokkr-sandbox`
+  by default. A new `Runner` enum (`Plain` vs
+  `Sandboxed(Box<SandboxRunner>)`) replaces the bare `run_command`
+  function; the CLI binary builds a `Sandboxed` runner unless
+  `--no-sandbox` is passed. `WorkerConfig.runner` defaults to
+  `Runner::Plain` so the existing Phase 1 in-process test fixtures
+  keep working without rebuilding the runner binary. Four new e2e
+  tests in `brokkr-worker/tests/sandbox_e2e.rs` exercise the
+  sandbox path; the existing Phase 1 control-plane tests stay
+  green on the Plain runner. Phase 2 definition-of-done assertions
+  hold: every evil-action test passes, AC-01-ish (echo + hostname
+  + /etc/shadow blocked) passes through the worker's runner
+  abstraction, AC-04 (byte-identical repeatability) is covered in
+  M8.
+
+### Decisions
+
+- **`WorkerConfig.runner` default is `Plain`.** The alternative
+  ("default to Sandboxed and force every test to pass a runner
+  binary path") would have broken `brokkr-control/tests/common.rs`
+  and `brokkr-control/tests/phase1_dod.rs` without buying
+  anything: those tests already exercise the worker → control
+  plane → CAS plumbing with the Plain runner, and the sandbox
+  path has its own dedicated e2e tests. The CLI binary, which
+  *is* the production entry point, defaults to Sandboxed.
+- **Mapping `ExitStatus` → `i32` follows shell convention.**
+  `Signaled { signal }` → `128 + signal`, `OutOfMemory` → `137`
+  (SIGKILL convention), `Timeout` → `124` (GNU timeout's exit
+  code). REAPI's `ActionResult.exit_code` is a single `int32`, so
+  we have to flatten somewhere — using the conventions GNU
+  coreutils / shells use means downstream tooling reads it the
+  way users already expect.
+- **`Runner` enum boxes the Sandboxed variant.** clippy's
+  `large_enum_variant` lint fired because `SandboxRunner` embeds
+  a `RootfsSpec` and three `Vec`s — boxing it keeps the enum
+  16 bytes on 64-bit and silences the lint. The cost is one
+  allocation per worker startup; negligible.
+- **CLI surface kept minimal.** `--no-sandbox`,
+  `--sandbox-runner`, `--sandbox-cgroup-root`,
+  `--sandbox-wall-clock-secs`, `--sandbox-memory-bytes`,
+  `--sandbox-pids-max`. Per-action `Platform`-property overrides
+  are deferred to a later milestone (they're a Phase 4 concern
+  per the plan: REAPI clients negotiating constraints).
+- **Host probe runs at worker startup.** A sandboxed worker that
+  starts but immediately fails every job is worse than a worker
+  that refuses to register. `host_check::run()` runs before we
+  build the `Runner`; on failure we print a useful error
+  pointing at `--check-host` and `--no-sandbox`.
+
+### What surprised me
+
+- **`CARGO_BIN_EXE_<name>` is per-crate, not workspace-wide.**
+  The integration tests in `brokkr-worker/tests/` cannot find
+  `brokkr-sandboxd` via the env var the way
+  `brokkr-sandbox/tests/` can. Workaround: resolve via
+  `std::env::current_exe().parent().parent().join(...)` — cargo
+  reliably places test binaries in `target/<profile>/deps/` and
+  the runner binary as a sibling at `target/<profile>/`.
+  Documented at the test helper since it's the kind of brittle
+  workaround that earns a comment.
+- **The Phase 1 e2e tests broke on the `Runner` field with a
+  clear `missing field "runner"` error.** Adding the field
+  without a default would have been a compile-time tax on every
+  caller. Putting `Default::default()` on `WorkerConfig`
+  (defaulting `runner` to `Plain`) feels right *and* matches
+  the test fixture's actual need; the CLI binary doesn't go
+  through `Default` so it isn't tempted to silently fall back
+  to Plain.
+- **Mapping `ExitStatus::Timeout` to 124 vs `Signaled(9)` to
+  137.** GNU timeout's manpage is the de-facto spec here; the
+  difference makes "the action took too long" vs "the action
+  was OOM-killed" distinguishable from an exit code alone, even
+  though the underlying `WaitStatus` is the same `SIGKILL`.
+  Phase 4's auxiliary metadata will carry the structured
+  `ExitStatus`; until then, encoding the failure mode in the
+  exit code is the cheapest signal.


### PR DESCRIPTION
## Motivation

Phase 2 M9 (worker-side integration of the sandbox) was previously merged into PR #50 but its base branch (`feat/phase2-determinism`) had already been merged into `main` via PR #49, so the M9 changes never landed on `main`. This PR re-lands the M9 commit cherry-picked onto current `main`, with the trivial conflict resolved (`brokkr_sandbox::host_check` → `brokkr_sandbox::checks`, renamed by the `refactor: split host-check into per-check modules` change that landed after M9 was originally written).

## What changed

Cherry-pick of `2f8c74a` "feat(phase2): M9 — wire sandbox into brokkr-worker" — the original M9 work, unchanged except for the rename above. From the original commit message:

- `Runner` enum (`Plain` for Phase 1 parity, `Sandboxed(Box<SandboxRunner>)` for the new path)
- `SandboxTemplate::brokkr_default()` encodes the worker's per-action template
- `brokkr-worker` CLI defaults to the sandbox; `--no-sandbox` opts out and logs a warning
- `--sandbox-runner`, `--sandbox-cgroup-root`, `--sandbox-wall-clock-secs`, `--sandbox-memory-bytes`, `--sandbox-pids-max` flags expose the rest of `SandboxConfig`
- Host compatibility is probed at startup via `checks::run()`; if the sandbox cannot run, the worker refuses to start with a message pointing at `--check-host` and `--no-sandbox`
- `WorkerConfig.runner` defaults to `Runner::Plain` so the existing in-process integration test fixture keeps working without rebuilding `brokkr-sandboxd`
- `ExitStatus` mapped to `i32` using shell convention so existing REAPI `ActionResult.exit_code` plumbing carries the information (`128 + signal`, `137` OOM, `124` timeout)
- Four new e2e tests in `brokkr-worker/tests/sandbox_e2e.rs`

## How it was tested

- `cargo check --workspace` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- `cargo test --workspace --exclude brokkr-control` green on macOS aarch64 (the `brokkr-control` failure is a pre-existing macOS-only issue: the Phase 1 e2e test hardcodes `/bin/false` which Apple Silicon doesn't ship; CI runs on Linux and is unaffected)

## Related

- Plan section: `docs/phase-2-plan.md` §6 ("Wiring into brokkr-worker")
- Originally: PR #50 (closed/orphaned)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `brokkr-worker` now executes actions through sandbox isolation by default
  * Added CLI flags to control sandbox behavior, resource limits, and configuration
  * Startup host capability checks ensure sandbox support before worker initialization

* **Tests**
  * Added comprehensive end-to-end sandbox tests covering isolation and execution behavior

* **Documentation**
  * Updated changelog and project journal with Phase 2 milestone M9 details

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jackthepunished/brokkr/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->