### PR TITLE
fix(sandbox): seccomp clippy needless_return + aarch64 SYS_fadvise64 build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `brokkr-sandbox::runner::seccomp` compiled with a stray `return`
+  inside a single-arm `cfg` block which a newer clippy flagged as
+  `needless_return`; replaced with bare expressions so all four
+  arch arms keep the same shape.
+- `brokkr-sandbox::runner::seccomp::syscall_nr` referenced
+  `libc::SYS_fadvise64`, which `libc` does not expose on aarch64
+  Linux (the kernel calls the syscall `arm64_fadvise64_64`
+  internally and `libc` has no constant for it). The lookup is
+  now gated to `x86_64` / `riscv64`; on aarch64 the `fadvise64`
+  allowlist entry is silently dropped, which is the same fall-back
+  `syscall_nr` already does for arch-absent entries. Restores
+  `cargo test` on the aarch64-unknown-linux-gnu CI matrix entry.
+
 ### Added
 - Phase 0 bootstrap: Cargo workspace, 9 crates, toolchain pin to Rust 1.85,
   rustfmt/clippy/deny configuration, root README, CONTRIBUTING, LICENSE

--- a/crates/brokkr-sandbox/src/runner/seccomp.rs
+++ b/crates/brokkr-sandbox/src/runner/seccomp.rs
@@ -212,6 +212,13 @@ fn syscall_nr(name: &str) -> Option<i64> {
         "readlinkat" => Some(libc::SYS_readlinkat),
         "faccessat" => Some(libc::SYS_faccessat),
         "faccessat2" => Some(libc::SYS_faccessat2),
+        // `SYS_fadvise64` is exposed on x86_64 / riscv64 but not on
+        // aarch64 in `libc` (the aarch64 ABI calls the syscall
+        // `arm64_fadvise64_64` internally; the `libc` crate hasn't added
+        // a constant for it). Skip silently on arches that don't expose
+        // a usable constant — `resolve_or_skip` treats `None` from this
+        // helper as "syscall absent on this arch".
+        #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
         "fadvise64" => Some(libc::SYS_fadvise64),
         "fdatasync" => Some(libc::SYS_fdatasync),
         "fsync" => Some(libc::SYS_fsync),
@@ -372,19 +379,16 @@ fn syscall_nr(name: &str) -> Option<i64> {
 fn host_target_arch() -> io::Result<TargetArch> {
     #[cfg(target_arch = "x86_64")]
     {
-        return Ok(TargetArch::x86_64);
+        Ok(TargetArch::x86_64)
     }
-
     #[cfg(target_arch = "aarch64")]
     {
-        return Ok(TargetArch::aarch64);
+        Ok(TargetArch::aarch64)
     }
-
     #[cfg(target_arch = "riscv64")]
     {
-        return Ok(TargetArch::riscv64);
+        Ok(TargetArch::riscv64)
     }
-
     #[cfg(not(any(
         target_arch = "x86_64",
         target_arch = "aarch64",


### PR DESCRIPTION
## Motivation

CI on `main` is currently red on:

- **clippy** (`needless_return` in `seccomp::host_target_arch`) on every target
- **cargo test (aarch64-unknown-linux-gnu)** because `libc::SYS_fadvise64` doesn't exist on aarch64 Linux in current `libc`

These block every PR landing on `main`. Both regressions slipped in with the M7 seccomp work and weren't visible on `cargo test` on x86_64 Linux or on macOS aarch64 (no Linux toolchain).

## What changed

`crates/brokkr-sandbox/src/runner/seccomp.rs`:

1. `host_target_arch()` — drop `return` from the three `cfg`-gated arms. Only one arm compiles per build, so trailing-expression form is correct and clippy-clean. The final `cfg(not(any(...)))` arm still returns `Err(...)` and keeps the same shape.

2. `syscall_nr()` — gate the `"fadvise64" => Some(libc::SYS_fadvise64)` arm to `target_arch = "x86_64"` / `riscv64`. The aarch64 kernel ABI calls the syscall `arm64_fadvise64_64` and `libc` doesn't currently expose a constant for it. On aarch64 the `fadvise64` entry in the default allowlist now falls through to the existing `None → drop` path in `syscall_nr` — same handling `mmap2` and `fcntl64` (which are 32-bit-only ABIs) already get.

## How it was tested

- `cargo fmt --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean on macOS aarch64
- Pushed for CI to verify on Linux x86_64 + aarch64; the `cargo test (aarch64-unknown-linux-gnu)` step that was failing on every PR should now pass.

## Notes

- This is the prerequisite for landing PR #74 (M9 reland) and PR #75 (Phase 3 reland); both bring the existing M7 code along and inherit the CI break until this lands.
- PR #75 also needs two `cargo doc` link fixes (`Topology::from_proto_nodes`, `CasError::Unsupported`) which I'll push directly to that branch separately.