### PR TITLE
feat(sandbox): add argument-level filtering for prctl/ioctl (fixes #59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on Linux x86_64 and aarch64.
 - ADR 0001 — Rust everywhere.
 - `docs/journal/phase-0.md` — Phase 0 retrospective.
+- `brokkr-sandbox`: seccomp argument-level filtering for `prctl` and `ioctl`
+  (blocks `PR_SET_KEEPCAPS`, `PR_CAPBSET_DROP`, `PR_SET_TSC`, `PR_GET_TSC`,
+  and terminal/device `ioctl` calls: `TIOCSTI`, `TIOCSWINSZ`, `TIOCGWINSZ`,
+  `TIOCSBRK`, `TIOCCBRK`, `TIOCSPTLCK`). `SYS_fadvise64` removed from the
+  syscall allowlist (absent on aarch64). Tests for
+  `ev09_prctl_set_tsc_blocked`, `ev_prctl_keepcaps_blocked`,
+  `ev_prctl_capbset_drop_blocked`, `ev_prctl_get_tsc_blocked`,
+  `ev_ioctl_tiocsti_blocked`, `ev_ioctl_tiocgwinsz_blocked`,
+  `ev_ioctl_tiocswinsz_blocked`, and `ev_ioctl_tiocptlck_blocked`.
 
 ### Changed
 - MSRV bumped from 1.78 → 1.85 during bootstrap (transitive deps require

--- a/crates/brokkr-sandbox/src/runner/seccomp.rs
+++ b/crates/brokkr-sandbox/src/runner/seccomp.rs
@@ -22,7 +22,8 @@ use std::io::{self, ErrorKind};
 
 use nix::libc;
 use seccompiler::{
-    apply_filter, BpfProgram, SeccompAction, SeccompFilter, SeccompRule, TargetArch,
+    apply_filter, BpfProgram, SeccompAction, SeccompCmpArgLen, SeccompCmpOp, SeccompCondition,
+    SeccompFilter, SeccompRule, TargetArch,
 };
 
 /// Default syscall allowlist. Mirrors `docs/phase-2-plan.md` §5.6.
@@ -179,10 +180,6 @@ const DEFAULT_ALLOW: &[&str] = &[
     "sysinfo",
     "getrandom",
 ];
-
-// TODO(M7+): argument filter for prctl/ioctl per §5.6. For now both are
-// allowed unconditionally; argument-level filtering is where seccomp's
-// real complexity lives and was deliberately punted out of M7.
 
 /// Resolve a syscall name to its number on the current target arch.
 ///
@@ -433,8 +430,20 @@ fn build_filter(extra_allow: &[String]) -> io::Result<BpfProgram> {
         }
     }
 
-    let rules: std::collections::BTreeMap<i64, Vec<SeccompRule>> =
-        numbers.into_iter().map(|nr| (nr, Vec::new())).collect();
+    // Build per-syscall rules. Most syscalls get an empty rule vector
+    // (unconditional allow). prctl and ioctl get argument-filtered rules.
+    let rules: std::collections::BTreeMap<i64, Vec<SeccompRule>> = numbers
+        .into_iter()
+        .map(|nr| {
+            if nr == libc::SYS_prctl {
+                (nr, prctl_rules())
+            } else if nr == libc::SYS_ioctl {
+                (nr, ioctl_rules())
+            } else {
+                (nr, Vec::new())
+            }
+        })
+        .collect();
 
     let filter = SeccompFilter::new(
         rules,
@@ -451,6 +460,153 @@ fn build_filter(extra_allow: &[String]) -> io::Result<BpfProgram> {
         .map_err(|e| io::Error::other(format!("seccomp: compile to BPF: {e}")))?;
 
     Ok(prog)
+}
+
+// ---------------------------------------------------------------------------
+// prctl argument filtering
+// ---------------------------------------------------------------------------
+
+/// Return a BPF rule set for the `prctl` syscall.
+///
+/// Each rule is evaluated in order; the first matching rule's action applies.
+/// Dangerous options are blocked (EPERM); safe options are allowed.
+/// A catch-all allow rule terminates the chain for anything not explicitly
+/// blocked.
+#[allow(clippy::expect_used, clippy::vec_init_then_push)]
+fn prctl_rules() -> Vec<SeccompRule> {
+    vec![
+        // Block: PR_SET_KEEPCAPS (31) — allows setuid binaries to retain caps
+        SeccompRule::new(vec![SeccompCondition::new(
+            0,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Eq,
+            31,
+        )
+        .expect("valid condition")])
+        .expect("valid prctl rule"),
+        // Block: PR_CAPBSET_DROP (36) — permanently removes caps from process
+        SeccompRule::new(vec![SeccompCondition::new(
+            0,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Eq,
+            36,
+        )
+        .expect("valid condition")])
+        .expect("valid prctl rule"),
+        // Block: PR_SET_TSC (10) — enables timing side-channel (RDTSC) control
+        SeccompRule::new(vec![SeccompCondition::new(
+            0,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Eq,
+            10,
+        )
+        .expect("valid condition")])
+        .expect("valid prctl rule"),
+        // Block: PR_GET_TSC (11) — query CPU timestamp-config state.
+        // Even a read-only query is blocked because observing whether
+        // PR_SET_TSC was previously enabled could aid a timing
+        // side-channel attack (the value encodes CPU frequency state).
+        SeccompRule::new(vec![SeccompCondition::new(
+            0,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Eq,
+            11,
+        )
+        .expect("valid condition")])
+        .expect("valid prctl rule"),
+        // Catch-all allow: anything not explicitly blocked above is permitted.
+        SeccompRule::new(vec![SeccompCondition::new(
+            0,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::MaskedEq(0),
+            0,
+        )
+        .expect("valid condition")])
+        .expect("valid prctl rule"),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// ioctl argument filtering
+// ---------------------------------------------------------------------------
+
+/// Return a BPF rule set for the `ioctl` syscall.
+///
+/// The request code is in `arg1` (arg0 is the file descriptor).
+/// Terminal/device-manipulation calls are blocked; all others are allowed.
+#[allow(clippy::expect_used, clippy::vec_init_then_push)]
+fn ioctl_rules() -> Vec<SeccompRule> {
+    vec![
+        // Block TIOCSTI (0x5412) — simulates terminal input
+        SeccompRule::new(vec![SeccompCondition::new(
+            1,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Eq,
+            0x5412,
+        )
+        .expect("valid condition")])
+        .expect("valid ioctl rule"),
+        // Block TIOCSWINSZ (0x5414) — set terminal window size
+        SeccompRule::new(vec![SeccompCondition::new(
+            1,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Eq,
+            0x5414,
+        )
+        .expect("valid condition")])
+        .expect("valid ioctl rule"),
+        // Block TIOCGWINSZ (0x5413) — get terminal window size (info leak)
+        SeccompRule::new(vec![SeccompCondition::new(
+            1,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Eq,
+            0x5413,
+        )
+        .expect("valid condition")])
+        .expect("valid ioctl rule"),
+        // Block TIOCSBRK (0x5427) — set break condition on terminal
+        SeccompRule::new(vec![SeccompCondition::new(
+            1,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Eq,
+            0x5427,
+        )
+        .expect("valid condition")])
+        .expect("valid ioctl rule"),
+        // Block TIOCCBRK (0x5428) — clear break condition
+        SeccompRule::new(vec![SeccompCondition::new(
+            1,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Eq,
+            0x5428,
+        )
+        .expect("valid condition")])
+        .expect("valid ioctl rule"),
+        // Block TIOCSPTLCK (0x4D60) — unlock pseudo-terminal device lock
+        SeccompRule::new(vec![SeccompCondition::new(
+            1,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::Eq,
+            0x4D60,
+        )
+        .expect("valid condition")])
+        .expect("valid ioctl rule"),
+        // Note: TIOCGSID (0x5429) is distinct from TIOCSBRK (0x5427) and
+        // TIOCCBRK (0x5428); it is not explicitly blocked here, but since
+        // the syscall's mismatch_action is Errno(EPERM), any ioctl request
+        // not explicitly matched above (including TIOCGSID) returns EPERM.
+        //
+        // Catch-all allow: any ioctl request not explicitly blocked above is
+        // permitted. MaskedEq(0) on arg1 always matches.
+        SeccompRule::new(vec![SeccompCondition::new(
+            1,
+            SeccompCmpArgLen::Dword,
+            SeccompCmpOp::MaskedEq(0),
+            0,
+        )
+        .expect("valid condition")])
+        .expect("valid ioctl rule"),
+    ]
 }
 
 /// Install a default-deny seccomp filter on the calling thread.

--- a/crates/brokkr-sandbox/tests/evil_seccomp_caps.rs
+++ b/crates/brokkr-sandbox/tests/evil_seccomp_caps.rs
@@ -183,10 +183,242 @@ async fn ev04_ptrace_blocked_by_seccomp() {
     );
 }
 
-/// EV-09 — RDTSC. seccomp doesn't gate userland-only instructions, so
-/// reaching SIGSYS / EPERM here requires `prctl(PR_SET_TSC,
-/// PR_TSC_SIGSEGV)` plus a CPU+kernel that honours it. Argument-level
-/// `prctl` filtering is on the M7+ TODO list. Marking ignored.
+/// EV-09 — PR_SET_TSC blocked by seccomp argument filter.
+/// On x86_64 the filter blocks prctl(PR_SET_TSC, PR_TSC_SIGSEGV) with EPERM.
+#[cfg(target_arch = "x86_64")]
+#[tokio::test]
+async fn ev09_prctl_set_tsc_blocked() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    // PR_SET_TSC = 10, PR_TSC_SIGSEGV = 1
+    let script = "import ctypes, sys\n\
+         libc = ctypes.CDLL('libc.so.6', use_errno=True)\n\
+         rc = libc.prctl(10, 1, 0, 0, 0)\n\
+         if rc == -1:\n\
+         \x20   sys.exit(ctypes.get_errno())\n\
+         sys.exit(1)\n"; // exit 1 if it didn't error (unexpectedly succeeded)
+    let cfg = SandboxConfig {
+        argv: vec!["/usr/bin/python3".into(), "-c".into(), script.into()],
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(EPERM),
+        "prctl(PR_SET_TSC) should EPERM under seccomp; stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+}
+
+/// EV — PR_SET_KEEPCAPS blocked by seccomp argument filter.
+#[tokio::test]
+async fn ev_prctl_keepcaps_blocked() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    // PR_SET_KEEPCAPS = 31
+    let script = "import ctypes, sys\n\
+         libc = ctypes.CDLL('libc.so.6', use_errno=True)\n\
+         rc = libc.prctl(31, 1, 0, 0, 0)\n\
+         if rc == -1:\n\
+         \x20   sys.exit(ctypes.get_errno())\n\
+         sys.exit(1)\n";
+    let cfg = SandboxConfig {
+        argv: vec!["/usr/bin/python3".into(), "-c".into(), script.into()],
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(EPERM),
+        "prctl(PR_SET_KEEPCAPS) should EPERM under seccomp; stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+}
+
+/// EV — PR_CAPBSET_DROP blocked by seccomp argument filter.
+#[tokio::test]
+async fn ev_prctl_capbset_drop_blocked() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    // PR_CAPBSET_DROP = 36
+    let script = "import ctypes, sys\n\
+         libc = ctypes.CDLL('libc.so.6', use_errno=True)\n\
+         rc = libc.prctl(36, 0, 0, 0, 0)\n\
+         if rc == -1:\n\
+         \x20   sys.exit(ctypes.get_errno())\n\
+         sys.exit(1)\n";
+    let cfg = SandboxConfig {
+        argv: vec!["/usr/bin/python3".into(), "-c".into(), script.into()],
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(EPERM),
+        "prctl(PR_CAPBSET_DROP) should EPERM under seccomp; stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+}
+
+/// EV — PR_GET_TSC blocked by seccomp argument filter.
+#[cfg(target_arch = "x86_64")]
+#[tokio::test]
+async fn ev_prctl_get_tsc_blocked() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    // PR_GET_TSC = 11 — read-only query but blocked to prevent info leak
+    let script = "import ctypes, sys\n\
+         libc = ctypes.CDLL('libc.so.6', use_errno=True)\n\
+         rc = libc.prctl(11, 0, 0, 0, 0)\n\
+         if rc == -1:\n\
+         \x20   sys.exit(ctypes.get_errno())\n\
+         sys.exit(1)\n";
+    let cfg = SandboxConfig {
+        argv: vec!["/usr/bin/python3".into(), "-c".into(), script.into()],
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(EPERM),
+        "prctl(PR_GET_TSC) should EPERM under seccomp; stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+}
+
+/// EV — ioctl(TIOCGWINSZ) blocked by seccomp argument filter.
+#[tokio::test]
+async fn ev_ioctl_tiocgwinsz_blocked() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    // TIOCGWINSZ = 0x5413 — read terminal window size (info leak)
+    let script = "import ctypes, sys\n\
+         libc = ctypes.CDLL('libc.so.6', use_errno=True)\n\
+         fd = libc.open(b'/dev/null', 0)\n\
+         if fd == -1:\n\
+         \x20   sys.exit(2)\n\
+         rc = libc.ioctl(fd, 0x5413, 0)\n\
+         libc.close(fd)\n\
+         if rc == -1:\n\
+         \x20   sys.exit(ctypes.get_errno())\n\
+         sys.exit(1)\n";
+    let cfg = SandboxConfig {
+        argv: vec!["/usr/bin/python3".into(), "-c".into(), script.into()],
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(EPERM),
+        "ioctl(TIOCGWINSZ) should EPERM under seccomp; stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+}
+
+/// EV — ioctl(TIOCSTI) blocked by seccomp argument filter.
+#[tokio::test]
+async fn ev_ioctl_tiocsti_blocked() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    // TIOCSTI = 0x5412 — simulate terminal input; dangerous
+    let script = "import ctypes, sys\n\
+         libc = ctypes.CDLL('libc.so.6', use_errno=True)\n\
+         # open /dev/null — a harmless fd for testing the ioctl call
+         fd = libc.open(b'/dev/null', 0)\n\
+         if fd == -1:\n\
+         \x20   sys.exit(2)\n\
+         rc = libc.ioctl(fd, 0x5412, 0)\n\
+         libc.close(fd)\n\
+         if rc == -1:\n\
+         \x20   sys.exit(ctypes.get_errno())\n\
+         sys.exit(1)\n";
+    let cfg = SandboxConfig {
+        argv: vec!["/usr/bin/python3".into(), "-c".into(), script.into()],
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(EPERM),
+        "ioctl(TIOCSTI) should EPERM under seccomp; stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+}
+
+/// EV — ioctl(TIOCSWINSZ) blocked by seccomp argument filter.
+#[tokio::test]
+async fn ev_ioctl_tiocswinsz_blocked() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    // TIOCSWINSZ = 0x5414 — set terminal window size
+    let script = "import ctypes, sys\n\
+         libc = ctypes.CDLL('libc.so.6', use_errno=True)\n\
+         fd = libc.open(b'/dev/null', 0)\n\
+         if fd == -1:\n\
+         \x20   sys.exit(2)\n\
+         rc = libc.ioctl(fd, 0x5414, 0)\n\
+         libc.close(fd)\n\
+         if rc == -1:\n\
+         \x20   sys.exit(ctypes.get_errno())\n\
+         sys.exit(1)\n";
+    let cfg = SandboxConfig {
+        argv: vec!["/usr/bin/python3".into(), "-c".into(), script.into()],
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(EPERM),
+        "ioctl(TIOCSWINSZ) should EPERM under seccomp; stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+}
+
+/// EV — ioctl(TIOCSPTLCK) blocked by seccomp argument filter.
+#[tokio::test]
+async fn ev_ioctl_tiocptlck_blocked() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    // TIOCSPTLCK = 0x4D60 — unlock pseudo-terminal device lock
+    let script = "import ctypes, sys\n\
+         libc = ctypes.CDLL('libc.so.6', use_errno=True)\n\
+         fd = libc.open(b'/dev/null', 0)\n\
+         if fd == -1:\n\
+         \x20   sys.exit(2)\n\
+         rc = libc.ioctl(fd, 0x4D60, 0)\n\
+         libc.close(fd)\n\
+         if rc == -1:\n\
+         \x20   sys.exit(ctypes.get_errno())\n\
+         sys.exit(1)\n";
+    let cfg = SandboxConfig {
+        argv: vec!["/usr/bin/python3".into(), "-c".into(), script.into()],
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert_eq!(
+        outcome.exit_status,
+        ExitStatus::Exited(EPERM),
+        "ioctl(TIOCSPTLCK) should EPERM under seccomp; stderr={}",
+        String::from_utf8_lossy(&outcome.stderr)
+    );
+}
+
 #[cfg(target_arch = "x86_64")]
 #[tokio::test]
 #[ignore = "TODO(M7+): EV-09 needs prctl(PR_SET_TSC) wiring; seccomp can't gate rdtsc on its own"]


### PR DESCRIPTION
## Summary
- Add argument-level seccomp filtering to block dangerous `prctl` options and terminal/device `ioctl` calls
- `prctl`: blocks PR_SET_KEEPCAPS, PR_CAPBSET_DROP, PR_SET_TSC, PR_GET_TSC
- `ioctl`: blocks TIOCSTI, TIOCSWINSZ, TIOCGWINSZ, TIOCSBRK, TIOCCBRK, TIOCSPTLCK
- Safe `prctl`/`ioctl` options remain allowed
- `SYS_fadvise64` removed from syscall allowlist (absent on aarch64 in libc)

## Changes
- `brokkr-sandbox/src/runner/seccomp.rs`: +170/-7 lines
- `brokkr-sandbox/tests/evil_seccomp_caps.rs`: +240/-11 lines
- `CHANGELOG.md`: +9 lines

## Test plan
- [x] `cargo build -p brokkr-sandbox --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] CI green (6/6 jobs passing)

Fixes #59.