### PR TITLE
fix(sdk): check ExecuteResponse.status before accessing result (fixes #61)

### DIFF
--- a/crates/brokkr-sdk/src/client.rs
+++ b/crates/brokkr-sdk/src/client.rs
@@ -153,6 +153,24 @@ pub struct RunOutcome {
     pub cache_hit: bool,
 }
 
+/// Check server-reported status before accessing result.
+/// Returns `Ok(ActionResult)` if status is OK or absent (owned copy).
+/// Returns `Err((code, message))` if status.code != 0.
+/// Check server-reported status before accessing result.
+/// Returns `Ok(ActionResult)` if status is OK or absent (owned copy).
+/// Returns `Err((code, message))` if status.code != 0.
+pub fn check_status(resp: &rapi::ExecuteResponse) -> Result<rapi::ActionResult, (i32, &str)> {
+    if let Some(status) = &resp.status {
+        if status.code != 0 {
+            return Err((status.code, status.message.as_str()));
+        }
+    }
+    match resp.result.clone() {
+        Some(r) => Ok(r),
+        None => Err((0, "ExecuteResponse missing ActionResult")),
+    }
+}
+
 /// Run `argv` on the cluster and return its result.
 ///
 /// Builds an `Action` (with empty input root + the given Command), uploads
@@ -283,21 +301,12 @@ pub async fn run_command(
             Some(brokkr_proto::longrunning::operation::Result::Response(any)) => {
                 let resp = rapi::ExecuteResponse::decode(any.value.as_slice())
                     .context("decoding ExecuteResponse")?;
-                // Check server-reported status before accessing result.
-                // Per REAPI spec, non-OK status means the action did not finish.
-                if let Some(status) = &resp.status {
-                    if status.code != 0 {
-                        tracing::Span::current().record("exec_status_code", status.code);
-                        return Err(anyhow!(
-                            "execution failed: {} (code={})",
-                            status.message,
-                            status.code
-                        ));
-                    }
+                let result = check_status(&resp)
+                    .map_err(|(code, msg)| anyhow!("execution failed: {} (code={})", msg, code))?;
+                let status_code = resp.status.as_ref().map(|s| s.code).unwrap_or(0);
+                if status_code != 0 {
+                    tracing::Span::current().record("exec_status_code", status_code);
                 }
-                let result = resp
-                    .result
-                    .ok_or_else(|| anyhow!("ExecuteResponse missing ActionResult"))?;
                 tracing::Span::current()
                     .record("cache_hit", resp.cached_result)
                     .record("exit_code", result.exit_code);

--- a/crates/brokkr-sdk/src/client.rs
+++ b/crates/brokkr-sdk/src/client.rs
@@ -283,6 +283,17 @@ pub async fn run_command(
             Some(brokkr_proto::longrunning::operation::Result::Response(any)) => {
                 let resp = rapi::ExecuteResponse::decode(any.value.as_slice())
                     .context("decoding ExecuteResponse")?;
+                // Check server-reported status before accessing result.
+                // Per REAPI spec, non-OK status means the action did not finish.
+                if let Some(status) = &resp.status {
+                    if status.code != 0 {
+                        return Err(anyhow!(
+                            "execution failed: {} (code={})",
+                            status.message,
+                            status.code
+                        ));
+                    }
+                }
                 let result = resp
                     .result
                     .ok_or_else(|| anyhow!("ExecuteResponse missing ActionResult"))?;

--- a/crates/brokkr-sdk/src/client.rs
+++ b/crates/brokkr-sdk/src/client.rs
@@ -287,6 +287,7 @@ pub async fn run_command(
                 // Per REAPI spec, non-OK status means the action did not finish.
                 if let Some(status) = &resp.status {
                     if status.code != 0 {
+                        tracing::Span::current().record("exec_status_code", status.code);
                         return Err(anyhow!(
                             "execution failed: {} (code={})",
                             status.message,

--- a/crates/brokkr-sdk/src/client.rs
+++ b/crates/brokkr-sdk/src/client.rs
@@ -15,6 +15,22 @@ use sha2::{Digest as _, Sha256};
 use thiserror::Error;
 use tonic::transport::{Channel, Endpoint};
 
+/// Errors from [`check_status`].
+#[derive(Debug, Error)]
+pub enum ExecuteError {
+    /// Server returned a non-OK status.
+    #[error("execution failed: {message} (code={code})")]
+    Status {
+        /// The gRPC status code (non-zero).
+        code: i32,
+        /// The error message from the server.
+        message: String,
+    },
+    /// `ExecuteResponse` had no `ActionResult`.
+    #[error("ExecuteResponse missing ActionResult")]
+    MissingResult,
+}
+
 /// TLS configuration for a [`BrokkrClient`] connection.
 #[derive(Debug, Clone)]
 pub struct TlsConfig {
@@ -155,19 +171,19 @@ pub struct RunOutcome {
 
 /// Check server-reported status before accessing result.
 /// Returns `Ok(ActionResult)` if status is OK or absent (owned copy).
-/// Returns `Err((code, message))` if status.code != 0.
-/// Check server-reported status before accessing result.
-/// Returns `Ok(ActionResult)` if status is OK or absent (owned copy).
-/// Returns `Err((code, message))` if status.code != 0.
-pub fn check_status(resp: &rapi::ExecuteResponse) -> Result<rapi::ActionResult, (i32, &str)> {
+/// Returns `Err(ExecuteError)` if status.code != 0 or result is absent.
+pub fn check_status(resp: &rapi::ExecuteResponse) -> Result<rapi::ActionResult, ExecuteError> {
     if let Some(status) = &resp.status {
         if status.code != 0 {
-            return Err((status.code, status.message.as_str()));
+            return Err(ExecuteError::Status {
+                code: status.code,
+                message: status.message.clone(),
+            });
         }
     }
     match resp.result.clone() {
         Some(r) => Ok(r),
-        None => Err((0, "ExecuteResponse missing ActionResult")),
+        None => Err(ExecuteError::MissingResult),
     }
 }
 
@@ -301,9 +317,8 @@ pub async fn run_command(
             Some(brokkr_proto::longrunning::operation::Result::Response(any)) => {
                 let resp = rapi::ExecuteResponse::decode(any.value.as_slice())
                     .context("decoding ExecuteResponse")?;
-                let result = check_status(&resp)
-                    .map_err(|(code, msg)| anyhow!("execution failed: {} (code={})", msg, code))?;
                 let status_code = resp.status.as_ref().map(|s| s.code).unwrap_or(0);
+                let result = check_status(&resp).map_err(|e| anyhow!("{e}"))?;
                 if status_code != 0 {
                     tracing::Span::current().record("exec_status_code", status_code);
                 }

--- a/crates/brokkr-sdk/src/lib.rs
+++ b/crates/brokkr-sdk/src/lib.rs
@@ -7,4 +7,6 @@
 
 pub mod client;
 
-pub use client::{check_status, run_command, BrokkrClient, ClientError, RunOutcome, TlsConfig};
+pub use client::{
+    check_status, run_command, BrokkrClient, ClientError, ExecuteError, RunOutcome, TlsConfig,
+};

--- a/crates/brokkr-sdk/src/lib.rs
+++ b/crates/brokkr-sdk/src/lib.rs
@@ -7,4 +7,4 @@
 
 pub mod client;
 
-pub use client::{run_command, BrokkrClient, ClientError, RunOutcome, TlsConfig};
+pub use client::{check_status, run_command, BrokkrClient, ClientError, RunOutcome, TlsConfig};

--- a/crates/brokkr-sdk/tests/status_check.rs
+++ b/crates/brokkr-sdk/tests/status_check.rs
@@ -1,68 +1,97 @@
-//! Tests for ExecuteResponse status handling.
+//! Tests for ExecuteResponse status handling via `check_status`.
 //!
-//! These tests verify that the SDK correctly surfaces server-reported
-//! errors from ExecuteResponse.status. See issue #61.
+//! These tests verify the pure `check_status` function that underpins
+//! `run_command`'s error-path behavior. See issue #61.
 
 #![allow(clippy::disallowed_methods, clippy::unwrap_used)]
 
 use brokkr_proto::google::rpc::Status as RpcStatus;
-use brokkr_proto::reapi_v2::ExecuteResponse;
+use brokkr_proto::reapi_v2::{ExecuteResponse, ActionResult};
 
-/// Verify that an ExecuteResponse with status.code != 0 is detected.
+use brokkr_sdk::client::check_status;
+
+/// ExecuteResponse with status.code != 0 returns Err((code, message)).
 #[test]
-fn execute_response_non_zero_status() {
-    let status = RpcStatus {
-        code: 3, // FAILED_PRECONDITION
-        message: "missing input blob".to_string(),
-        details: vec![],
-    };
+fn check_status_nonzero_code_returns_err() {
     let resp = ExecuteResponse {
-        status: Some(status),
+        status: Some(RpcStatus {
+            code: 3, // FAILED_PRECONDITION
+            message: "missing input blob".to_string(),
+            details: vec![],
+        }),
         result: None,
         cached_result: false,
         ..Default::default()
     };
 
-    // Sanity check: status is present and non-OK
-    assert!(resp.status.is_some(), "status should be present");
-    let s = resp.status.as_ref().unwrap();
-    assert_eq!(s.code, 3);
-    assert_eq!(s.message, "missing input blob");
+    let result = check_status(&resp);
+    assert!(result.is_err());
+    let (code, msg) = result.unwrap_err();
+    assert_eq!(code, 3);
+    assert_eq!(msg, "missing input blob");
 }
 
-/// Verify that ExecuteResponse with OK status (code == 0) passes the check.
+/// ExecuteResponse with status.code == 0 and result present returns Ok.
 #[test]
-fn execute_response_ok_status() {
-    let status = RpcStatus {
-        code: 0, // OK
-        message: String::new(),
-        details: vec![],
-    };
+fn check_status_zero_code_with_result_returns_ok() {
     let resp = ExecuteResponse {
-        status: Some(status),
-        result: None,
+        status: Some(RpcStatus {
+            code: 0,
+            message: String::new(),
+            details: vec![],
+        }),
+        result: Some(ActionResult {
+            exit_code: 0,
+            stdout_raw: b"hello".to_vec(),
+            stderr_raw: b"".to_vec(),
+            ..Default::default()
+        }),
         cached_result: false,
         ..Default::default()
     };
 
-    // Code 0 means OK — the SDK would proceed to check result
-    let code = match resp.status.as_ref() {
-        Some(s) => s.code,
-        None => -1,
-    };
-    assert_eq!(code, 0);
+    let result = check_status(&resp);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().exit_code, 0);
 }
 
-/// Verify that ExecuteResponse with no status field is treated as OK.
+/// ExecuteResponse with no status field is treated as OK (proceeds).
 #[test]
-fn execute_response_missing_status() {
-    let resp: ExecuteResponse = ExecuteResponse {
+fn check_status_none_treated_as_ok() {
+    let resp = ExecuteResponse {
         status: None,
+        result: Some(ActionResult {
+            exit_code: 42,
+            stdout_raw: b"".to_vec(),
+            stderr_raw: b"".to_vec(),
+            ..Default::default()
+        }),
+        cached_result: false,
+        ..Default::default()
+    };
+
+    let result = check_status(&resp);
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().exit_code, 42);
+}
+
+/// ExecuteResponse with OK status but no result returns Err.
+#[test]
+fn check_status_result_none_returns_err() {
+    let resp = ExecuteResponse {
+        status: Some(RpcStatus {
+            code: 0,
+            message: String::new(),
+            details: vec![],
+        }),
         result: None,
         cached_result: false,
         ..Default::default()
     };
 
-    // Missing status means OK per REAPI spec
-    assert!(resp.status.is_none());
+    let result = check_status(&resp);
+    assert!(result.is_err());
+    let (code, msg) = result.unwrap_err();
+    assert_eq!(code, 0);
+    assert_eq!(msg, "ExecuteResponse missing ActionResult");
 }

--- a/crates/brokkr-sdk/tests/status_check.rs
+++ b/crates/brokkr-sdk/tests/status_check.rs
@@ -6,7 +6,7 @@
 #![allow(clippy::disallowed_methods, clippy::unwrap_used)]
 
 use brokkr_proto::google::rpc::Status as RpcStatus;
-use brokkr_proto::reapi_v2::{ExecuteResponse, ActionResult};
+use brokkr_proto::reapi_v2::{ActionResult, ExecuteResponse};
 
 use brokkr_sdk::client::check_status;
 

--- a/crates/brokkr-sdk/tests/status_check.rs
+++ b/crates/brokkr-sdk/tests/status_check.rs
@@ -1,0 +1,61 @@
+//! Tests for ExecuteResponse status handling.
+//!
+//! These tests verify that the SDK correctly surfaces server-reported
+//! errors from ExecuteResponse.status. See issue #61.
+
+use brokkr_proto::google::rpc::Status as RpcStatus;
+use brokkr_proto::reapi_v2::ExecuteResponse;
+
+/// Verify that an ExecuteResponse with status.code != 0 is detected.
+#[test]
+fn execute_response_non_zero_status() {
+    let status = RpcStatus {
+        code: 3, // FAILED_PRECONDITION
+        message: "missing input blob".to_string(),
+        details: vec![],
+    };
+    let resp = ExecuteResponse {
+        status: Some(status),
+        result: None,
+        cached_result: false,
+        ..Default::default()
+    };
+
+    // Sanity check: status is present and non-OK
+    let s = resp.status.as_ref().expect("status should be present");
+    assert_eq!(s.code, 3);
+    assert_eq!(s.message, "missing input blob");
+}
+
+/// Verify that ExecuteResponse with OK status (code == 0) passes the check.
+#[test]
+fn execute_response_ok_status() {
+    let status = RpcStatus {
+        code: 0, // OK
+        message: String::new(),
+        details: vec![],
+    };
+    let resp = ExecuteResponse {
+        status: Some(status),
+        result: None,
+        cached_result: false,
+        ..Default::default()
+    };
+
+    // Code 0 means OK — the SDK would proceed to check result
+    assert_eq!(resp.status.as_ref().map(|s| s.code).expect("status should be present"), 0);
+}
+
+/// Verify that ExecuteResponse with no status field is treated as OK.
+#[test]
+fn execute_response_missing_status() {
+    let resp: ExecuteResponse = ExecuteResponse {
+        status: None,
+        result: None,
+        cached_result: false,
+        ..Default::default()
+    };
+
+    // Missing status means OK per REAPI spec
+    assert!(resp.status.is_none());
+}

--- a/crates/brokkr-sdk/tests/status_check.rs
+++ b/crates/brokkr-sdk/tests/status_check.rs
@@ -3,12 +3,12 @@
 //! These tests verify the pure `check_status` function that underpins
 //! `run_command`'s error-path behavior. See issue #61.
 
-#![allow(clippy::disallowed_methods, clippy::unwrap_used)]
+#![allow(clippy::disallowed_methods, clippy::unwrap_used, clippy::panic)]
 
 use brokkr_proto::google::rpc::Status as RpcStatus;
 use brokkr_proto::reapi_v2::{ActionResult, ExecuteResponse};
 
-use brokkr_sdk::client::check_status;
+use brokkr_sdk::client::{check_status, ExecuteError};
 
 /// ExecuteResponse with status.code != 0 returns Err((code, message)).
 #[test]
@@ -26,9 +26,11 @@ fn check_status_nonzero_code_returns_err() {
 
     let result = check_status(&resp);
     assert!(result.is_err());
-    let (code, msg) = result.unwrap_err();
+    let ExecuteError::Status { code, message } = result.unwrap_err() else {
+        panic!("expected Status variant");
+    };
     assert_eq!(code, 3);
-    assert_eq!(msg, "missing input blob");
+    assert_eq!(message, "missing input blob");
 }
 
 /// ExecuteResponse with status.code == 0 and result present returns Ok.
@@ -91,7 +93,6 @@ fn check_status_result_none_returns_err() {
 
     let result = check_status(&resp);
     assert!(result.is_err());
-    let (code, msg) = result.unwrap_err();
-    assert_eq!(code, 0);
-    assert_eq!(msg, "ExecuteResponse missing ActionResult");
+    let err = result.unwrap_err();
+    assert!(matches!(err, ExecuteError::MissingResult));
 }

--- a/crates/brokkr-sdk/tests/status_check.rs
+++ b/crates/brokkr-sdk/tests/status_check.rs
@@ -3,6 +3,8 @@
 //! These tests verify that the SDK correctly surfaces server-reported
 //! errors from ExecuteResponse.status. See issue #61.
 
+#![allow(clippy::disallowed_methods, clippy::unwrap_used)]
+
 use brokkr_proto::google::rpc::Status as RpcStatus;
 use brokkr_proto::reapi_v2::ExecuteResponse;
 
@@ -22,7 +24,8 @@ fn execute_response_non_zero_status() {
     };
 
     // Sanity check: status is present and non-OK
-    let s = resp.status.as_ref().expect("status should be present");
+    assert!(resp.status.is_some(), "status should be present");
+    let s = resp.status.as_ref().unwrap();
     assert_eq!(s.code, 3);
     assert_eq!(s.message, "missing input blob");
 }
@@ -43,7 +46,11 @@ fn execute_response_ok_status() {
     };
 
     // Code 0 means OK — the SDK would proceed to check result
-    assert_eq!(resp.status.as_ref().map(|s| s.code).expect("status should be present"), 0);
+    let code = match resp.status.as_ref() {
+        Some(s) => s.code,
+        None => -1,
+    };
+    assert_eq!(code, 0);
 }
 
 /// Verify that ExecuteResponse with no status field is treated as OK.


### PR DESCRIPTION
## Summary
- Check `ExecuteResponse.status` (google.rpc.Status) before accessing `resp.result` in `run_command`
- If `status.code != 0`, return an error with the status code and message instead of silently ignoring the server error
- Fixes issue where SDK treated server errors (e.g., `FAILED_PRECONDITION` for missing inputs) as success

## Changes
- `brokkr-sdk/src/client.rs`: +11 lines — status check after decoding `ExecuteResponse`

## Test plan
- [x] `cargo build -p brokkr-sdk`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] CI green on this PR

Fixes #61.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public status-validation utility to explicitly surface and handle server-reported execution status and missing results.
* **Bug Fixes**
  * Improved error handling so non-OK server statuses are treated as failures rather than successful results.
* **Tests**
  * Added unit tests covering non-zero, zero, absent status cases and the missing-result scenario to ensure correct behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jackthepunished/brokkr/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->