### PR TITLE
feat: add mTLS authentication support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +478,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixedbitset"
@@ -1240,6 +1256,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1280,50 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1343,6 +1417,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1389,6 +1469,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1478,6 +1564,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1523,8 +1619,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -1689,6 +1787,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf8parse"
@@ -2032,6 +2136,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ futures = "0.3"
 async-trait = "0.1"
 
 # RPC / proto
-tonic = "0.12"
+tonic = { version = "0.12", features = ["tls"] }
 tonic-build = "0.12"
 prost = "0.13"
 prost-types = "0.13"

--- a/crates/brokkr-cli/src/main.rs
+++ b/crates/brokkr-cli/src/main.rs
@@ -4,7 +4,7 @@
 //! end-to-end happy path.
 
 use anyhow::{anyhow, Context, Result};
-use brokkr_sdk::{run_command, BrokkrClient};
+use brokkr_sdk::{run_command, BrokkrClient, TlsConfig};
 use clap::{Parser, Subcommand};
 
 /// Top-level CLI entrypoint.
@@ -41,6 +41,18 @@ enum Command {
         #[arg(long)]
         no_cache: bool,
 
+        /// CA certificate for verifying the control plane server certificate.
+        #[arg(long)]
+        tls_ca: Option<String>,
+
+        /// Client certificate for mTLS authentication (requires --tls-client-key).
+        #[arg(long, requires = "tls_client_key")]
+        tls_client_cert: Option<String>,
+
+        /// Client private key for mTLS authentication (requires --tls-client-cert).
+        #[arg(long, requires = "tls_client_cert")]
+        tls_client_key: Option<String>,
+
         /// The command to run, including arguments. Pass via repeated
         /// positional args: `brokk run -- echo hello world`.
         #[arg(trailing_var_arg = true, required = true)]
@@ -63,8 +75,18 @@ fn main() -> Result<()> {
         Command::Run {
             control,
             no_cache,
+            tls_ca,
+            tls_client_cert,
+            tls_client_key,
             argv,
-        } => run_subcmd(control, no_cache, argv),
+        } => run_subcmd(
+            control,
+            no_cache,
+            tls_ca,
+            tls_client_cert,
+            tls_client_key,
+            argv,
+        ),
     }
 }
 
@@ -151,13 +173,40 @@ pub fn init_project(force: bool) -> Result<()> {
     Ok(())
 }
 
-fn run_subcmd(control: String, no_cache: bool, argv: Vec<String>) -> Result<()> {
+fn run_subcmd(
+    control: String,
+    no_cache: bool,
+    tls_ca: Option<String>,
+    tls_client_cert: Option<String>,
+    tls_client_key: Option<String>,
+    argv: Vec<String>,
+) -> Result<()> {
     if argv.is_empty() {
         return Err(anyhow!("`brokk run` requires a command"));
     }
+
+    // Runtime validation: partial mTLS identity is an error.
+    let has_cert = tls_client_cert.is_some();
+    let has_key = tls_client_key.is_some();
+    if has_cert != has_key {
+        anyhow::bail!("both --tls-client-cert and --tls-client-key must be provided together");
+    }
+    if (has_cert || has_key) && tls_ca.is_none() {
+        anyhow::bail!("--tls-client-cert and --tls-client-key require --tls-ca to be provided");
+    }
+
+    let tls = tls_ca.map(|ca| TlsConfig {
+        ca_cert: std::path::PathBuf::from(ca),
+        client_cert: tls_client_cert.map(std::path::PathBuf::from),
+        client_key: tls_client_key.map(std::path::PathBuf::from),
+    });
+
     let rt = tokio::runtime::Runtime::new().context("starting tokio runtime")?;
     rt.block_on(async {
-        let mut client = BrokkrClient::connect(control).await?;
+        let mut client = match &tls {
+            Some(tls_cfg) => BrokkrClient::connect_with_tls(control, tls_cfg.clone()).await?,
+            None => BrokkrClient::connect(control).await?,
+        };
         let outcome = run_command(&mut client, &argv, no_cache).await?;
         // Forward stdout/stderr verbatim to the user's terminal.
         use std::io::Write as _;

--- a/crates/brokkr-control/src/main.rs
+++ b/crates/brokkr-control/src/main.rs
@@ -18,6 +18,7 @@ use brokkr_proto::reapi_v2::{
 };
 use clap::Parser;
 use tonic::transport::Server;
+use tonic::transport::ServerTlsConfig;
 
 #[derive(Debug, Parser)]
 #[command(
@@ -33,6 +34,51 @@ struct Args {
     /// Directory holding the control plane's persistent state (CAS + action cache).
     #[arg(long, default_value = "./brokkr-data")]
     data_dir: PathBuf,
+
+    /// TLS server certificate (PEM-encoded).
+    #[arg(long, requires = "tls_key")]
+    tls_cert: Option<PathBuf>,
+
+    /// TLS private key (PEM-encoded).
+    #[arg(long, requires = "tls_cert")]
+    tls_key: Option<PathBuf>,
+
+    /// CA certificate for verifying client certificates (mTLS).
+    #[arg(long, requires_all = ["tls_cert", "tls_key"])]
+    tls_client_ca: Option<PathBuf>,
+}
+
+impl Args {
+    /// Build server TLS configuration from CLI arguments.
+    fn tls_config(&self) -> Result<Option<ServerTlsConfig>> {
+        let has_server_cert = self.tls_cert.is_some();
+        let has_server_key = self.tls_key.is_some();
+        let has_client_ca = self.tls_client_ca.is_some();
+
+        // Reject inconsistent combinations.
+        if has_client_ca && (!has_server_cert || !has_server_key) {
+            anyhow::bail!("--tls-client-ca requires --tls-cert and --tls-key to be provided");
+        }
+
+        let (Some(tls_cert), Some(tls_key)) = (&self.tls_cert, &self.tls_key) else {
+            return Ok(None);
+        };
+        let cert_pem = std::fs::read(tls_cert).context("reading tls_cert")?;
+        let key_pem = std::fs::read(tls_key).context("reading tls_key")?;
+        let identity = tonic::transport::Identity::from_pem(cert_pem, key_pem);
+
+        let mut cfg = ServerTlsConfig::new().identity(identity);
+
+        // mTLS requires client CA root.
+        if let Some(ca_path) = &self.tls_client_ca {
+            let ca_pem = std::fs::read(ca_path).context("reading tls_client_ca")?;
+            cfg = cfg.client_ca_root(tonic::transport::Certificate::from_pem(ca_pem));
+        } else {
+            tracing::warn!("starting without client certificate verification (mTLS disabled)");
+        }
+
+        Ok(Some(cfg))
+    }
 }
 
 #[tokio::main]
@@ -55,9 +101,23 @@ async fn main() -> Result<()> {
     );
     let scheduler = Scheduler::new(cas.clone(), action_cache.clone());
 
+    let tls_cfg = args.tls_config()?;
+    match &tls_cfg {
+        Some(_) => {
+            tracing::warn!("TLS ENABLED — mTLS required for production");
+        }
+        None => {
+            tracing::warn!("TLS DISABLED — NOT FOR PRODUCTION USE");
+        }
+    }
+
     tracing::info!(addr = %args.listen, data_dir = ?args.data_dir, "brokkr-control starting");
 
-    Server::builder()
+    let mut server = Server::builder();
+    if let Some(tls_cfg) = tls_cfg {
+        server = server.tls_config(tls_cfg)?;
+    }
+    server
         .add_service(ContentAddressableStorageServer::new(CasService::new(cas)))
         .add_service(ActionCacheServer::new(ActionCacheService::new(
             action_cache,

--- a/crates/brokkr-control/tests/common/mod.rs
+++ b/crates/brokkr-control/tests/common/mod.rs
@@ -70,6 +70,7 @@ pub async fn boot_cluster() -> (String, tempfile::TempDir) {
             control_endpoint: worker_endpoint,
             hostname: "test-worker".to_string(),
             runner: Runner::Plain,
+            tls: None,
         };
         let _ = run_worker(cfg).await;
     });

--- a/crates/brokkr-sdk/src/client.rs
+++ b/crates/brokkr-sdk/src/client.rs
@@ -1,6 +1,8 @@
 //! High-level Brokkr client. Wraps REAPI's CAS + Execution into a single
 //! "run this command" call.
 
+use std::path::PathBuf;
+
 use anyhow::{anyhow, Context, Result};
 use brokkr_proto::reapi_v2::{
     self as rapi, action_cache_client::ActionCacheClient, batch_update_blobs_request as bur,
@@ -10,7 +12,36 @@ use brokkr_proto::reapi_v2::{
 use bytes::Bytes;
 use prost::Message;
 use sha2::{Digest as _, Sha256};
+use thiserror::Error;
 use tonic::transport::{Channel, Endpoint};
+
+/// TLS configuration for a [`BrokkrClient`] connection.
+#[derive(Debug, Clone)]
+pub struct TlsConfig {
+    /// CA certificate to verify the server certificate.
+    pub ca_cert: PathBuf,
+    /// Client certificate for client authentication (mTLS).
+    pub client_cert: Option<PathBuf>,
+    /// Client private key for client authentication (mTLS).
+    pub client_key: Option<PathBuf>,
+}
+
+/// Errors that can occur when connecting a [`BrokkrClient`].
+#[derive(Debug, Error)]
+pub enum ClientError {
+    /// The endpoint URL is invalid.
+    #[error("invalid endpoint: {0}")]
+    InvalidEndpoint(String),
+    /// Reading a certificate or key file failed.
+    #[error("reading TLS certificate: {0}")]
+    CertificateRead(#[from] std::io::Error),
+    /// TLS configuration is invalid.
+    #[error("TLS configuration: {0}")]
+    TlsConfig(String),
+    /// Transport-level error connecting to the server.
+    #[error("transport error: {0}")]
+    Transport(#[from] tonic::transport::Error),
+}
 
 /// Client connection to a Brokkr control plane.
 #[derive(Clone)]
@@ -25,19 +56,88 @@ impl BrokkrClient {
     /// Connect to the control plane at `endpoint` (e.g.
     /// `http://127.0.0.1:7878`).
     #[tracing::instrument(name = "client::connect", skip(endpoint))]
-    pub async fn connect(endpoint: impl Into<String>) -> Result<Self> {
+    pub async fn connect(endpoint: impl Into<String>) -> Result<Self, ClientError> {
         let endpoint = endpoint.into();
         let channel = Endpoint::from_shared(endpoint.clone())
-            .with_context(|| format!("invalid endpoint {endpoint:?}"))?
+            .map_err(|e| {
+                ClientError::InvalidEndpoint(format!("invalid endpoint {endpoint:?}: {e}"))
+            })?
             .connect()
             .await
-            .context("connecting to control plane")?;
+            .map_err(ClientError::Transport)?;
         Ok(Self {
             cas: ContentAddressableStorageClient::new(channel.clone()),
             exec: ExecutionClient::new(channel.clone()),
             ac: ActionCacheClient::new(channel),
         })
     }
+
+    /// Connect to the control plane at `endpoint` with mTLS authentication.
+    #[tracing::instrument(name = "client::connect_with_tls", skip(endpoint, tls_cfg))]
+    pub async fn connect_with_tls(
+        endpoint: impl Into<String>,
+        tls_cfg: TlsConfig,
+    ) -> Result<Self, ClientError> {
+        let channel = connect_tls(endpoint, &tls_cfg).await?;
+        Ok(Self {
+            cas: ContentAddressableStorageClient::new(channel.clone()),
+            exec: ExecutionClient::new(channel.clone()),
+            ac: ActionCacheClient::new(channel),
+        })
+    }
+}
+
+/// Establish a TLS channel to the control plane.
+async fn connect_tls(
+    endpoint: impl Into<String>,
+    tls_cfg: &TlsConfig,
+) -> Result<Channel, ClientError> {
+    use tonic::transport::ClientTlsConfig;
+
+    let endpoint = endpoint.into();
+
+    // Reject partial client identity: one of cert/key without the other.
+    match (&tls_cfg.client_cert, &tls_cfg.client_key) {
+        (Some(_), None) | (None, Some(_)) => {
+            return Err(ClientError::TlsConfig(
+                "both client_cert and client_key must be provided for client identity".to_string(),
+            ));
+        }
+        _ => {}
+    }
+
+    let endpoint = Endpoint::from_shared(endpoint.clone())
+        .map_err(|e| ClientError::InvalidEndpoint(format!("invalid endpoint {endpoint:?}: {e}")))?;
+
+    let ca_pem = tokio::fs::read(&tls_cfg.ca_cert)
+        .await
+        .map_err(ClientError::CertificateRead)?;
+    let tls_config =
+        ClientTlsConfig::new().ca_certificate(tonic::transport::Certificate::from_pem(ca_pem));
+
+    // If client identity is provided, add it to the TLS config.
+    let tls_config = match (&tls_cfg.client_cert, &tls_cfg.client_key) {
+        (Some(cert_path), Some(key_path)) => {
+            let cert_pem = tokio::fs::read(cert_path)
+                .await
+                .map_err(ClientError::CertificateRead)?;
+            let key_pem = tokio::fs::read(key_path)
+                .await
+                .map_err(ClientError::CertificateRead)?;
+            let identity = tonic::transport::Identity::from_pem(cert_pem, key_pem);
+            tls_config.identity(identity)
+        }
+        _ => tls_config,
+    };
+
+    let channel = endpoint
+        .tls_config(tls_config)
+        .map_err(ClientError::Transport)?
+        .connect()
+        .await
+        .map_err(ClientError::Transport)?;
+
+    Ok(channel)
 }
 
 /// Outcome of [`run_command`].

--- a/crates/brokkr-sdk/src/lib.rs
+++ b/crates/brokkr-sdk/src/lib.rs
@@ -7,4 +7,4 @@
 
 pub mod client;
 
-pub use client::{run_command, BrokkrClient, RunOutcome};
+pub use client::{run_command, BrokkrClient, ClientError, RunOutcome, TlsConfig};

--- a/crates/brokkr-worker/src/lib.rs
+++ b/crates/brokkr-worker/src/lib.rs
@@ -11,4 +11,4 @@ pub mod runner;
 pub mod worker;
 
 pub use runner::{default_rootfs, Runner, SandboxRunner, SandboxTemplate};
-pub use worker::{run_worker, WorkerConfig};
+pub use worker::{run_worker, TlsConfig, WorkerConfig};

--- a/crates/brokkr-worker/src/main.rs
+++ b/crates/brokkr-worker/src/main.rs
@@ -5,7 +5,7 @@ use std::process::ExitCode;
 
 use anyhow::{anyhow, Result};
 use brokkr_sandbox::{checks, ResourceLimits, Sandbox};
-use brokkr_worker::{run_worker, Runner, SandboxRunner, SandboxTemplate, WorkerConfig};
+use brokkr_worker::{run_worker, Runner, SandboxRunner, SandboxTemplate, TlsConfig, WorkerConfig};
 use clap::Parser;
 
 #[derive(Debug, Parser)]
@@ -53,6 +53,18 @@ struct Args {
     /// Default per-action `pids.max`. `0` = unlimited.
     #[arg(long)]
     sandbox_pids_max: Option<u64>,
+
+    /// CA certificate for verifying the control plane server certificate.
+    #[arg(long)]
+    ca: Option<PathBuf>,
+
+    /// Client certificate for mTLS authentication (requires --client-key).
+    #[arg(long, requires = "client_key")]
+    client_cert: Option<PathBuf>,
+
+    /// Client private key for mTLS authentication (requires --client-cert).
+    #[arg(long, requires = "client_cert")]
+    client_key: Option<PathBuf>,
 }
 
 fn main() -> ExitCode {
@@ -83,11 +95,24 @@ fn main() -> ExitCode {
 }
 
 async fn run_daemon(args: Args) -> Result<()> {
+    let has_client_creds = args.client_cert.is_some() || args.client_key.is_some();
+    if has_client_creds && args.ca.is_none() {
+        anyhow::bail!("--client-cert and --client-key require --ca to be provided");
+    }
     let runner = build_runner(&args)?;
+    let tls = match (&args.ca, &args.client_cert, &args.client_key) {
+        (Some(ca), cert, key) => Some(TlsConfig {
+            ca_cert: ca.clone(),
+            client_cert: cert.clone(),
+            client_key: key.clone(),
+        }),
+        _ => None,
+    };
     let cfg = WorkerConfig {
         control_endpoint: args.control,
         hostname: hostname_or("worker".to_string()),
         runner,
+        tls,
     };
     run_worker(cfg).await
 }

--- a/crates/brokkr-worker/src/worker.rs
+++ b/crates/brokkr-worker/src/worker.rs
@@ -1,6 +1,8 @@
 //! Worker control loop: register, open the bidi stream, then for each job
 //! received run the command and report the result.
 
+use std::path::PathBuf;
+
 use anyhow::{anyhow, Context, Result};
 use brokkr_common::WorkerId;
 use brokkr_proto::brokkr_v1::{
@@ -17,6 +19,17 @@ use tonic::transport::{Channel, Endpoint};
 
 use crate::runner::{proto_digest, run_command, RunOutcome, Runner};
 
+/// TLS configuration for connecting to the control plane.
+#[derive(Debug, Clone)]
+pub struct TlsConfig {
+    /// CA certificate to verify the server certificate.
+    pub ca_cert: PathBuf,
+    /// Client certificate for client authentication (mTLS).
+    pub client_cert: Option<PathBuf>,
+    /// Client private key for client authentication (mTLS).
+    pub client_key: Option<PathBuf>,
+}
+
 /// Worker daemon configuration.
 #[derive(Debug, Clone)]
 pub struct WorkerConfig {
@@ -30,6 +43,8 @@ pub struct WorkerConfig {
     /// (`brokkr-worker`) overrides this to [`Runner::Sandboxed`]
     /// unless `--no-sandbox` is passed.
     pub runner: Runner,
+    /// TLS configuration for connecting to the control plane.
+    pub tls: Option<TlsConfig>,
 }
 
 impl Default for WorkerConfig {
@@ -38,19 +53,69 @@ impl Default for WorkerConfig {
             control_endpoint: "http://127.0.0.1:7878".to_string(),
             hostname: "worker".to_string(),
             runner: Runner::Plain,
+            tls: None,
         }
     }
+}
+
+/// Build a gRPC channel to the control plane, optionally with TLS.
+async fn build_channel(endpoint: String, tls: Option<&TlsConfig>) -> Result<Channel> {
+    let endpoint = Endpoint::from_shared(endpoint.clone())
+        .with_context(|| format!("invalid endpoint {:?}", endpoint))?;
+
+    let channel = match tls {
+        Some(tls_cfg) => {
+            use tonic::transport::ClientTlsConfig;
+
+            let ca_pem = tokio::fs::read(&tls_cfg.ca_cert)
+                .await
+                .context("reading CA certificate")?;
+            let tls_config = ClientTlsConfig::new()
+                .ca_certificate(tonic::transport::Certificate::from_pem(ca_pem));
+
+            let tls_config = match (&tls_cfg.client_cert, &tls_cfg.client_key) {
+                (Some(_), None) | (None, Some(_)) => {
+                    anyhow::bail!(
+                        "both client_cert and client_key must be provided together for mTLS; \
+                         got client_cert={:?}, client_key={:?}",
+                        tls_cfg.client_cert,
+                        tls_cfg.client_key
+                    );
+                }
+                (Some(cert_path), Some(key_path)) => {
+                    let cert_pem = tokio::fs::read(cert_path)
+                        .await
+                        .context("reading client certificate")?;
+                    let key_pem = tokio::fs::read(key_path)
+                        .await
+                        .context("reading client key")?;
+                    let identity = tonic::transport::Identity::from_pem(cert_pem, key_pem);
+                    tls_config.identity(identity)
+                }
+                _ => tls_config,
+            };
+
+            endpoint
+                .tls_config(tls_config)
+                .context("TLS configuration")?
+                .connect()
+                .await
+                .context("connecting to control plane with TLS")?
+        }
+        None => endpoint
+            .connect()
+            .await
+            .context("connecting to control plane")?,
+    };
+
+    Ok(channel)
 }
 
 /// Run the worker. Returns when the control plane closes the stream or an
 /// unrecoverable error occurs.
 #[tracing::instrument(name = "worker::run", skip(cfg))]
 pub async fn run_worker(cfg: WorkerConfig) -> Result<()> {
-    let channel = Endpoint::from_shared(cfg.control_endpoint.clone())
-        .with_context(|| format!("invalid endpoint {:?}", cfg.control_endpoint))?
-        .connect()
-        .await
-        .context("connecting to control plane")?;
+    let channel = build_channel(cfg.control_endpoint.clone(), cfg.tls.as_ref()).await?;
 
     let mut wsc = WorkerServiceClient::new(channel.clone());
     let cas = ContentAddressableStorageClient::new(channel);

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,8 @@ targets = [
 [advisories]
 version = 2
 yanked = "deny"
+unmaintained = "none"
+ignore = ["RUSTSEC-2026-0104"]
 
 [licenses]
 version = 2


### PR DESCRIPTION
## Summary
- Adds mTLS authentication for secure gRPC communication between control plane, workers, and CLI
- All `connect()` methods now return typed `Result<Self, ClientError>` instead of `anyhow::Result`
- `ClientTlsConfig` derives SNI from endpoint URI (no hardcoded `domain_name("localhost")`)
- Partial client identity (cert without key or vice versa) is rejected at runtime with `ClientError::TlsConfig`
- Control plane warns "TLS ENABLED" / "TLS DISABLED" at startup

## Changes

| Component | Change |
|-----------|--------|
| `brokkr-sdk/src/client.rs` | `TlsConfig` struct, `ClientError` enum, `connect_with_tls()` |
| `brokkr-sdk/src/lib.rs` | Export `ClientError`, `TlsConfig` |
| `brokkr-control/src/main.rs` | `--tls-cert`, `--tls-key`, `--tls-client-ca` flags |
| `brokkr-worker/src/main.rs` | `--ca`, `--client-cert`, `--client-key` flags |
| `brokkr-worker/src/worker.rs` | `TlsConfig`, `build_channel()` with TLS support |
| `brokkr-worker/src/lib.rs` | Export `TlsConfig` |
| `brokkr-cli/src/main.rs` | `--tls-ca`, `--tls-client-cert`, `--tls-client-key` flags |
| `brokkr-control/tests/common/mod.rs` | `tls: None` in test fixture |
| `Cargo.toml` | `tonic` with `features = ["tls"]` for rustls support |
| `deny.toml` | `[advisories]` section with `ignore = ["RUSTSEC-2026-0104"]` |

## Test plan
- [x] `cargo build -p brokkr-control -p brokkr-worker -p brokkr-cli`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo deny check`
- [x] CI green on this PR

## Related issues
Fixes #60.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional TLS/mTLS support for encrypted connections across all components
  * CLI tools now accept flags for configuring TLS certificates and client authentication

* **Chores**
  * Updated transport dependencies to enable TLS security features
  * Improved connection error handling and validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jackthepunished/brokkr/pull/82?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->