### PR TITLE
fix(control): log terminal states in worker-stream inbound pump (closes #64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   allowlist entry is silently dropped, which is the same fall-back
   `syscall_nr` already does for arch-absent entries. Restores
   `cargo test` on the aarch64-unknown-linux-gnu CI matrix entry.
+- `brokkr-control::worker_service::stream` inbound pump no longer
+  exits silently when the worker stream returns `Ok(None)` (clean
+  close), `Err` (transport / decode failure), or a message with no
+  payload. Each terminal state now logs at the appropriate level
+  (`info` / `error` / `warn`) so an operator can tell why the pump
+  stopped (issue #64).
 
 ### Added
 - Phase 0 bootstrap: Cargo workspace, 9 crates, toolchain pin to Rust 1.85,

--- a/crates/brokkr-control/src/worker_service.rs
+++ b/crates/brokkr-control/src/worker_service.rs
@@ -61,19 +61,50 @@ impl WorkerService for WorkerServiceImpl {
         let (out_tx, out_rx) = mpsc::channel(4);
 
         // Inbound pump: read Hello (ignored beyond presence) and JobResults.
+        // Issue #64: previously this loop pattern-matched `Ok(Some(msg))`
+        // and silently exited on `Ok(None)` (clean stream end) and on `Err`
+        // (transport error, decode failure, peer reset). The worker then
+        // appeared to function while its stream was broken. We now log
+        // each terminal state at the appropriate level so an operator
+        // monitoring the control plane can tell why the loop quit.
         let scheduler_in = scheduler.clone();
         tokio::spawn(async move {
-            while let Ok(Some(msg)) = inbound.message().await {
-                match msg.payload {
-                    Some(bv1::worker_stream_message::Payload::Hello(_)) => {
-                        tracing::debug!("worker stream: hello received");
-                    }
-                    Some(bv1::worker_stream_message::Payload::Result(result)) => {
-                        if let Err(e) = scheduler_in.report(result).await {
-                            tracing::error!(error = %e, "invalid job_id in worker result");
+            loop {
+                match inbound.message().await {
+                    Ok(Some(msg)) => match msg.payload {
+                        Some(bv1::worker_stream_message::Payload::Hello(_)) => {
+                            tracing::debug!("worker stream: hello received");
                         }
+                        Some(bv1::worker_stream_message::Payload::Result(result)) => {
+                            if let Err(e) = scheduler_in.report(result).await {
+                                tracing::error!(
+                                    error = %e,
+                                    "invalid job_id in worker result"
+                                );
+                            }
+                        }
+                        None => {
+                            tracing::warn!(
+                                "worker stream: received WorkerStreamMessage with no payload"
+                            );
+                        }
+                    },
+                    Ok(None) => {
+                        tracing::info!(
+                            "worker stream: closed cleanly by the worker — pump exiting"
+                        );
+                        break;
                     }
-                    None => {}
+                    Err(status) => {
+                        tracing::error!(
+                            code = ?status.code(),
+                            message = status.message(),
+                            "worker stream: transport error — pump exiting; \
+                             pending jobs for this worker will time out via the \
+                             scheduler timeout"
+                        );
+                        break;
+                    }
                 }
             }
         });


### PR DESCRIPTION
## Motivation

Closes #64 (C6, Critical).

The inbound pump in `worker_service::stream` (`brokkr-control/src/worker_service.rs:66`) used:

\`\`\`rust
while let Ok(Some(msg)) = inbound.message().await {
\`\`\`

…which exits silently on both `Ok(None)` (clean stream end) and `Err` (transport error, decode failure, peer reset). The control plane appeared to function while its only worker's stream was broken — an operator looking at logs would see absolutely nothing.

## What changed

Switch to an explicit `loop { match }`:

- `Ok(Some(msg))`: dispatch as before. **Empty payload** now logs at `warn` instead of being silently dropped.
- `Ok(None)` (clean close): logs at `info` and breaks.
- `Err(status)` (transport failure): logs at `error` with the gRPC `Code` and message, breaks. This is the path that was previously invisible.

Pure observability change — no behaviour difference for the happy path. Pending jobs whose worker just disconnected are now bounded by the C5 scheduler timeout (PR #77 / issue #63), so a broken stream eventually surfaces to the client as `DEADLINE_EXCEEDED` instead of hanging forever.

## How it was tested

- `cargo fmt --check` clean
- `cargo clippy -p brokkr-control --all-targets -- -D warnings` clean
- No new test: the change is a logging-only fix on an error path that's hard to drive synthetically without re-architecting the stream fixture. Existing `tests/end_to_end.rs` and `tests/grpc_smoke.rs` continue to exercise the happy path.

## Notes

- Stacks logically with PR #77 (C5 scheduler timeout): #77 ensures broken streams surface to clients with the right gRPC status code; this PR ensures the control-plane operator can see *why*.
- Reconnection logic is intentionally out of scope here (the issue mentions "Consider reconnection logic" as a follow-up). Reconnection belongs on the worker side and is part of the Phase 4 scheduler / heartbeat work.