### PR TITLE
fix(cas): verify digest at service boundary in BatchUpdateBlobs (closes #70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ExecutionError::Timeout(Duration)`, which the `Execution` service
   surfaces to clients as gRPC `DEADLINE_EXCEEDED` (code 4) so they
   can retry without parsing error strings (issue #63).
+- `brokkr-control` CAS service now verifies each `BatchUpdateBlobs`
+  entry's declared digest against its payload *at the service
+  boundary* and rejects mismatches with per-entry
+  `INVALID_ARGUMENT`. The backend has always re-verified before
+  storing (so no data corruption was ever possible) — the
+  service-layer check just avoids a `spawn_blocking` redb txn for
+  known-bad entries and gives the client an earlier, cheaper
+  rejection (issue #70).
 
 ### Changed
 - `Scheduler::execute` now returns `Result<ExecutionOutcome,

--- a/crates/brokkr-control/src/services/cas.rs
+++ b/crates/brokkr-control/src/services/cas.rs
@@ -56,41 +56,74 @@ impl<C: Cas> CasSvc for CasService<C> {
         let span = tracing::info_span!("cas::batch_update_blobs");
         let req = request.into_inner();
         let request_count = req.requests.len();
+
+        // Verify each entry's declared digest against its bytes *before*
+        // we hand the batch to the backend. The backend re-verifies (issue
+        // #70 defence-in-depth), but rejecting at the service boundary
+        // avoids a spawn_blocking redb txn for known-bad entries and gives
+        // the client per-entry feedback in the REAPI-required shape.
+        let mut responses: Vec<rapi::batch_update_blobs_response::Response> =
+            Vec::with_capacity(request_count);
         let mut blobs: Vec<(super::Digest, Bytes)> = Vec::with_capacity(request_count);
+        let mut accepted_indices: Vec<usize> = Vec::with_capacity(request_count);
         for r in req.requests {
             let d = r
                 .digest
                 .as_ref()
                 .ok_or_else(|| Status::invalid_argument("missing digest"))?;
             let digest = proto_to_digest(d)?;
-            blobs.push((digest, Bytes::from(r.data)));
+            let data = Bytes::from(r.data);
+            match digest.verify(data.as_ref()) {
+                Ok(()) => {
+                    accepted_indices.push(responses.len());
+                    responses.push(rapi::batch_update_blobs_response::Response {
+                        digest: Some(digest_to_proto(&digest)),
+                        // Placeholder; replaced after backend write succeeds.
+                        status: None,
+                    });
+                    blobs.push((digest, data));
+                }
+                Err(e) => {
+                    responses.push(rapi::batch_update_blobs_response::Response {
+                        digest: Some(digest_to_proto(&digest)),
+                        status: Some(brokkr_proto::rpc::Status {
+                            // INVALID_ARGUMENT
+                            code: 3,
+                            message: format!("digest verification failed: {e}"),
+                            details: vec![],
+                        }),
+                    });
+                }
+            }
         }
+
         let results = self
             .backend
             .batch_update_blobs(blobs)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
         let _enter = span.enter();
-        tracing::info!(request_count);
-        let responses = results
-            .into_iter()
-            .map(|u| rapi::batch_update_blobs_response::Response {
-                digest: Some(digest_to_proto(&u.digest)),
-                status: Some(match u.status {
-                    Ok(()) => brokkr_proto::rpc::Status {
-                        code: 0,
-                        message: String::new(),
-                        details: vec![],
-                    },
-                    Err(msg) => brokkr_proto::rpc::Status {
-                        // INVALID_ARGUMENT
-                        code: 3,
-                        message: msg,
-                        details: vec![],
-                    },
-                }),
-            })
-            .collect();
+        tracing::info!(
+            request_count,
+            accepted = accepted_indices.len(),
+            rejected = request_count - accepted_indices.len(),
+        );
+        for (idx, u) in accepted_indices.into_iter().zip(results) {
+            responses[idx].status = Some(match u.status {
+                Ok(()) => brokkr_proto::rpc::Status {
+                    code: 0,
+                    message: String::new(),
+                    details: vec![],
+                },
+                Err(msg) => brokkr_proto::rpc::Status {
+                    // INVALID_ARGUMENT — backend re-verification failed
+                    // (size limit, partial write, etc.).
+                    code: 3,
+                    message: msg,
+                    details: vec![],
+                },
+            });
+        }
         Ok(Response::new(rapi::BatchUpdateBlobsResponse { responses }))
     }
 

--- a/crates/brokkr-control/tests/grpc_smoke.rs
+++ b/crates/brokkr-control/tests/grpc_smoke.rs
@@ -128,6 +128,101 @@ async fn cas_roundtrip_and_find_missing() {
 }
 
 #[tokio::test]
+async fn batch_update_rejects_bytes_that_do_not_match_declared_digest() {
+    // Issue #70 — the gRPC CAS service must reject entries whose payload
+    // does not hash to the declared digest. Per REAPI the rejection is
+    // per-entry (status = INVALID_ARGUMENT) inside the success response,
+    // not a top-level Status error.
+    let (addr, _dir) = boot_server().await;
+    let mut cas = ContentAddressableStorageClient::new(client(&addr).await);
+
+    let good_payload = b"truthful blob";
+    let good_d = Digest::of(good_payload);
+    let good_proto = rapi::Digest {
+        hash: good_d.hash().to_string(),
+        size_bytes: good_d.size_bytes(),
+    };
+
+    // A digest that claims to be of `good_payload` but the body is
+    // actually different bytes — classic hash-collision-attack shape,
+    // useful for any client that builds digests incorrectly.
+    let lying_payload = b"actually different bytes";
+    let lying_d = rapi::Digest {
+        hash: good_d.hash().to_string(),
+        size_bytes: good_d.size_bytes(),
+    };
+
+    let upd = cas
+        .batch_update_blobs(rapi::BatchUpdateBlobsRequest {
+            instance_name: String::new(),
+            requests: vec![
+                rapi::batch_update_blobs_request::Request {
+                    digest: Some(good_proto.clone()),
+                    data: good_payload.to_vec(),
+                    compressor: 0,
+                },
+                rapi::batch_update_blobs_request::Request {
+                    digest: Some(lying_d.clone()),
+                    data: lying_payload.to_vec(),
+                    compressor: 0,
+                },
+            ],
+            digest_function: 0,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+
+    assert_eq!(upd.responses.len(), 2);
+    assert_eq!(
+        upd.responses[0].status.as_ref().unwrap().code,
+        0,
+        "honest entry must be accepted"
+    );
+    assert_eq!(
+        upd.responses[1].status.as_ref().unwrap().code,
+        3,
+        "mismatched entry must be rejected with INVALID_ARGUMENT (code 3); got status {:?}",
+        upd.responses[1].status,
+    );
+
+    // The lying entry must not have been persisted under either the
+    // declared *or* the actual digest.
+    let actual_d_of_lie = Digest::of(lying_payload);
+    let actual_d_proto = rapi::Digest {
+        hash: actual_d_of_lie.hash().to_string(),
+        size_bytes: actual_d_of_lie.size_bytes(),
+    };
+    let missing = cas
+        .find_missing_blobs(rapi::FindMissingBlobsRequest {
+            instance_name: String::new(),
+            blob_digests: vec![actual_d_proto.clone()],
+            digest_function: 0,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(
+        missing.missing_blob_digests,
+        vec![actual_d_proto],
+        "rejected payload must not be silently stored under its real hash"
+    );
+
+    // The honest entry must be readable.
+    let read = cas
+        .batch_read_blobs(rapi::BatchReadBlobsRequest {
+            instance_name: String::new(),
+            digests: vec![good_proto],
+            acceptable_compressors: vec![],
+            digest_function: 0,
+        })
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(read.responses[0].data, good_payload);
+}
+
+#[tokio::test]
 async fn action_cache_miss_then_hit() {
     let (addr, _dir) = boot_server().await;
     let mut ac = ActionCacheClient::new(client(&addr).await);


### PR DESCRIPTION
## Motivation

Closes #70 (H6).

The CAS backends (`InMemoryCas`, `RedbCas`) have always verified each blob's hash + size before persisting it (see `in_memory.rs:63`, `redb_backend.rs:71`), so silent data corruption was never possible. But the gRPC service layer in `brokkr-control/src/services/cas.rs::batch_update_blobs` forwarded every entry — including blatantly mismatched ones — to the backend, which paid for a `spawn_blocking` redb txn just to discover the mismatch and reject it.

## What changed

- Verify each entry's declared digest against its bytes at the service boundary first. Honest entries take the unchanged backend path; lying entries get rejected immediately with per-entry `INVALID_ARGUMENT` per REAPI.
- The backend's re-verification stays in place as defence-in-depth.
- Tracing log now includes `accepted` / `rejected` counts.

## How it was tested

- New regression test `batch_update_rejects_bytes_that_do_not_match_declared_digest` in `crates/brokkr-control/tests/grpc_smoke.rs`: sends a mixed batch (one honest entry, one with payload that does not match its declared digest), asserts:
  - honest entry returns code 0
  - mismatched entry returns code 3 (INVALID_ARGUMENT)
  - lying payload is **not** silently stored under its real hash (verified via `FindMissingBlobs`)
- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p brokkr-control --test grpc_smoke` 4/4 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CAS service now validates blob digests at the service boundary, rejecting entries with mismatched digests early with `INVALID_ARGUMENT` status before backend processing.

* **Tests**
  * Added test verifying per-entry digest mismatch rejection in blob batch update operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jackthepunished/brokkr/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->