### PR TITLE
feat(phase3): M6b — FUSE lazy input materialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -498,3 +498,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pre-FUSE foundation: workers can use it today on Phase 3
   clusters; M6b will replace it with a FUSE filesystem so trees
   bigger than RAM mount in ~ms without copying every byte.
+- M6b sub-plan written into `docs/phase-3-plan.md` §5.5.1 and
+  `docs/journal/phase-3.md`. Locks in crate placement
+  (`brokkr-worker/src/fuse.rs`), the tokio↔fuser bridge
+  (dedicated thread + `Handle::block_on` with a per-mount
+  `Semaphore`), the RAII `InputMount` lifecycle, the
+  `fuse_device` host probe surfaced via `worker --check-host`,
+  and the M6b definition-of-done.
+- M6b: `brokkr-worker::fuse` — FUSE-backed lazy input
+  materialisation, Linux-only. `fuse::inode::InodeTable`
+  builds a path-resolvable inode map from a REAPI `Directory`
+  Merkle DAG (one CAS read per directory proto, zero file
+  fetches). `fuse::mount::mount(cas, InputMountSpec)` spawns
+  a `fuser` background session that serves `lookup` /
+  `getattr` / `readdir` / `readlink` from the table and
+  fetches file content lazily on first `read(2)`. Per-mount
+  `Semaphore(16)` caps concurrent CAS fetches; per-inode
+  `tokio::sync::OnceCell<Arc<Mmap>>` coalesces concurrent
+  reads of the same file into a single fetch + `mmap`. The
+  `InputMount` RAII handle unmounts on drop with a 5 s
+  `umount_and_join` timeout and a `fusermount -uz` fallback;
+  the per-action cache directory is rm-rf'd after the
+  unmount completes.
+- M6b: `/dev/fuse accessible` probe added to
+  `brokkr-sandbox::checks::linux` and surfaced through the
+  existing `brokkr-worker --check-host`. Three outcomes
+  (`Pass` / `Warn` for present-but-not-rw / `Fail` for
+  missing); does not break sandbox functionality when a
+  worker won't use FUSE.
+- M6b: seven inode-table unit tests (empty / flat / nested /
+  exec-bit / symlink / NotFound / non-dir-parent) and one
+  integration test (`tests/fuse_lazy_fetch.rs`,
+  `#[ignore]` by default) that mounts a 3-file CAS-backed
+  tree, reads two of the three files, and asserts exactly
+  two file-content fetches reached CAS.
+- M6b: new workspace deps `fuser = "0.17"` and `memmap2 = "0.9"`,
+  scoped to `cfg(target_os = "linux")` on `brokkr-worker`.
+  Non-Linux hosts get a compile-time stub
+  (`fuse::mount::MountError::Unsupported`) so the CLI/SDK
+  build stays portable.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,7 +273,7 @@ dependencies = [
  "bytes",
  "caps",
  "libc",
- "nix",
+ "nix 0.29.0",
  "seccompiler",
  "serde",
  "serde_json",
@@ -316,12 +316,17 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "brokkr-cas",
  "brokkr-common",
  "brokkr-proto",
  "brokkr-sandbox",
  "bytes",
  "clap",
+ "fuser",
  "hex",
+ "memmap2",
+ "nix 0.29.0",
+ "parking_lot",
  "prost",
  "sha2",
  "tempfile",
@@ -486,6 +491,26 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fuser"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80a5eca878900c2e39e9e52fd797954b7fc39eeefc8558257114bfea6a698fcf"
+dependencies = [
+ "bitflags",
+ "libc",
+ "log",
+ "memchr",
+ "nix 0.30.1",
+ "num_enum",
+ "page_size",
+ "parking_lot",
+ "pkg-config",
+ "ref-cast",
+ "smallvec",
+ "zerocopy",
+]
 
 [[package]]
 name = "futures"
@@ -883,6 +908,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,12 +961,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -937,6 +1015,16 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1004,6 +1092,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,6 +1114,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1208,6 +1311,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1500,6 +1623,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -1832,6 +1985,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,6 +2093,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,10 @@ tempfile = "3"
 # Linux primitives (sandbox)
 nix = { version = "0.29", default-features = false, features = ["fs", "hostname", "mount", "process", "sched", "signal", "user"] }
 
+# FUSE input materialisation (M6b, worker only, Linux only at runtime)
+fuser = "0.17"
+memmap2 = "0.9"
+
 # Internal crates
 brokkr-common = { path = "crates/brokkr-common", version = "0.1.0" }
 brokkr-proto = { path = "crates/brokkr-proto", version = "0.1.0" }

--- a/crates/brokkr-sandbox/src/checks/linux/fuse_device.rs
+++ b/crates/brokkr-sandbox/src/checks/linux/fuse_device.rs
@@ -1,0 +1,74 @@
+//! `/dev/fuse` accessibility probe (Phase 3 M6b).
+//!
+//! The FUSE input mount in `brokkr-worker::fuse` needs read +
+//! write access to `/dev/fuse`. We don't actually open it here —
+//! that would race with whatever else might be using it — we just
+//! check existence and the calling process's r/w access bits.
+//!
+//! Outcomes:
+//! * `Pass`  — device exists and the worker uid has rw.
+//! * `Warn`  — device exists but the worker can't rw it (e.g. WSL
+//!   default where `/dev/fuse` is `0600 root:root`). The hint
+//!   points at the usual remediation. Sandbox stays "functional"
+//!   per [`super::super::Report::is_functional`]; an operator who
+//!   never runs an action with a FUSE-mounted input tree can
+//!   ignore the warning.
+//! * `Fail`  — device missing entirely (no `fuse` kernel module).
+
+use std::fs;
+use std::path::Path;
+
+use super::super::{Outcome, Status};
+
+const DEV_FUSE: &str = "/dev/fuse";
+
+/// Probe `/dev/fuse` for the M6b lazy-input mount.
+pub(super) fn check_fuse_device() -> Outcome {
+    const NAME: &str = "/dev/fuse accessible";
+    let path = Path::new(DEV_FUSE);
+    match fs::metadata(path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Outcome {
+            name: NAME.to_string(),
+            status: Status::Fail,
+            detail: Some(
+                "/dev/fuse does not exist — FUSE kernel module not loaded. \
+                 On WSL2: `sudo modprobe fuse`. On a custom kernel: \
+                 enable CONFIG_FUSE_FS."
+                    .to_string(),
+            ),
+        },
+        Err(e) => Outcome {
+            name: NAME.to_string(),
+            status: Status::Fail,
+            detail: Some(format!("/dev/fuse: {e}")),
+        },
+        Ok(_) => match check_rw_access(path) {
+            Ok(()) => Outcome {
+                name: NAME.to_string(),
+                status: Status::Pass,
+                detail: None,
+            },
+            Err(detail) => Outcome {
+                name: NAME.to_string(),
+                status: Status::Warn,
+                detail: Some(detail),
+            },
+        },
+    }
+}
+
+// Returns `Ok(())` iff the calling process can open `/dev/fuse`
+// for read+write. We use `access(2)` semantics rather than
+// actually opening because opening might trip a kernel rate
+// limit or interact badly with other FUSE consumers on the host.
+fn check_rw_access(path: &Path) -> Result<(), String> {
+    use nix::unistd::{access, AccessFlags};
+    match access(path, AccessFlags::R_OK | AccessFlags::W_OK) {
+        Ok(()) => Ok(()),
+        Err(e) => Err(format!(
+            "/dev/fuse exists but is not rw to the worker uid ({e}). \
+             Try `sudo chmod 666 /dev/fuse` or add the worker user to \
+             the `fuse` group (on distros that ship one)."
+        )),
+    }
+}

--- a/crates/brokkr-sandbox/src/checks/linux/mod.rs
+++ b/crates/brokkr-sandbox/src/checks/linux/mod.rs
@@ -8,6 +8,8 @@ mod brokkr_slice;
 #[cfg(target_os = "linux")]
 mod cgroup2;
 #[cfg(target_os = "linux")]
+mod fuse_device;
+#[cfg(target_os = "linux")]
 pub(crate) mod kernel_version;
 #[cfg(target_os = "linux")]
 pub(crate) mod memory_peak;
@@ -32,5 +34,6 @@ pub fn run_linux(kernel_release: Option<&str>) -> Vec<super::Outcome> {
         seccomp::check_seccomp(),
         memory_peak::check_memory_peak(kernel_release),
         setgroups::check_setgroups(),
+        fuse_device::check_fuse_device(),
     ]
 }

--- a/crates/brokkr-sandbox/src/checks/mod.rs
+++ b/crates/brokkr-sandbox/src/checks/mod.rs
@@ -291,10 +291,15 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
-    fn linux_run_produces_eight_outcomes() {
+    fn linux_run_produces_all_outcomes() {
         let report = run();
         assert_eq!(report.os, "linux");
-        assert_eq!(report.outcomes.len(), 8);
+        // Eight Phase-2 sandbox probes + the M6b `/dev/fuse` probe.
+        assert_eq!(report.outcomes.len(), 9);
+        assert!(report
+            .outcomes
+            .iter()
+            .any(|o| o.name == "/dev/fuse accessible"));
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/crates/brokkr-worker/Cargo.toml
+++ b/crates/brokkr-worker/Cargo.toml
@@ -16,6 +16,7 @@ name = "brokkr-worker"
 path = "src/main.rs"
 
 [dependencies]
+brokkr-cas.workspace = true
 brokkr-common.workspace = true
 brokkr-proto.workspace = true
 brokkr-sandbox.workspace = true
@@ -33,5 +34,16 @@ tonic.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 
+[target.'cfg(target_os = "linux")'.dependencies]
+# FUSE input mount (M6b). Linux-only at runtime — the worker binary
+# still builds on macOS, but `fuse::mount::mount()` returns
+# `Unsupported` there (see `fuse/mod.rs` non-linux stub).
+fuser.workspace = true
+memmap2.workspace = true
+nix.workspace = true
+
 [dev-dependencies]
+async-trait.workspace = true
+bytes.workspace = true
+parking_lot = "0.12"
 tempfile.workspace = true

--- a/crates/brokkr-worker/src/fuse/inode.rs
+++ b/crates/brokkr-worker/src/fuse/inode.rs
@@ -1,0 +1,404 @@
+//! In-memory inode table built from a REAPI `Directory` Merkle DAG.
+//!
+//! The FUSE filesystem (`super::mount`) serves `getattr` / `lookup` /
+//! `readdir` / `readlink` directly out of this table — no CAS round-trip
+//! for any directory-level metadata. Only the file *content* is fetched
+//! lazily on the first `read(2)`.
+//!
+//! Building the table is the only async step in the mount path: it
+//! walks the Merkle DAG (one CAS `get` per `Directory` proto). For a
+//! tree with N subdirectories the walk does N CAS calls, all for
+//! proto-sized blobs. File content blobs are *not* fetched here.
+//!
+//! This module is platform-independent on purpose so it can be unit
+//! tested without `/dev/fuse`. Anything that touches `fuser` belongs in
+//! [`super::mount`].
+
+use std::collections::HashMap;
+use std::ffi::{OsStr, OsString};
+use std::path::Path;
+
+use brokkr_cas::traits::Cas;
+use brokkr_cas::CasError;
+use brokkr_common::Digest;
+use brokkr_proto::reapi_v2 as rapi;
+use prost::Message;
+
+/// First user-assigned inode. `1` is reserved by the kernel for the
+/// FUSE root (matches `fuser::FUSE_ROOT_ID`). We hand out `2, 3, …`
+/// for everything else.
+pub const ROOT_INO: u64 = 1;
+
+/// One filesystem entry, indexed by inode number in [`InodeTable`].
+#[derive(Debug, Clone)]
+pub struct Inode {
+    /// Inode number. Equal to the entry's index in the table + 1.
+    pub ino: u64,
+    /// What kind of entry this is + the data needed to serve it.
+    pub kind: InodeKind,
+}
+
+/// File / directory / symlink discriminant for [`Inode`].
+#[derive(Debug, Clone)]
+pub enum InodeKind {
+    /// Directory: child entries by name.
+    Dir {
+        /// Name → child inode. We use a `HashMap` so `lookup` is O(1)
+        /// even for directories with thousands of entries (Bazel's
+        /// `external/` is a famous example).
+        entries: HashMap<OsString, u64>,
+    },
+    /// Regular file: CAS digest of the content, plus the metadata
+    /// `getattr` needs without touching CAS.
+    File {
+        /// Content digest. Resolved lazily on first `read(2)`.
+        digest: Digest,
+        /// Size in bytes; reported via `getattr` so the kernel can do
+        /// short reads correctly without us fetching first.
+        size: u64,
+        /// Whether the REAPI `FileNode.is_executable` bit was set.
+        /// Translated to mode `0o555` vs `0o444` at `getattr` time.
+        exec: bool,
+    },
+    /// Symlink. Target string is returned verbatim per REAPI v2
+    /// §SymlinkNode — no canonicalisation, may be absolute or
+    /// relative.
+    Link {
+        /// Symlink target, as stored in the REAPI proto.
+        target: OsString,
+    },
+}
+
+/// Full inode set for one mounted input tree.
+///
+/// Built once by [`InodeTable::build`]; immutable afterwards.
+#[derive(Debug, Clone)]
+pub struct InodeTable {
+    inodes: Vec<Inode>,
+}
+
+impl InodeTable {
+    /// Walk the `Directory` Merkle DAG rooted at `root_digest` and
+    /// return the populated table. Performs one CAS `get` per
+    /// `Directory` proto encountered; does **not** fetch file
+    /// content.
+    pub async fn build(cas: &dyn Cas, root_digest: &Digest) -> Result<Self, CasError> {
+        let mut inodes: Vec<Inode> = Vec::new();
+        // Reserve the root slot up front so its inode is ROOT_INO.
+        inodes.push(Inode {
+            ino: ROOT_INO,
+            kind: InodeKind::Dir {
+                entries: HashMap::new(),
+            },
+        });
+        build_dir(cas, root_digest, ROOT_INO, &mut inodes).await?;
+        Ok(InodeTable { inodes })
+    }
+
+    /// Root directory inode number (always [`ROOT_INO`]).
+    pub fn root_ino(&self) -> u64 {
+        ROOT_INO
+    }
+
+    /// Look up an inode by number. Returns `None` for unknown
+    /// inodes (kernel may send stale numbers after a mount restart).
+    pub fn get(&self, ino: u64) -> Option<&Inode> {
+        if ino == 0 {
+            return None;
+        }
+        self.inodes.get((ino - 1) as usize)
+    }
+
+    /// Resolve `parent_ino` + `name` to the child inode, if any.
+    /// Returns `None` if the parent is not a directory or the name
+    /// is absent.
+    pub fn lookup(&self, parent_ino: u64, name: &OsStr) -> Option<u64> {
+        match &self.get(parent_ino)?.kind {
+            InodeKind::Dir { entries } => entries.get(name).copied(),
+            _ => None,
+        }
+    }
+
+    /// Iterate the children of a directory inode. Order is
+    /// unspecified (HashMap iteration); callers that need stable
+    /// ordering should sort.
+    pub fn children(&self, dir_ino: u64) -> Option<impl Iterator<Item = (&OsStr, u64)> + '_> {
+        match &self.get(dir_ino)?.kind {
+            InodeKind::Dir { entries } => {
+                Some(entries.iter().map(|(name, ino)| (name.as_os_str(), *ino)))
+            }
+            _ => None,
+        }
+    }
+
+    /// Total inode count — useful for diagnostics and tests.
+    pub fn len(&self) -> usize {
+        self.inodes.len()
+    }
+
+    /// True iff the table has no entries (impossible after a
+    /// successful `build`, which always inserts the root).
+    pub fn is_empty(&self) -> bool {
+        self.inodes.is_empty()
+    }
+
+    /// Resolve a `/`-rooted path to an inode. Test helper; FUSE
+    /// itself uses [`Self::lookup`] one component at a time.
+    pub fn resolve(&self, path: &Path) -> Option<u64> {
+        let mut ino = self.root_ino();
+        for component in path.components() {
+            use std::path::Component;
+            match component {
+                Component::RootDir | Component::CurDir => continue,
+                Component::Normal(name) => {
+                    ino = self.lookup(ino, name)?;
+                }
+                Component::ParentDir | Component::Prefix(_) => return None,
+            }
+        }
+        Some(ino)
+    }
+}
+
+// Recursive DAG walker. Boxed because async fn can't recurse without
+// it on stable; the alternative is a work-stack. Tree depth is
+// bounded by the action's input tree (Bazel-style: shallow, <20).
+fn build_dir<'a>(
+    cas: &'a dyn Cas,
+    digest: &'a Digest,
+    parent_ino: u64,
+    inodes: &'a mut Vec<Inode>,
+) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<(), CasError>> + Send + 'a>> {
+    Box::pin(async move {
+        let directory = fetch_directory(cas, digest).await?;
+
+        for file_node in &directory.files {
+            let file_digest = decode_digest(&file_node.digest, &file_node.name, "FileNode")?;
+            let size = u64::try_from(file_digest.size_bytes()).map_err(|_| {
+                CasError::Other(format!(
+                    "FileNode {:?}: negative or oversize digest size {}",
+                    file_node.name,
+                    file_digest.size_bytes()
+                ))
+            })?;
+            let child_ino = push(
+                inodes,
+                InodeKind::File {
+                    digest: file_digest,
+                    size,
+                    exec: file_node.is_executable,
+                },
+            );
+            link_child(inodes, parent_ino, &file_node.name, child_ino)?;
+        }
+
+        for symlink in &directory.symlinks {
+            let child_ino = push(
+                inodes,
+                InodeKind::Link {
+                    target: OsString::from(&symlink.target),
+                },
+            );
+            link_child(inodes, parent_ino, &symlink.name, child_ino)?;
+        }
+
+        for child in &directory.directories {
+            let child_digest = decode_digest(&child.digest, &child.name, "DirectoryNode")?;
+            let child_ino = push(
+                inodes,
+                InodeKind::Dir {
+                    entries: HashMap::new(),
+                },
+            );
+            link_child(inodes, parent_ino, &child.name, child_ino)?;
+            build_dir(cas, &child_digest, child_ino, inodes).await?;
+        }
+
+        Ok(())
+    })
+}
+
+fn push(inodes: &mut Vec<Inode>, kind: InodeKind) -> u64 {
+    let ino = (inodes.len() as u64) + 1;
+    inodes.push(Inode { ino, kind });
+    ino
+}
+
+fn link_child(
+    inodes: &mut [Inode],
+    parent_ino: u64,
+    name: &str,
+    child_ino: u64,
+) -> Result<(), CasError> {
+    let idx = (parent_ino - 1) as usize;
+    let parent = inodes
+        .get_mut(idx)
+        .ok_or_else(|| CasError::Other(format!("parent inode {parent_ino} not allocated")))?;
+    match &mut parent.kind {
+        InodeKind::Dir { entries } => {
+            if entries.insert(OsString::from(name), child_ino).is_some() {
+                return Err(CasError::Other(format!(
+                    "duplicate entry {name:?} in inode {parent_ino}"
+                )));
+            }
+            Ok(())
+        }
+        _ => Err(CasError::Other(format!(
+            "parent inode {parent_ino} is not a directory"
+        ))),
+    }
+}
+
+fn decode_digest(
+    proto: &Option<rapi::Digest>,
+    name: &str,
+    kind: &'static str,
+) -> Result<Digest, CasError> {
+    match proto {
+        Some(d) => Digest::new(d.hash.clone(), d.size_bytes)
+            .map_err(|e| CasError::Other(format!("invalid {kind} digest {name}: {e}"))),
+        None => Err(CasError::Other(format!("{kind} {name:?} missing digest"))),
+    }
+}
+
+async fn fetch_directory(cas: &dyn Cas, digest: &Digest) -> Result<rapi::Directory, CasError> {
+    let mut results = cas.batch_read_blobs(&[digest.clone()]).await?;
+    let bytes = match results.pop() {
+        Some(Ok(b)) => b,
+        Some(Err(e)) => return Err(e),
+        None => return Err(CasError::NotFound(digest.clone())),
+    };
+    rapi::Directory::decode(bytes.as_ref())
+        .map_err(|e| CasError::Other(format!("Directory decode for {digest:?}: {e}")))
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::disallowed_methods,
+    clippy::panic
+)]
+mod tests {
+    use super::*;
+    use brokkr_cas::tree::build_tree_into;
+    use brokkr_cas::InMemoryCas;
+    use std::path::PathBuf;
+
+    async fn build_from_disk(src: &Path) -> (InodeTable, InMemoryCas) {
+        let cas = InMemoryCas::new();
+        let root = build_tree_into(&cas, src).await.unwrap();
+        let table = InodeTable::build(&cas, &root).await.unwrap();
+        (table, cas)
+    }
+
+    #[tokio::test]
+    async fn empty_tree_has_only_root() {
+        let src = tempfile::tempdir().unwrap();
+        let (table, _cas) = build_from_disk(src.path()).await;
+        assert_eq!(table.len(), 1);
+        assert_eq!(table.root_ino(), ROOT_INO);
+        let root = table.get(ROOT_INO).unwrap();
+        match &root.kind {
+            InodeKind::Dir { entries } => assert!(entries.is_empty()),
+            _ => panic!("root must be a directory"),
+        }
+    }
+
+    #[tokio::test]
+    async fn flat_files_assigned_distinct_inodes() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("a.txt"), b"hello").unwrap();
+        std::fs::write(src.path().join("b.bin"), b"\x00\x01\x02").unwrap();
+        let (table, _cas) = build_from_disk(src.path()).await;
+
+        assert_eq!(table.len(), 3); // root + 2 files
+        let a = table.resolve(&PathBuf::from("/a.txt")).unwrap();
+        let b = table.resolve(&PathBuf::from("/b.bin")).unwrap();
+        assert_ne!(a, b);
+
+        match &table.get(a).unwrap().kind {
+            InodeKind::File { size, exec, .. } => {
+                assert_eq!(*size, 5);
+                assert!(!exec);
+            }
+            other => panic!("a.txt was {other:?}"),
+        }
+        match &table.get(b).unwrap().kind {
+            InodeKind::File { size, .. } => assert_eq!(*size, 3),
+            other => panic!("b.bin was {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn nested_tree_resolves_paths() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("top.txt"), b"top").unwrap();
+        let sub = src.path().join("sub");
+        std::fs::create_dir(&sub).unwrap();
+        std::fs::write(sub.join("inner.txt"), b"inner").unwrap();
+        let deeper = sub.join("deeper");
+        std::fs::create_dir(&deeper).unwrap();
+        std::fs::write(deeper.join("bottom.txt"), b"bottom").unwrap();
+        let (table, _cas) = build_from_disk(src.path()).await;
+
+        // root, top.txt, sub, sub/inner.txt, sub/deeper, sub/deeper/bottom.txt
+        assert_eq!(table.len(), 6);
+
+        let bottom = table
+            .resolve(&PathBuf::from("/sub/deeper/bottom.txt"))
+            .unwrap();
+        match &table.get(bottom).unwrap().kind {
+            InodeKind::File { size, .. } => assert_eq!(*size, 6),
+            other => panic!("bottom was {other:?}"),
+        }
+        assert!(table.resolve(&PathBuf::from("/sub/missing")).is_none());
+    }
+
+    #[tokio::test]
+    async fn executable_bit_propagates_to_inode() {
+        use std::os::unix::fs::PermissionsExt as _;
+        let src = tempfile::tempdir().unwrap();
+        let script = src.path().join("run.sh");
+        std::fs::write(&script, b"#!/bin/sh\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let (table, _cas) = build_from_disk(src.path()).await;
+
+        let ino = table.resolve(&PathBuf::from("/run.sh")).unwrap();
+        match &table.get(ino).unwrap().kind {
+            InodeKind::File { exec, .. } => assert!(*exec),
+            other => panic!("run.sh was {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn symlink_target_preserved_verbatim() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("target.txt"), b"linked").unwrap();
+        std::os::unix::fs::symlink("target.txt", src.path().join("link")).unwrap();
+        let (table, _cas) = build_from_disk(src.path()).await;
+
+        let link = table.resolve(&PathBuf::from("/link")).unwrap();
+        match &table.get(link).unwrap().kind {
+            InodeKind::Link { target } => assert_eq!(target.as_os_str(), "target.txt"),
+            other => panic!("link was {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_root_propagates_not_found() {
+        let cas = InMemoryCas::new();
+        let bogus = Digest::of(b"not in cas");
+        let err = InodeTable::build(&cas, &bogus).await.unwrap_err();
+        assert!(matches!(err, CasError::NotFound(_)), "got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn lookup_returns_none_for_non_directory_parent() {
+        let src = tempfile::tempdir().unwrap();
+        std::fs::write(src.path().join("a.txt"), b"x").unwrap();
+        let (table, _cas) = build_from_disk(src.path()).await;
+        let a = table.resolve(&PathBuf::from("/a.txt")).unwrap();
+        assert!(table.lookup(a, OsStr::new("anything")).is_none());
+    }
+}

--- a/crates/brokkr-worker/src/fuse/mod.rs
+++ b/crates/brokkr-worker/src/fuse/mod.rs
@@ -1,0 +1,83 @@
+//! FUSE-backed lazy input materialisation for the worker (Phase 3 M6b).
+//!
+//! See `docs/phase-3-plan.md` §5.5 + §5.5.1 for the design. The
+//! short story: instead of copying a multi-GiB Bazel input tree to
+//! the workspace before every action (the M6a `materialize_tree`
+//! path), the worker exposes the tree as a FUSE mount. `getattr` /
+//! `lookup` / `readdir` are served from an in-memory inode table
+//! built from the `Directory` Merkle DAG; file content is fetched
+//! from CAS only on the first `read(2)` and cached locally for the
+//! lifetime of the action.
+//!
+//! ## Module layout
+//!
+//! * [`inode`]: pure data + DAG-walking builder. Platform-independent
+//!   and fully unit-testable without `/dev/fuse`.
+//! * [`mount`] (Linux only): the `fuser::Filesystem` implementation,
+//!   the [`mount::InputMount`] RAII handle, and the public
+//!   [`mount::mount`] entry point. Compiles to a stub on non-Linux
+//!   that returns [`mount::MountError::Unsupported`].
+//!
+//! ## Lifetime
+//!
+//! One mount per running action. The worker:
+//!
+//! 1. Builds an [`mount::InputMountSpec`] from the action's input
+//!    root digest and a job-scoped scratch directory.
+//! 2. Calls [`mount::mount`] (async — pre-walks the DAG).
+//! 3. Adds the mountpoint to the sandbox's `ro_binds`.
+//! 4. Runs the action.
+//! 5. Drops the [`mount::InputMount`] handle — unmount + cache
+//!    cleanup happen synchronously in `Drop`.
+
+pub mod inode;
+
+#[cfg(target_os = "linux")]
+pub mod mount;
+
+#[cfg(not(target_os = "linux"))]
+pub mod mount {
+    //! Non-Linux stub. Mounting always fails with
+    //! [`MountError::Unsupported`]; everything else compiles so the
+    //! rest of the worker crate stays portable for the CLI/SDK
+    //! build.
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use brokkr_cas::traits::Cas;
+    use brokkr_common::Digest;
+
+    /// Mount-time failure shapes. See [`mount`].
+    #[derive(Debug, thiserror::Error)]
+    pub enum MountError {
+        /// This platform doesn't support FUSE mounts.
+        #[error("FUSE input mount is Linux-only; this host is {0}")]
+        Unsupported(&'static str),
+    }
+
+    /// Inputs for [`mount`]: where to mount, where to cache, what
+    /// to serve.
+    #[derive(Debug, Clone)]
+    pub struct InputMountSpec {
+        /// Root of the REAPI input tree to expose.
+        pub root_digest: Digest,
+        /// Mountpoint directory. Must exist and be empty.
+        pub mountpoint: PathBuf,
+        /// Local cache directory for lazily-fetched file content.
+        pub cache_dir: PathBuf,
+    }
+
+    /// RAII handle. On non-Linux this is uninhabitable.
+    #[derive(Debug)]
+    pub struct InputMount {
+        _never: std::convert::Infallible,
+    }
+
+    /// Stub: always returns [`MountError::Unsupported`].
+    pub async fn mount(
+        _cas: Arc<dyn Cas>,
+        _spec: InputMountSpec,
+    ) -> Result<InputMount, MountError> {
+        Err(MountError::Unsupported(std::env::consts::OS))
+    }
+}

--- a/crates/brokkr-worker/src/fuse/mount.rs
+++ b/crates/brokkr-worker/src/fuse/mount.rs
@@ -1,0 +1,541 @@
+//! FUSE input mount for the worker (Linux-only).
+//!
+//! See `crates/brokkr-worker/src/fuse/mod.rs` for the high-level
+//! design and `docs/phase-3-plan.md` §5.5.1 for the M6b sub-plan.
+//!
+//! This module wires three layers:
+//!
+//! 1. **[`super::inode::InodeTable`]** — pre-walked Merkle DAG, all
+//!    directory metadata served from RAM.
+//! 2. **`BrokkrFs`** — the `fuser::Filesystem` implementation. Its
+//!    callbacks are synchronous (called by the kernel via fuser's
+//!    dedicated thread); CAS fetches inside `read` use
+//!    [`tokio::runtime::Handle::block_on`] on the same tokio
+//!    runtime that the rest of the worker uses.
+//! 3. **[`InputMount`]** — RAII handle. Holds the
+//!    `fuser::BackgroundSession`; dropping the handle unmounts and
+//!    cleans the cache directory.
+//!
+//! Concurrency: per-mount [`tokio::sync::Semaphore`] caps concurrent
+//! CAS fetches (default 16). Each file inode has its own
+//! [`tokio::sync::OnceCell`] so concurrent reads of the same file
+//! coalesce into one fetch.
+
+use std::ffi::OsStr;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime};
+
+use brokkr_cas::traits::Cas;
+use brokkr_cas::CasError;
+use brokkr_common::Digest;
+use fuser::{
+    BackgroundSession, Errno, FileAttr, FileHandle, FileType, Filesystem, FopenFlags, Generation,
+    INodeNo, LockOwner, MountOption, OpenFlags, ReplyAttr, ReplyData, ReplyDirectory, ReplyEntry,
+    ReplyOpen, Request,
+};
+use memmap2::Mmap;
+use tokio::runtime::Handle;
+use tokio::sync::{OnceCell, Semaphore};
+
+use super::inode::{Inode, InodeKind, InodeTable};
+
+const DEFAULT_FETCH_CONCURRENCY: usize = 16;
+const TTL: Duration = Duration::from_secs(1);
+const GENERATION: Generation = Generation(0);
+
+/// Where to mount, where to cache, what to serve.
+#[derive(Debug, Clone)]
+pub struct InputMountSpec {
+    /// Root of the REAPI input tree to expose.
+    pub root_digest: Digest,
+    /// Mountpoint directory. Must already exist and be empty.
+    pub mountpoint: PathBuf,
+    /// Local cache for lazily-fetched file content. Created on
+    /// mount if missing; rm-rf'd by `InputMount::drop`.
+    pub cache_dir: PathBuf,
+}
+
+/// Mount-time failure shapes.
+#[derive(Debug, thiserror::Error)]
+pub enum MountError {
+    /// `/dev/fuse` is missing or not accessible.
+    #[error("FUSE device unavailable: {0}")]
+    Device(String),
+    /// Underlying `mount(2)` failed.
+    #[error("mount syscall failed: {0}")]
+    Mount(io::Error),
+    /// Walking the `Directory` Merkle DAG failed.
+    #[error("input tree walk failed: {0}")]
+    Tree(#[from] CasError),
+    /// Mountpoint exists but isn't empty.
+    #[error("mountpoint not empty: {0}")]
+    Dirty(PathBuf),
+    /// Failed to set up the per-mount cache directory.
+    #[error("cache directory setup failed: {0}")]
+    Cache(io::Error),
+    /// Caller invoked [`mount`] outside a tokio runtime context.
+    #[error("must be called from within a tokio runtime")]
+    NoRuntime,
+}
+
+/// Live FUSE mount for one action's input tree.
+///
+/// Dropping the handle unmounts (via `fuser::BackgroundSession`'s
+/// own Drop), waits for the FUSE thread to join, and then rm-rfs
+/// the cache directory. If the join reports an error we shell out
+/// to `fusermount -uz` (lazy unmount) and log a warning — the
+/// cache rm-rf still runs.
+pub struct InputMount {
+    spec: InputMountSpec,
+    session: Option<BackgroundSession>,
+}
+
+impl std::fmt::Debug for InputMount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InputMount")
+            .field("mountpoint", &self.spec.mountpoint)
+            .field("cache_dir", &self.spec.cache_dir)
+            .field("session_active", &self.session.is_some())
+            .finish()
+    }
+}
+
+impl InputMount {
+    /// Mountpoint path, for the sandbox to bind into the action.
+    pub fn mountpoint(&self) -> &Path {
+        &self.spec.mountpoint
+    }
+
+    /// Cache directory holding lazily-fetched file content.
+    pub fn cache_dir(&self) -> &Path {
+        &self.spec.cache_dir
+    }
+}
+
+impl Drop for InputMount {
+    fn drop(&mut self) {
+        // Order matters: unmount first (releases the kernel's hold
+        // on the cache files we mmapped), then rm -rf the cache.
+        if let Some(session) = self.session.take() {
+            // Move umount + join onto a helper thread with a hard
+            // timeout. `umount_and_join` blocks until the fuser bg
+            // thread exits, which in turn waits for the kernel to
+            // close `/dev/fuse` after the unmount syscall. On a
+            // misbehaving mount that path can hang indefinitely, so
+            // we fall back to `fusermount -uz` (lazy detach) if the
+            // helper hasn't returned in 5 s.
+            let mountpoint = self.spec.mountpoint.clone();
+            let mountpoint_for_log = mountpoint.clone();
+            let (tx, rx) = std::sync::mpsc::channel();
+            let join = std::thread::Builder::new()
+                .name("brokkr-fuse-umount".to_string())
+                .spawn(move || {
+                    let result = session.umount_and_join();
+                    let _ = tx.send(result);
+                });
+            if join.is_err() {
+                tracing::warn!(
+                    mount = %mountpoint_for_log.display(),
+                    "could not spawn unmount helper thread; falling back to lazy unmount"
+                );
+                lazy_unmount(&mountpoint);
+            } else {
+                match rx.recv_timeout(std::time::Duration::from_secs(5)) {
+                    Ok(Ok(())) => {}
+                    Ok(Err(e)) => {
+                        tracing::warn!(
+                            mount = %mountpoint_for_log.display(),
+                            error = %e,
+                            "FUSE umount_and_join returned an error; lazy unmount fallback"
+                        );
+                        lazy_unmount(&mountpoint);
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                        tracing::warn!(
+                            mount = %mountpoint_for_log.display(),
+                            "FUSE umount_and_join timed out after 5s; lazy unmount fallback"
+                        );
+                        lazy_unmount(&mountpoint);
+                    }
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                        tracing::warn!(
+                            mount = %mountpoint_for_log.display(),
+                            "FUSE unmount helper disconnected unexpectedly; lazy unmount fallback"
+                        );
+                        lazy_unmount(&mountpoint);
+                    }
+                }
+            }
+        }
+        if let Err(e) = std::fs::remove_dir_all(&self.spec.cache_dir) {
+            if e.kind() != io::ErrorKind::NotFound {
+                tracing::warn!(
+                    cache = %self.spec.cache_dir.display(),
+                    error = %e,
+                    "failed to remove FUSE cache directory on drop"
+                );
+            }
+        }
+    }
+}
+
+fn lazy_unmount(mountpoint: &Path) {
+    match std::process::Command::new("fusermount")
+        .arg("-uz")
+        .arg(mountpoint)
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            tracing::info!(mount = %mountpoint.display(), "lazy unmount completed");
+        }
+        Ok(out) => {
+            tracing::warn!(
+                mount = %mountpoint.display(),
+                stderr = %String::from_utf8_lossy(&out.stderr),
+                "fusermount -uz exited non-zero"
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                mount = %mountpoint.display(),
+                error = %e,
+                "fusermount -uz failed to spawn"
+            );
+        }
+    }
+}
+
+/// Mount the input tree described by `spec`. Returns once the
+/// kernel side of the FUSE mount is live; file content is fetched
+/// lazily on the first `read(2)`.
+#[tracing::instrument(skip(cas), fields(
+    root = %spec.root_digest,
+    mountpoint = %spec.mountpoint.display(),
+))]
+pub async fn mount(cas: Arc<dyn Cas>, spec: InputMountSpec) -> Result<InputMount, MountError> {
+    validate_mountpoint(&spec.mountpoint)?;
+    std::fs::create_dir_all(&spec.cache_dir).map_err(MountError::Cache)?;
+
+    let table = Arc::new(InodeTable::build(cas.as_ref(), &spec.root_digest).await?);
+    tracing::debug!(inodes = table.len(), "built inode table for FUSE mount");
+
+    let handle = Handle::try_current().map_err(|_| MountError::NoRuntime)?;
+    let semaphore = Arc::new(Semaphore::new(DEFAULT_FETCH_CONCURRENCY));
+    let slots: Vec<Arc<OnceCell<Arc<Mmap>>>> = (0..table.len())
+        .map(|_| Arc::new(OnceCell::new()))
+        .collect();
+
+    let fs = BrokkrFs {
+        table,
+        cas,
+        cache_dir: spec.cache_dir.clone(),
+        handle,
+        semaphore,
+        slots,
+    };
+
+    let options = vec![
+        MountOption::FSName("brokkr-input".to_string()),
+        MountOption::Subtype("brokkrfs".to_string()),
+        MountOption::RO,
+        MountOption::NoSuid,
+        MountOption::NoDev,
+    ];
+
+    let mut config = fuser::Config::default();
+    config.mount_options = options;
+    let session =
+        fuser::spawn_mount2(fs, &spec.mountpoint, &config).map_err(|e| match e.kind() {
+            io::ErrorKind::NotFound | io::ErrorKind::PermissionDenied => {
+                MountError::Device(e.to_string())
+            }
+            _ => MountError::Mount(e),
+        })?;
+
+    Ok(InputMount {
+        spec,
+        session: Some(session),
+    })
+}
+
+fn validate_mountpoint(path: &Path) -> Result<(), MountError> {
+    let entries = std::fs::read_dir(path).map_err(|e| match e.kind() {
+        io::ErrorKind::NotFound => MountError::Cache(e),
+        _ => MountError::Mount(e),
+    })?;
+    if entries.into_iter().next().is_some() {
+        return Err(MountError::Dirty(path.to_path_buf()));
+    }
+    Ok(())
+}
+
+struct BrokkrFs {
+    table: Arc<InodeTable>,
+    cas: Arc<dyn Cas>,
+    cache_dir: PathBuf,
+    handle: Handle,
+    semaphore: Arc<Semaphore>,
+    /// Parallel to `table.inodes` — one slot per inode, used only
+    /// for file inodes. Directory and symlink slots stay empty.
+    slots: Vec<Arc<OnceCell<Arc<Mmap>>>>,
+}
+
+impl BrokkrFs {
+    fn slot(&self, ino: u64) -> Option<Arc<OnceCell<Arc<Mmap>>>> {
+        if ino == 0 {
+            return None;
+        }
+        self.slots.get((ino - 1) as usize).cloned()
+    }
+}
+
+impl Filesystem for BrokkrFs {
+    fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
+        match self.table.lookup(parent.into(), name) {
+            Some(child_ino) => match self.table.get(child_ino) {
+                Some(inode) => reply.entry(&TTL, &attr_for(inode), GENERATION),
+                None => reply.error(Errno::ENOENT),
+            },
+            None => reply.error(Errno::ENOENT),
+        }
+    }
+
+    fn getattr(&self, _req: &Request, ino: INodeNo, _fh: Option<FileHandle>, reply: ReplyAttr) {
+        match self.table.get(ino.into()) {
+            Some(inode) => reply.attr(&TTL, &attr_for(inode)),
+            None => reply.error(Errno::ENOENT),
+        }
+    }
+
+    fn readlink(&self, _req: &Request, ino: INodeNo, reply: ReplyData) {
+        match self.table.get(ino.into()).map(|i| &i.kind) {
+            Some(InodeKind::Link { target }) => reply.data(target.as_encoded_bytes()),
+            Some(_) => reply.error(Errno::EINVAL),
+            None => reply.error(Errno::ENOENT),
+        }
+    }
+
+    fn opendir(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+        match self.table.get(ino.into()).map(|i| &i.kind) {
+            Some(InodeKind::Dir { .. }) => reply.opened(FileHandle(0), FopenFlags::empty()),
+            Some(_) => reply.error(Errno::ENOTDIR),
+            None => reply.error(Errno::ENOENT),
+        }
+    }
+
+    fn readdir(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        _fh: FileHandle,
+        offset: u64,
+        mut reply: ReplyDirectory,
+    ) {
+        let ino_u64: u64 = ino.into();
+        let dir_inode = match self.table.get(ino_u64) {
+            Some(i) => i,
+            None => {
+                reply.error(Errno::ENOENT);
+                return;
+            }
+        };
+        let entries = match &dir_inode.kind {
+            InodeKind::Dir { entries } => entries,
+            _ => {
+                reply.error(Errno::ENOTDIR);
+                return;
+            }
+        };
+        // Synthesize "." and "..". For the FS root, ".." refers to
+        // the root itself (per FUSE convention).
+        let mut all: Vec<(u64, FileType, std::ffi::OsString)> =
+            Vec::with_capacity(2 + entries.len());
+        all.push((ino_u64, FileType::Directory, ".".into()));
+        all.push((ino_u64, FileType::Directory, "..".into()));
+        for (name, child_ino) in entries {
+            let kind = self
+                .table
+                .get(*child_ino)
+                .map(file_type_of)
+                .unwrap_or(FileType::RegularFile);
+            all.push((*child_ino, kind, name.clone()));
+        }
+        all.sort_by(|a, b| a.2.cmp(&b.2));
+
+        // `offset` is the index of the *next* entry to return.
+        let start = offset as usize;
+        for (i, (child_ino, kind, name)) in all.iter().enumerate().skip(start) {
+            let next_offset = (i + 1) as u64;
+            if reply.add(INodeNo(*child_ino), next_offset, *kind, name) {
+                break;
+            }
+        }
+        reply.ok();
+    }
+
+    fn open(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: ReplyOpen) {
+        match self.table.get(ino.into()).map(|i| &i.kind) {
+            Some(InodeKind::File { .. }) => reply.opened(FileHandle(0), FopenFlags::empty()),
+            Some(InodeKind::Dir { .. }) => reply.error(Errno::EISDIR),
+            Some(InodeKind::Link { .. }) => reply.error(Errno::EINVAL),
+            None => reply.error(Errno::ENOENT),
+        }
+    }
+
+    fn read(
+        &self,
+        _req: &Request,
+        ino: INodeNo,
+        _fh: FileHandle,
+        offset: u64,
+        size: u32,
+        _flags: OpenFlags,
+        _lock_owner: Option<LockOwner>,
+        reply: ReplyData,
+    ) {
+        let ino_u64: u64 = ino.into();
+        let inode = match self.table.get(ino_u64) {
+            Some(i) => i,
+            None => {
+                reply.error(Errno::ENOENT);
+                return;
+            }
+        };
+        let (digest, file_size) = match &inode.kind {
+            InodeKind::File { digest, size, .. } => (digest.clone(), *size),
+            _ => {
+                reply.error(Errno::EISDIR);
+                return;
+            }
+        };
+        let slot = match self.slot(ino_u64) {
+            Some(s) => s,
+            None => {
+                reply.error(Errno::ENOENT);
+                return;
+            }
+        };
+
+        let cas = self.cas.clone();
+        let cache_dir = self.cache_dir.clone();
+        let sem = self.semaphore.clone();
+
+        let mmap = self.handle.block_on(async move {
+            slot.get_or_try_init(|| async {
+                let _permit = sem
+                    .acquire()
+                    .await
+                    .map_err(|e| FetchError::Internal(format!("semaphore closed: {e}")))?;
+                fetch_and_mmap(cas.as_ref(), &digest, file_size, &cache_dir).await
+            })
+            .await
+            .cloned()
+        });
+
+        let mmap = match mmap {
+            Ok(m) => m,
+            Err(e) => {
+                tracing::warn!(ino = ino_u64, error = %e, "lazy fetch failed; returning EIO");
+                reply.error(Errno::EIO);
+                return;
+            }
+        };
+
+        let data: &[u8] = &mmap;
+        let start = (offset as usize).min(data.len());
+        let end = start.saturating_add(size as usize).min(data.len());
+        reply.data(&data[start..end]);
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum FetchError {
+    #[error("cas: {0}")]
+    Cas(#[from] CasError),
+    #[error("io: {0}")]
+    Io(#[from] io::Error),
+    #[error("size mismatch: digest claims {expected} bytes, got {actual}")]
+    SizeMismatch { expected: u64, actual: u64 },
+    #[error("internal: {0}")]
+    Internal(String),
+}
+
+async fn fetch_and_mmap(
+    cas: &dyn Cas,
+    digest: &Digest,
+    expected_size: u64,
+    cache_dir: &Path,
+) -> Result<Arc<Mmap>, FetchError> {
+    let mut results = cas.batch_read_blobs(&[digest.clone()]).await?;
+    let bytes = match results.pop() {
+        Some(Ok(b)) => b,
+        Some(Err(e)) => return Err(FetchError::Cas(e)),
+        None => return Err(FetchError::Cas(CasError::NotFound(digest.clone()))),
+    };
+    if bytes.len() as u64 != expected_size {
+        return Err(FetchError::SizeMismatch {
+            expected: expected_size,
+            actual: bytes.len() as u64,
+        });
+    }
+    let path = cache_dir.join(digest.hash());
+    std::fs::write(&path, &bytes)?;
+    let file = std::fs::File::open(&path)?;
+    // SAFETY: cache files are written-once and addressed by their
+    // content digest; nothing else writes to `cache_dir` while the
+    // mount is live, and the mmap is dropped before `InputMount`'s
+    // Drop removes the cache directory.
+    #[allow(unsafe_code)]
+    let mmap = unsafe { Mmap::map(&file)? };
+    Ok(Arc::new(mmap))
+}
+
+fn attr_for(inode: &Inode) -> FileAttr {
+    let (kind, size, perm, nlink) = match &inode.kind {
+        InodeKind::Dir { entries } => (
+            FileType::Directory,
+            0u64,
+            0o555u16,
+            (2 + entries.len()) as u32,
+        ),
+        InodeKind::File { size, exec, .. } => (
+            FileType::RegularFile,
+            *size,
+            if *exec { 0o555 } else { 0o444 },
+            1,
+        ),
+        InodeKind::Link { target } => (
+            FileType::Symlink,
+            target.as_encoded_bytes().len() as u64,
+            0o777,
+            1,
+        ),
+    };
+    FileAttr {
+        ino: INodeNo(inode.ino),
+        size,
+        blocks: size.div_ceil(512),
+        atime: SystemTime::UNIX_EPOCH,
+        mtime: SystemTime::UNIX_EPOCH,
+        ctime: SystemTime::UNIX_EPOCH,
+        crtime: SystemTime::UNIX_EPOCH,
+        kind,
+        perm,
+        nlink,
+        uid: nix::unistd::getuid().as_raw(),
+        gid: nix::unistd::getgid().as_raw(),
+        rdev: 0,
+        blksize: 4096,
+        flags: 0,
+    }
+}
+
+fn file_type_of(inode: &Inode) -> FileType {
+    match inode.kind {
+        InodeKind::Dir { .. } => FileType::Directory,
+        InodeKind::File { .. } => FileType::RegularFile,
+        InodeKind::Link { .. } => FileType::Symlink,
+    }
+}

--- a/crates/brokkr-worker/src/lib.rs
+++ b/crates/brokkr-worker/src/lib.rs
@@ -7,6 +7,7 @@
 
 #![deny(missing_docs)]
 
+pub mod fuse;
 pub mod runner;
 pub mod worker;
 

--- a/crates/brokkr-worker/tests/fuse_lazy_fetch.rs
+++ b/crates/brokkr-worker/tests/fuse_lazy_fetch.rs
@@ -1,0 +1,178 @@
+//! M6b end-to-end: mount a CAS-backed tree via FUSE, read a
+//! subset of files, assert that CAS was only touched for the
+//! files we actually opened.
+//!
+//! Gated on `target_os = "linux"` and `/dev/fuse` accessibility.
+//! `#[ignore]` by default so `cargo test --workspace` on hosts
+//! without FUSE (or in containers that lack `/dev/fuse`) skips
+//! cleanly. Run explicitly with:
+//!
+//! ```text
+//! cargo test -p brokkr-worker --test fuse_lazy_fetch -- --ignored
+//! ```
+
+#![cfg(target_os = "linux")]
+#![allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::disallowed_methods,
+    clippy::panic
+)]
+
+use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use brokkr_cas::traits::{Cas, UpdateResult};
+use brokkr_cas::tree::build_tree_into;
+use brokkr_cas::{CasError, InMemoryCas};
+use brokkr_common::Digest;
+use brokkr_worker::fuse::mount::{mount, InputMountSpec};
+use bytes::Bytes;
+
+/// Wraps another `Cas` and counts every `batch_read_blobs` call by
+/// digest. The integration test asserts that only the digests of
+/// the files we actually opened were fetched.
+struct CountingCas {
+    inner: Arc<dyn Cas>,
+    /// Total digests requested across all read calls (sum of slice
+    /// lengths). Directory protos count too — we subtract those in
+    /// the assertion.
+    reads: AtomicUsize,
+    /// File-content digests we expect; reads of these increment
+    /// `file_reads`.
+    file_digests: parking_lot::Mutex<Vec<Digest>>,
+    file_reads: AtomicUsize,
+}
+
+impl CountingCas {
+    fn new(inner: Arc<dyn Cas>, file_digests: Vec<Digest>) -> Self {
+        Self {
+            inner,
+            reads: AtomicUsize::new(0),
+            file_digests: parking_lot::Mutex::new(file_digests),
+            file_reads: AtomicUsize::new(0),
+        }
+    }
+
+    fn file_reads(&self) -> usize {
+        self.file_reads.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl Cas for CountingCas {
+    async fn find_missing_blobs(&self, digests: &[Digest]) -> Result<Vec<Digest>, CasError> {
+        self.inner.find_missing_blobs(digests).await
+    }
+
+    async fn batch_update_blobs(
+        &self,
+        blobs: Vec<(Digest, Bytes)>,
+    ) -> Result<Vec<UpdateResult>, CasError> {
+        self.inner.batch_update_blobs(blobs).await
+    }
+
+    async fn batch_read_blobs(
+        &self,
+        digests: &[Digest],
+    ) -> Result<Vec<Result<Bytes, CasError>>, CasError> {
+        self.reads.fetch_add(digests.len(), Ordering::SeqCst);
+        let tracked = self.file_digests.lock().clone();
+        for d in digests {
+            if tracked.iter().any(|t| t == d) {
+                self.file_reads.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        self.inner.batch_read_blobs(digests).await
+    }
+
+    async fn list_digests(&self) -> Result<Vec<Digest>, CasError> {
+        self.inner.list_digests().await
+    }
+
+    async fn delete_blob(&self, digest: &Digest) -> Result<(), CasError> {
+        self.inner.delete_blob(digest).await
+    }
+}
+
+fn fuse_available() -> bool {
+    use std::os::unix::fs::PermissionsExt as _;
+    match std::fs::metadata("/dev/fuse") {
+        Ok(meta) => {
+            let mode = meta.permissions().mode();
+            // Want rw for the test process; if perms look ok but
+            // EACCES happens at mount time we'll skip later.
+            mode & 0o600 == 0o600
+        }
+        Err(_) => false,
+    }
+}
+
+fn write_tree(src: &Path) -> Vec<(String, Vec<u8>)> {
+    let files = vec![
+        ("alpha.txt".to_string(), b"alpha-contents-aaaaa".to_vec()),
+        ("beta.bin".to_string(), b"\x00\x01\x02\x03beta".to_vec()),
+        ("gamma.dat".to_string(), b"gamma-payload-xyz".to_vec()),
+    ];
+    for (name, bytes) in &files {
+        std::fs::write(src.join(name), bytes).unwrap();
+    }
+    files
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "requires /dev/fuse access; run with --ignored"]
+async fn fuse_mount_lazy_fetch() {
+    if !fuse_available() {
+        eprintln!("skipping: /dev/fuse not accessible to test process");
+        return;
+    }
+
+    // 1. Build a 3-file tree in CAS.
+    let src = tempfile::tempdir().unwrap();
+    let files = write_tree(src.path());
+    let backing: Arc<dyn Cas> = Arc::new(InMemoryCas::new());
+    let root = build_tree_into(backing.as_ref(), src.path()).await.unwrap();
+
+    let file_digests: Vec<Digest> = files.iter().map(|(_, b)| Digest::of(b)).collect();
+
+    let counting: Arc<CountingCas> = Arc::new(CountingCas::new(backing.clone(), file_digests));
+    let cas_for_mount: Arc<dyn Cas> = counting.clone();
+
+    // 2. Mount it.
+    let mountpoint = tempfile::tempdir().unwrap();
+    let cache = tempfile::tempdir().unwrap();
+    let spec = InputMountSpec {
+        root_digest: root,
+        mountpoint: mountpoint.path().to_path_buf(),
+        cache_dir: cache.path().to_path_buf(),
+    };
+    let mount_handle = match mount(cas_for_mount, spec).await {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("skipping: mount failed: {e}");
+            return;
+        }
+    };
+
+    // 3. Read only alpha + gamma. Beta stays untouched.
+    let alpha = std::fs::read(mountpoint.path().join("alpha.txt")).unwrap();
+    assert_eq!(alpha, b"alpha-contents-aaaaa");
+    let gamma = std::fs::read(mountpoint.path().join("gamma.dat")).unwrap();
+    assert_eq!(gamma, b"gamma-payload-xyz");
+
+    // 4. Re-reading alpha must NOT cause another CAS fetch.
+    let alpha2 = std::fs::read(mountpoint.path().join("alpha.txt")).unwrap();
+    assert_eq!(alpha2, b"alpha-contents-aaaaa");
+
+    let file_reads = counting.file_reads();
+    assert_eq!(
+        file_reads, 2,
+        "expected exactly 2 file-content fetches (alpha + gamma), got {file_reads}"
+    );
+
+    // 5. Drop unmount cleanly.
+    drop(mount_handle);
+}

--- a/docs/journal/phase-3.md
+++ b/docs/journal/phase-3.md
@@ -466,3 +466,117 @@ debrief.
   works — we don't have to pre-clean. (Phase 3 still doesn't
   remove the target directory; the worker manages its
   workspace lifecycle.)
+
+## M6b — `feat/phase3-fuse-input-materialization`
+
+- **Date:** 2026-05-17
+- **PR:** _(filled in after merge)_
+- **Outcome:** FUSE-backed lazy input mount shipped in
+  `brokkr-worker::fuse`. `fuse::inode::InodeTable` walks a
+  REAPI `Directory` Merkle DAG into an inode-indexed,
+  path-resolvable map (one CAS read per directory proto, zero
+  file fetches). `fuse::mount::mount(cas, InputMountSpec)`
+  spawns a `fuser` background session that serves `lookup` /
+  `getattr` / `readdir` / `readlink` from RAM and fetches file
+  content lazily on first `read(2)`. Per-mount `Semaphore(16)`
+  caps concurrent CAS fetches; per-inode
+  `tokio::sync::OnceCell<Arc<Mmap>>` coalesces concurrent
+  reads of the same file into a single fetch + mmap. The
+  `InputMount` RAII handle unmounts on drop with a 5 s
+  `umount_and_join` timeout and a `fusermount -uz` fallback;
+  the cache directory is rm-rf'd after the unmount completes.
+  Seven inode-table unit tests; one `#[ignore]`-by-default
+  integration test that mounts a 3-file CAS-backed tree and
+  asserts exactly two CAS fetches when only two files are
+  opened. New `/dev/fuse accessible` host probe surfaced
+  through the existing `worker --check-host`.
+
+### Decisions locked in before coding
+
+- **Crate placement:** `brokkr-worker/src/fuse.rs`. Keeps
+  `brokkr-cas` portable (CLI builds on macOS/Windows); the
+  FUSE thread lives with the runtime that owns the action
+  lifecycle anyway. `brokkr-cas` is consumed via the `Cas`
+  trait only — no inverse dep.
+- **Tokio ↔ fuser bridge:** dedicated OS thread runs
+  `fuser::spawn_mount2`; in-callback async fetches use
+  `Handle::block_on` with a per-mount bounded `Semaphore`.
+  Rejected: a fully-sync CAS façade (would force every CAS
+  caller to grow a sync method), or `tokio::task::spawn` per
+  callback (kernel waits on a sync return — we'd have to
+  block-park anyway).
+- **Mount ownership:** `InputMount` is an RAII handle in the
+  job runner. Drop unmounts with a 5 s join then
+  `fusermount -uz` fallback. The job dir is rm-rf'd by the
+  worker after drop, not by the mount itself — keeps the
+  mount module from depending on workspace layout.
+- **Host probe lives in `brokkr-sandbox::checks::linux`** as
+  `fuse_device`. Three outcomes: `Pass` / `Warn` (WSL
+  permission case) / `Fail` (no `/dev/fuse`). Surfaced via
+  the existing `worker --check-host` flag — no new CLI
+  surface.
+- **Concurrency cap default:** 16 concurrent CAS fetches per
+  mount. Justification: typical action opens hundreds of
+  files but only a handful are large; we want a runaway
+  action with `for f in *.o; do cat $f & done` to throttle,
+  not the worker.
+- **Cache scope:** per-action `cache_dir`, rm-rf'd on drop.
+  No intra-action eviction — the action is the natural unit.
+
+### What surprised me
+
+- **`BackgroundSession::join()` alone hangs forever.** The
+  obvious shape was "drop the handle → call `join()` to wait
+  for the bg thread → done." It deadlocks. fuser's bg loop
+  only exits when its `/dev/fuse` fd is closed by the
+  unmount; the unmount only fires from
+  `BackgroundSession::Drop`'s `UmountOnDrop`. Calling `join`
+  consumes the BackgroundSession but leaves the inner
+  `UmountOnDrop` un-dropped until `join` returns — which
+  never happens because the loop is still reading.
+  `umount_and_join()` is the right primitive: it explicitly
+  `take`s the Mount cookie and umounts before joining. Even
+  with that, on a busy or misbehaving mount the call can
+  hang, so the Drop wraps the whole sequence in a 5 s
+  timeout via a helper thread + `mpsc::recv_timeout`, with
+  `fusermount -uz` as the lazy-detach fallback. That matches
+  what the M6b plan promised and survives the kernel
+  deciding to be slow.
+- **The fuser 0.17 trait signatures use wrapper newtypes
+  (`INodeNo`, `FileHandle`, `OpenFlags`, `LockOwner`,
+  `Errno`), not raw `u64` / `i32`.** Eyeballing the docs
+  example was misleading because the rendered HTML hides the
+  newtype boundaries. `cargo build`'s "expected signature"
+  diagnostic was the fastest way to converge — once one
+  callback matched, the rest fell into place by pattern.
+- **`fuser::Config` is `#[non_exhaustive]`,** so the
+  `Config { mount_options, ..Default::default() }` shape
+  doesn't compile cross-crate. Had to spell it out as
+  `Config::default()` + field assignment. Minor but
+  surprising — the rustdoc doesn't flag the attribute
+  obviously.
+- **Mounting on WSL2 worked first try.** `/dev/fuse` is
+  `crw-rw-rw-` on the WSL2 image I'm using; the
+  `fuse_device` probe reports `Pass` and `spawn_mount2`
+  succeeds without root. The `Warn` branch is there for
+  hardened distros where the device is 0600 root:root —
+  haven't been able to hit that path locally yet, will
+  exercise it via CI matrix later.
+- **The `clippy.toml` `disallowed_methods` rule fires inside
+  `#[cfg(test)]` modules** unless explicitly allowed. The
+  M5b/M6a tests already had the right four-attribute incantation
+  (`clippy::unwrap_used, clippy::expect_used,
+  clippy::disallowed_methods, clippy::panic`); copy-pasted
+  it here. Worth a meta-note: the project's lint set is
+  strict enough that any test module that uses `unwrap` /
+  `panic!` needs the full block.
+- **mmap of cache files survives the unmount in the right
+  direction.** I was worried the cache mmaps (which point at
+  files in a separate directory, not on the FUSE mount)
+  might keep the FUSE thread alive. They don't — the FUSE
+  thread holds `BrokkrFs` which holds the `Arc<Mmap>` slots,
+  and the whole `BrokkrFs` goes away when the bg thread
+  exits. The Drop's "unmount first, then rm-rf the cache"
+  ordering is still right because the kernel might be
+  servicing a final `read` callback that's mid-mmap when
+  unmount lands.

--- a/docs/phase-3-plan.md
+++ b/docs/phase-3-plan.md
@@ -387,6 +387,207 @@ filesystem from inside the sandbox.
 `-EIO` to the kernel and the action sees a read error. We surface
 this in the worker log and in the ActionResult's `stderr_raw`.
 
+#### 5.5.1 M6b — FUSE sub-plan
+
+M6a (committed in 407f88a) gave us the eager-copy fallback
+(`brokkr-cas::tree::materialize_tree`). M6b layers the FUSE
+filesystem on top so multi-GiB input trees mount in ~ms and
+only the bytes the action actually reads transfer from CAS.
+This sub-plan freezes the design choices that §5.5 left open.
+
+**Crate placement.** The FUSE filesystem lives in
+`crates/brokkr-worker/src/fuse.rs`, **not** in `brokkr-cas`.
+Rationale: `brokkr-cas` must stay portable (it compiles on
+macOS / Windows for the CLI), `fuser` is Linux-only at
+runtime, and the mount lifecycle is owned by the worker per
+action. The filesystem depends on `brokkr-cas` for the
+`Cas` trait and the `Directory` walk; no inverse dep.
+
+**Public surface.**
+
+```rust
+// brokkr-worker/src/fuse.rs
+
+/// A live FUSE mount for one action's input tree.
+/// Dropping the handle unmounts and joins the background
+/// fuser thread (with a bounded timeout, then `fusermount -uz`).
+pub struct InputMount {
+    mountpoint: PathBuf,
+    cache_dir:  PathBuf,
+    _bg: JoinHandle<()>,
+    // ... unmount sentinel ...
+}
+
+pub struct InputMountSpec {
+    pub root_digest: Digest,
+    pub mountpoint:  PathBuf,    // /var/lib/brokkr/work/<job>/inputs
+    pub cache_dir:   PathBuf,    // /var/lib/brokkr/work/<job>/cache
+}
+
+pub async fn mount(
+    cas: Arc<dyn Cas>,
+    spec: InputMountSpec,
+) -> Result<InputMount, MountError>;
+```
+
+`mount()` is `async` because it pre-fetches the full
+`Directory` Merkle DAG (small — only proto bytes, no file
+content) before returning, so the kernel's first `readdir`
+hits an in-memory tree. File content is fetched lazily.
+
+**Inode table.** Walking the DAG builds a `Vec<Inode>` keyed
+by `ino: u64` (starting at `FUSE_ROOT_ID = 1`). Each inode
+carries:
+
+```rust
+enum InodeKind {
+    Dir   { entries: HashMap<OsString, u64> /* name -> child ino */ },
+    File  { digest: Digest, size: u64, exec: bool,
+            cached: OnceCell<PathBuf> },
+    Link  { target: OsString },
+}
+```
+
+Symlink targets are returned verbatim from `readlink` (REAPI
+v2 §SymlinkNode). The DAG is finite and acyclic by
+construction (digests-as-IDs); no cycle detection.
+
+**Lazy fetch on `read`.** First `read` for a file inode
+fetches the whole blob from CAS into
+`<cache_dir>/<hex(digest)>`, then `mmap`s it. `OnceCell`
+serializes the fetch — concurrent kernel reads of the same
+inode wait on the first fetcher rather than racing N
+duplicate CAS round-trips. `read` then serves from the
+mmap. We `fadvise(WILLNEED)` after mmap and
+`fadvise(DONTNEED)` on `InputMount::drop` (§9 risk:
+"memory-mapped FUSE backing files can survive umount").
+
+**Tokio / fuser bridge.** `fuser::spawn_mount2` runs on a
+dedicated OS thread (it loops on the `/dev/fuse` fd
+synchronously). Lazy fetches inside FUSE callbacks need
+async CAS calls — we hold a `tokio::runtime::Handle` and use
+`handle.block_on(cas.get(&digest))` from the FUSE thread. A
+shared `Arc<dyn Cas>` and a bounded `Semaphore` (default 16)
+cap per-mount concurrent fetches so a runaway action can't
+starve the worker's runtime.
+
+**Mount lifecycle.** Owned by the worker, one mount per
+running action. The job-runner sequence becomes:
+
+```
+1. resolve action.input_root_digest
+2. let mount = fuse::mount(cas, spec).await?
+3. update RootfsSpec.ro_binds with mount.mountpoint -> /work/inputs
+4. run sandbox (existing Phase 2 path)
+5. drop(mount)   // unmount + cleanup happens here
+```
+
+The drop guard uses `fuser`'s `BackgroundSession::join()` with
+a 5 s timeout; on timeout we shell out to `fusermount -uz`
+(lazy unmount) and log a warning. The job dir is rm-rf'd
+afterwards.
+
+**Sandbox interaction.** The mount path is a regular
+filesystem from inside the sandbox — no FUSE awareness in
+`brokkr-sandbox`. The bind is `MS_BIND | MS_REC | MS_RDONLY`,
+same as any other ro input bind. The sandbox's mount
+namespace is created after the FUSE mount is live, so the
+FUSE fd belongs to the worker, not the sandbox.
+
+**Host probe.** `brokkr-sandbox::checks::linux` gains a
+`fuse_device` probe:
+
+| Outcome | Trigger |
+|---|---|
+| `Pass` | `/dev/fuse` exists, readable, writable. |
+| `Warn` | `/dev/fuse` exists but worker uid lacks rw (e.g. WSL default). Hint: `sudo chmod 666 /dev/fuse` or add user to `fuse` group. |
+| `Fail` | `/dev/fuse` missing (no `fuse` kernel module). Hint: `sudo modprobe fuse` (WSL2) or kernel rebuild. |
+
+This is surfaced through the existing `worker --check-host`
+flag — no new flag.
+
+**Failure shapes.** New `MountError` enum, `thiserror`:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum MountError {
+    #[error("FUSE device unavailable: {0}")]
+    Device(String),                       // -> /dev/fuse missing/eperm
+    #[error("mount syscall failed: {0}")]
+    Mount(std::io::Error),
+    #[error("input tree walk failed: {0}")]
+    Tree(#[from] brokkr_cas::CasError),
+    #[error("mountpoint not empty: {0}")]
+    Dirty(PathBuf),
+}
+```
+
+`-EIO` is returned to the kernel for any in-flight `read`
+failure, and the underlying `CasError` is logged with the
+mount's `tracing` span (`fuse.mount=<path>, action=<id>`).
+
+**Testing strategy.**
+
+- **Unit tests, no FUSE.** The inode table builder
+  (`Directory` proto → `Vec<Inode>`) is pure; tested in
+  isolation against five fixtures (empty / flat / nested /
+  exec-bit / symlink) shared with M6a.
+- **Integration test, `#[cfg(target_os = "linux")]` +
+  `#[ignore]` by default.** Mounts a synthetic 3-file tree
+  against `InMemoryCas`, opens & reads each file, asserts
+  byte equality, drops the handle, asserts the mountpoint is
+  empty. Gated on `/dev/fuse` accessibility (skip with a
+  log line otherwise — same shape as the existing sandbox
+  tests).
+- **Lazy-fetch assertion.** A wrapping `CountingCas` records
+  every `get(digest)`; the test reads two of three files
+  and asserts `get` was called exactly twice.
+- **Soak hook for M7.** The three-node soak adds a 5 GiB
+  synthetic tree and asserts mount time `< 100 ms` and
+  measured CAS bytes transferred ≈ bytes-read-by-action.
+
+**New deps.**
+
+- `fuser = "0.15"` — actively maintained pure-Rust FUSE
+  bindings, used by major projects (rust-fuse fork). License
+  MIT. Optional `unprivileged` feature off by default; we
+  use the privileged path.
+- `memmap2 = "0.9"` — already in the tree? If not, justify
+  as the obvious choice for `mmap` wrappers (BSD license,
+  widely vendored).
+
+**Out of scope for M6b** (explicit, to prevent creep):
+
+- Output-tree FUSE (upload-on-`close`). Outputs stay
+  materialised to local disk and walked by `build_tree_into`.
+- macOS / FUSE-T support. `#[cfg(target_os = "linux")]`
+  gates the entire module; non-Linux workers panic on
+  `mount()` with a clear error. Phase 6 can revisit.
+- Read-ahead / speculative prefetch (deferred per §1.2).
+- Per-file LRU eviction of the cache. The cache lives for
+  the lifetime of one action and is rm-rf'd on `Drop` — no
+  intra-action eviction.
+
+**Definition of done for M6b.**
+
+1. `fuse::mount(spec)` returns a live `InputMount` in
+   < 100 ms for a tree with up to 10k entries (DAG walk,
+   no file fetches).
+2. Reading a 1 MiB file through the mount produces exactly
+   one CAS `get` for that digest; re-reading the same file
+   produces zero further `get`s.
+3. Dropping the `InputMount` unmounts cleanly within 5 s on
+   the happy path; falls back to `fusermount -uz` and logs
+   on timeout.
+4. `worker --check-host` reports a `fuse_device` line and
+   exits non-zero on `Fail`.
+5. `cargo clippy --workspace --all-targets -- -D warnings`
+   clean; new tests green on Linux; non-Linux compile
+   succeeds (module is `cfg`-gated, with a stub returning
+   `MountError::Device("not linux")`).
+6. CHANGELOG `## Unreleased` entry; rustdoc on public
+   surface; tracing span on `mount()` and per-`read`.
+
 ### 5.6 Garbage collection
 
 **Reachability.** A blob is reachable if any of:
@@ -537,8 +738,9 @@ REAPI protos are unchanged — `ContentAddressableStorage` and
 | M3 | `feat/phase3-tiered-storage`                 | Hot / warm / cold tiers composed via `TieredStore`; OpenDAL behind a feature flag for the cold tier; tier-promotion tests. | ~800 |
 | M4 | `feat/phase3-replication`                    | Quorum write + read fan-out across replicas; partial-failure tests; the existing single-node CAS becomes a `R=1` special case. | ~700 |
 | M5 | `feat/phase3-peer-repair-and-gc`             | `CasPeer.Replicate` for async catch-up; `brokk admin gc` subcommand + control-plane GC daemon.       | ~700     |
-| M6 | `feat/phase3-fuse-input-materialization`     | FUSE input mount in the worker; lazy fetch; sandbox bind-in of the mount; integration test.        | ~800     |
-| M7 | `feat/phase3-three-node-soak-and-journal`    | Three-node soak test (M3 §7.3); Phase 3 journal retrospective; plan updates.                       | ~250     |
+| M6a | `feat/phase3-tree-materialization`          | Eager `materialize_tree` / `build_tree_into` in `brokkr-cas`: REAPI `Directory` ↔ on-disk tree, files/dirs/symlinks/exec-bit, six unit tests. Foundation for M6b. | ~450 |
+| M6b | `feat/phase3-fuse-input-materialization`    | FUSE input mount in the worker via `fuser`; lazy fetch on first `read(2)`; per-action mount lifecycle; `--check-host` FUSE probe; integration test.            | ~750 |
+| M7  | `feat/phase3-three-node-soak-and-journal`   | Three-node soak test (M3 §7.3); Phase 3 journal retrospective; plan updates.                       | ~250     |
 
 Total: ~4.4k lines including tests.
 


### PR DESCRIPTION
## Summary

- Lazy-fetch FUSE input mount in `brokkr-worker::fuse`. A worker action sees its input tree as a userspace filesystem; file content transfers from CAS only on first `read(2)` and is mmapped locally for the lifetime of the action.
- `/dev/fuse accessible` host probe added to `brokkr-sandbox::checks::linux`, surfaced through the existing `brokkr-worker --check-host`.
- Plan + journal updates: `docs/phase-3-plan.md` §5.5.1 (M6b sub-plan) and §8 (M6 split into M6a / M6b); `docs/journal/phase-3.md` M6b retrospective.

Implements Phase 3 M6b per `docs/phase-3-plan.md`. Builds on M6a (#58, `brokkr-cas::tree::materialize_tree`); the eager-copy path stays available as a fallback.

## What changed

**`brokkr-worker::fuse`** (new module, split into two layers)

- `fuse::inode::InodeTable` — pure, platform-independent. Walks a REAPI `Directory` Merkle DAG into a path-resolvable inode map. One CAS read per directory proto, zero file fetches.
- `fuse::mount::mount(cas, InputMountSpec)` — Linux-only. Spawns a `fuser::BackgroundSession` whose `Filesystem` impl serves `lookup` / `getattr` / `readdir` / `readlink` from the inode table and resolves `read` via a per-inode `tokio::sync::OnceCell<Arc<Mmap>>`, so concurrent reads of the same file coalesce into one fetch. Per-mount `tokio::sync::Semaphore(16)` caps concurrent CAS round-trips.
- `fuse::mount::InputMount` — RAII handle. Drop unmounts via `umount_and_join` wrapped in a 5 s helper-thread timeout, with `fusermount -uz` lazy-detach as the fallback; the per-action cache directory is rm-rf'd after the unmount completes.
- Non-Linux hosts get a compile-time stub (`fuse::mount::MountError::Unsupported`) so the CLI/SDK build stays portable.

**Host probe**

- `brokkr-sandbox::checks::linux::fuse_device` with three outcomes: `Pass`, `Warn` (present-but-not-rw — WSL2's default), `Fail` (missing kernel module). Does not break sandbox functionality when a worker won't use FUSE.

**Dependencies**

- `fuser = "0.17"` and `memmap2 = "0.9"` added as workspace deps, scoped to `cfg(target_os = "linux")` on `brokkr-worker` only. Both are mainstream, MIT-licensed crates with active maintenance.

**Docs**

- `docs/phase-3-plan.md` §5.5.1 — new M6b sub-plan section locks in crate placement, tokio↔fuser bridge model, mount lifecycle, host probe shape, fetch concurrency default, cache scope, and the six-point definition of done.
- `docs/phase-3-plan.md` §8 — M6 row split into M6a (already shipped, #58) and M6b (this PR).
- `docs/journal/phase-3.md` — M6b retrospective: decisions, what shipped, what surprised me.
- `CHANGELOG.md` — Phase 3 Unreleased entry.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all existing tests + 7 new inode-table unit tests, integration test correctly `#[ignore]`-skipped by default
- [x] `cargo test -p brokkr-worker --test fuse_lazy_fetch -- --ignored` — mounts a 3-file CAS-backed tree via real `/dev/fuse`, reads two of three files plus a second read of the first, asserts exactly two file-content fetches reach CAS. Passes in 0.05s on WSL2; no orphan mounts left behind.
- [x] `cargo build -p brokkr-worker` — verified non-Linux stub compiles via the cfg-gated `mount` module structure (Linux file present, non-Linux inline stub returns `Unsupported`)
- [ ] CI matrix to exercise the `Warn` and `Fail` branches of the `fuse_device` probe (the WSL2 host I'm developing on has `/dev/fuse` at `crw-rw-rw-`, so the probe always reports `Pass` locally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added FUSE filesystem mounting capability with on-demand file content fetching from the content store.
  * Added host check for `/dev/fuse` accessibility with pass/warn/fail outcomes.

* **Documentation**
  * Updated Phase 3 plan and journal with implementation details and design decisions.
  * Added changelog entries documenting new functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jackthepunished/brokkr/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->