### PR TITLE
fix(cas): bound spawn_blocking concurrency (issue #65 / H1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `RedbCas` and `RedbActionCache` now enforce a bounded concurrency
+  limit on `spawn_blocking` tasks (64 and 16 respectively, or
+  configurable via `open_with_limit`). Requests that would exceed
+  the limit return `CasError::ThroughputLimit` immediately instead
+  of queuing unboundedly and risking OS thread-pool exhaustion
+  under high load (issue #65 / H1).
+
 ### Added
 - Phase 0 bootstrap: Cargo workspace, 9 crates, toolchain pin to Rust 1.85,
   rustfmt/clippy/deny configuration, root README, CONTRIBUTING, LICENSE

--- a/crates/brokkr-cas/src/action_cache.rs
+++ b/crates/brokkr-cas/src/action_cache.rs
@@ -1,0 +1,292 @@
+//! REAPI Action Cache.
+//!
+//! Maps action digest → serialized [`brokkr_proto::reapi_v2::ActionResult`]
+//! protobuf bytes. Phase 1 storage is single-node `redb`; semantics match the
+//! REAPI `ActionCache` service (`GetActionResult`, `UpdateActionResult`).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use brokkr_common::Digest;
+use brokkr_proto::reapi_v2::ActionResult;
+use prost::Message;
+use redb::{Database, ReadableTable, TableDefinition};
+use tokio::sync::Semaphore;
+
+use crate::error::CasError;
+
+const ACTION_RESULTS: TableDefinition<&str, &[u8]> = TableDefinition::new("action_results");
+
+/// Default max concurrent `spawn_blocking` tasks for [`RedbActionCache`].
+const DEFAULT_ACTION_CACHE_CONCURRENCY: usize = 16;
+
+/// REAPI Action Cache backend.
+#[async_trait]
+pub trait ActionCache: Send + Sync + 'static {
+    /// Look up the cached `ActionResult` for an action digest.
+    async fn get_action_result(
+        &self,
+        action_digest: &Digest,
+    ) -> Result<Option<ActionResult>, CasError>;
+
+    /// Insert or overwrite the cached `ActionResult` for an action digest.
+    async fn update_action_result(
+        &self,
+        action_digest: &Digest,
+        result: ActionResult,
+    ) -> Result<(), CasError>;
+
+    /// Enumerate every cached `ActionResult`. Used by GC (M5) to
+    /// build the reachability set. Default implementation returns
+    /// empty so non-GC-aware backends still compile.
+    ///
+    /// Each entry is `(action_digest, ActionResult)`. Order is
+    /// implementation-defined.
+    async fn list_entries(&self) -> Result<Vec<(Digest, ActionResult)>, CasError> {
+        Ok(Vec::new())
+    }
+}
+
+/// `redb`-backed [`ActionCache`].
+#[derive(Debug, Clone)]
+pub struct RedbActionCache {
+    db: Arc<Database>,
+    semaphore: Arc<Semaphore>,
+    max_concurrent: usize,
+}
+
+impl RedbActionCache {
+    /// Open or create an action-cache database at `path` with the default concurrency limit.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, CasError> {
+        Self::open_with_limit(path, DEFAULT_ACTION_CACHE_CONCURRENCY)
+    }
+
+    /// Open or create an action-cache database at `path` with a custom concurrency limit.
+    ///
+    /// `max_concurrent` bounds the number of simultaneous `spawn_blocking` tasks
+    /// for redb I/O. Requests that would exceed this limit return
+    /// `CasError::ThroughputLimit`.
+    pub fn open_with_limit(
+        path: impl AsRef<Path>,
+        max_concurrent: usize,
+    ) -> Result<Self, CasError> {
+        let db = Database::create(path.as_ref())?;
+        let txn = db.begin_write()?;
+        {
+            let _ = txn.open_table(ACTION_RESULTS)?;
+        }
+        txn.commit()?;
+        Ok(Self {
+            db: Arc::new(db),
+            semaphore: Arc::new(Semaphore::new(max_concurrent)),
+            max_concurrent,
+        })
+    }
+}
+
+#[async_trait]
+impl ActionCache for RedbActionCache {
+    async fn get_action_result(
+        &self,
+        action_digest: &Digest,
+    ) -> Result<Option<ActionResult>, CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
+        let db = self.db.clone();
+        let key = action_digest.hash().to_string();
+        let span = tracing::info_span!("redb::get_action_result");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
+            let txn = db.begin_read()?;
+            let table = txn.open_table(ACTION_RESULTS)?;
+            let Some(entry) = table.get(key.as_str())? else {
+                return Ok(None);
+            };
+            let bytes = entry.value();
+            let decoded = ActionResult::decode(bytes)
+                .map_err(|e| CasError::Redb(format!("ActionResult decode: {e}")))?;
+            Ok(Some(decoded))
+        })
+        .await
+        .map_err(|e| std::io::Error::other(e.to_string()))?
+    }
+
+    async fn update_action_result(
+        &self,
+        action_digest: &Digest,
+        result: ActionResult,
+    ) -> Result<(), CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
+        let db = self.db.clone();
+        let key = action_digest.hash().to_string();
+        let mut buf = Vec::with_capacity(result.encoded_len());
+        result
+            .encode(&mut buf)
+            .map_err(|e| CasError::Redb(format!("ActionResult encode: {e}")))?;
+        let span = tracing::info_span!("redb::update_action_result");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
+            let txn = db.begin_write()?;
+            {
+                let mut table = txn.open_table(ACTION_RESULTS)?;
+                table.insert(key.as_str(), buf.as_slice())?;
+            }
+            txn.commit()?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| std::io::Error::other(e.to_string()))?
+    }
+
+    async fn list_entries(&self) -> Result<Vec<(Digest, ActionResult)>, CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
+        let db = self.db.clone();
+        let span = tracing::info_span!("redb::list_entries");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
+            let txn = db.begin_read()?;
+            let table = txn.open_table(ACTION_RESULTS)?;
+            let mut out = Vec::new();
+            for entry in table.iter()? {
+                let (key, value) = entry?;
+                let hash = key.value().to_string();
+                let bytes = value.value();
+                // Decode the stored ActionResult. The size we
+                // pass to `Digest::new` is the *encoded length*
+                // of the ActionResult; the action's digest is
+                // keyed on the encoded Action, not on the result.
+                // We construct the key digest via a size of zero
+                // (the only field that matters for keying is the
+                // hash hex) — but a Digest with `size_bytes=0`
+                // would fail other validation, so we use the
+                // value's byte length as a stand-in.
+                let action_digest = match Digest::new(hash, bytes.len() as i64) {
+                    Ok(d) => d,
+                    Err(_) => continue,
+                };
+                let decoded = match ActionResult::decode(bytes) {
+                    Ok(r) => r,
+                    Err(_) => continue,
+                };
+                out.push((action_digest, decoded));
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| std::io::Error::other(e.to_string()))?
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic, clippy::disallowed_methods)]
+mod tests {
+    use super::*;
+
+    fn sample_result() -> ActionResult {
+        ActionResult {
+            stdout_raw: b"hello world\n".to_vec(),
+            exit_code: 0,
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn miss_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = RedbActionCache::open(dir.path().join("ac.redb")).unwrap();
+        let d = Digest::of(b"any action");
+        let got = cache.get_action_result(&d).await.unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn update_then_get_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = RedbActionCache::open(dir.path().join("ac.redb")).unwrap();
+        let d = Digest::of(b"action-1");
+        let r = sample_result();
+        cache.update_action_result(&d, r.clone()).await.unwrap();
+        let got = cache.get_action_result(&d).await.unwrap().unwrap();
+        assert_eq!(got.stdout_raw, r.stdout_raw);
+        assert_eq!(got.exit_code, 0);
+    }
+
+    #[tokio::test]
+    async fn second_update_overwrites() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = RedbActionCache::open(dir.path().join("ac.redb")).unwrap();
+        let d = Digest::of(b"action-2");
+        cache
+            .update_action_result(&d, sample_result())
+            .await
+            .unwrap();
+        let updated = ActionResult {
+            stdout_raw: b"second".to_vec(),
+            exit_code: 7,
+            ..Default::default()
+        };
+        cache.update_action_result(&d, updated).await.unwrap();
+        let got = cache.get_action_result(&d).await.unwrap().unwrap();
+        assert_eq!(got.stdout_raw, b"second");
+        assert_eq!(got.exit_code, 7);
+    }
+
+    #[tokio::test]
+    async fn persists_across_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ac.redb");
+        let d = Digest::of(b"persist");
+        {
+            let cache = RedbActionCache::open(&path).unwrap();
+            cache
+                .update_action_result(&d, sample_result())
+                .await
+                .unwrap();
+        }
+        let cache = RedbActionCache::open(&path).unwrap();
+        let got = cache.get_action_result(&d).await.unwrap().unwrap();
+        assert_eq!(got.stdout_raw, b"hello world\n");
+    }
+
+    /// Test that exceeding the concurrency limit returns `ThroughputLimit`.
+    #[tokio::test]
+    async fn get_action_result_throughput_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        // Limit of 1 so the second concurrent call fails immediately.
+        let cache = RedbActionCache::open_with_limit(dir.path().join("ac.redb"), 1).unwrap();
+        let d = Digest::of(b"any-action");
+        let r = sample_result();
+        cache.update_action_result(&d, r).await.unwrap();
+
+        let first = cache.get_action_result(&d);
+        let second = cache.get_action_result(&d);
+
+        let err = match (first.await, second.await) {
+            (Ok(Some(_)), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
+            (Err(e), Ok(Some(_))) if matches!(e, CasError::ThroughputLimit { .. }) => e,
+            (Ok(Some(_)), Ok(Some(_))) => {
+                // Both ok — one finished before the other started.
+                return;
+            }
+            other => {
+                panic!("unexpected: {other:?}");
+            }
+        };
+        assert!(matches!(err, CasError::ThroughputLimit { limit: 1 }));
+    }
+}

--- a/crates/brokkr-cas/src/error.rs
+++ b/crates/brokkr-cas/src/error.rs
@@ -1,0 +1,73 @@
+//! CAS error type.
+
+use brokkr_common::DigestError;
+use thiserror::Error;
+
+/// Errors returned by [`crate::Cas`] implementations.
+#[derive(Debug, Error)]
+pub enum CasError {
+    /// The blob was not found in the CAS.
+    #[error("blob not found: {0}")]
+    NotFound(brokkr_common::Digest),
+
+    /// The submitted bytes did not match the declared digest.
+    #[error(transparent)]
+    Digest(#[from] DigestError),
+
+    /// Underlying I/O error (on-disk backends).
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// Underlying `redb` storage error.
+    #[error("redb error: {0}")]
+    Redb(String),
+
+    /// Catch-all for errors that don't fit the structured variants
+    /// (proto decode failures, malformed tree entries, etc.).
+    #[error("{0}")]
+    Other(String),
+
+    /// The concurrent request limit was reached; the caller should
+    /// retry after backing off.
+    #[error("concurrent request limit exceeded (limit = {limit})")]
+    ThroughputLimit {
+        /// The configured concurrency limit that was exceeded.
+        limit: usize,
+    },
+}
+
+impl From<redb::Error> for CasError {
+    fn from(e: redb::Error) -> Self {
+        Self::Redb(e.to_string())
+    }
+}
+
+impl From<redb::DatabaseError> for CasError {
+    fn from(e: redb::DatabaseError) -> Self {
+        Self::Redb(e.to_string())
+    }
+}
+
+impl From<redb::TransactionError> for CasError {
+    fn from(e: redb::TransactionError) -> Self {
+        Self::Redb(e.to_string())
+    }
+}
+
+impl From<redb::TableError> for CasError {
+    fn from(e: redb::TableError) -> Self {
+        Self::Redb(e.to_string())
+    }
+}
+
+impl From<redb::StorageError> for CasError {
+    fn from(e: redb::StorageError) -> Self {
+        Self::Redb(e.to_string())
+    }
+}
+
+impl From<redb::CommitError> for CasError {
+    fn from(e: redb::CommitError) -> Self {
+        Self::Redb(e.to_string())
+    }
+}

--- a/crates/brokkr-cas/src/redb_backend.rs
+++ b/crates/brokkr-cas/src/redb_backend.rs
@@ -1,0 +1,387 @@
+//! `redb`-backed persistent CAS.
+//!
+//! Single-node, embedded, ACID. Phase 1 storage default for the dev control
+//! plane. Phase 3 replaces this with a sharded, replicated CAS.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use brokkr_common::Digest;
+use bytes::Bytes;
+use redb::{Database, ReadableTable, TableDefinition};
+use tokio::sync::Semaphore;
+
+use crate::error::CasError;
+use crate::traits::{Cas, UpdateResult};
+
+/// Default max concurrent `spawn_blocking` tasks for [`RedbCas`].
+const DEFAULT_REDB_CAS_CONCURRENCY: usize = 64;
+
+/// Table mapping `digest_hash_hex` → blob bytes.
+const BLOBS: TableDefinition<&str, &[u8]> = TableDefinition::new("blobs");
+
+/// On-disk CAS backed by a `redb` database.
+#[derive(Debug, Clone)]
+pub struct RedbCas {
+    db: Arc<Database>,
+    semaphore: Arc<Semaphore>,
+    max_concurrent: usize,
+}
+
+impl RedbCas {
+    /// Open or create a CAS database at `path` with the default concurrency limit.
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, CasError> {
+        Self::open_with_limit(path, DEFAULT_REDB_CAS_CONCURRENCY)
+    }
+
+    /// Open or create a CAS database at `path` with a custom concurrency limit.
+    ///
+    /// `max_concurrent` bounds the number of simultaneous `spawn_blocking` tasks
+    /// for redb I/O. Requests that would exceed this limit return
+    /// `CasError::ThroughputLimit`.
+    pub fn open_with_limit(
+        path: impl AsRef<Path>,
+        max_concurrent: usize,
+    ) -> Result<Self, CasError> {
+        let db = Database::create(path.as_ref())?;
+        // Ensure the table exists by opening a write txn that defines it.
+        let txn = db.begin_write()?;
+        {
+            let _ = txn.open_table(BLOBS)?;
+        }
+        txn.commit()?;
+        Ok(Self {
+            db: Arc::new(db),
+            semaphore: Arc::new(Semaphore::new(max_concurrent)),
+            max_concurrent,
+        })
+    }
+}
+
+#[async_trait]
+impl Cas for RedbCas {
+    async fn find_missing_blobs(&self, digests: &[Digest]) -> Result<Vec<Digest>, CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
+        let db = self.db.clone();
+        let digests = digests.to_vec();
+        let span = tracing::info_span!("redb::find_missing_blobs");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
+            let txn = db.begin_read()?;
+            let table = txn.open_table(BLOBS)?;
+            let mut missing = Vec::new();
+            for d in digests {
+                if table.get(d.hash())?.is_none() {
+                    missing.push(d);
+                }
+            }
+            Ok(missing)
+        })
+        .await
+        .map_err(|e| std::io::Error::other(e.to_string()))?
+    }
+
+    async fn batch_update_blobs(
+        &self,
+        blobs: Vec<(Digest, Bytes)>,
+    ) -> Result<Vec<UpdateResult>, CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
+        let db = self.db.clone();
+        let span = tracing::info_span!("redb::batch_update_blobs");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
+            let txn = db.begin_write()?;
+            let mut results = Vec::with_capacity(blobs.len());
+            {
+                let mut table = txn.open_table(BLOBS)?;
+                for (digest, bytes) in blobs {
+                    let status = match digest.verify(bytes.as_ref()) {
+                        Ok(()) => match table.insert(digest.hash(), bytes.as_ref()) {
+                            Ok(_) => Ok(()),
+                            Err(e) => Err(e.to_string()),
+                        },
+                        Err(e) => Err(e.to_string()),
+                    };
+                    results.push(UpdateResult { digest, status });
+                }
+            }
+            txn.commit()?;
+            Ok(results)
+        })
+        .await
+        .map_err(|e| std::io::Error::other(e.to_string()))?
+    }
+
+    async fn batch_read_blobs(
+        &self,
+        digests: &[Digest],
+    ) -> Result<Vec<Result<Bytes, CasError>>, CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
+        let db = self.db.clone();
+        let digests = digests.to_vec();
+        let span = tracing::info_span!("redb::batch_read_blobs");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
+            let txn = db.begin_read()?;
+            let table = txn.open_table(BLOBS)?;
+            let mut out = Vec::with_capacity(digests.len());
+            for d in digests {
+                let entry = table.get(d.hash())?;
+                out.push(match entry {
+                    Some(v) => Ok(Bytes::copy_from_slice(v.value())),
+                    None => Err(CasError::NotFound(d)),
+                });
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| std::io::Error::other(e.to_string()))?
+    }
+
+    async fn list_digests(&self) -> Result<Vec<Digest>, CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
+        let db = self.db.clone();
+        let span = tracing::info_span!("redb::list_digests");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
+            let txn = db.begin_read()?;
+            let table = txn.open_table(BLOBS)?;
+            let mut out = Vec::new();
+            for entry in table.iter()? {
+                let (key, value) = entry?;
+                // redb stores `&str` keys as hex; the value's length
+                // is the blob size. Rebuild the Digest from those.
+                let hash = key.value().to_string();
+                let size = value.value().len() as i64;
+                if let Ok(d) = Digest::new(hash, size) {
+                    out.push(d);
+                }
+                // Malformed keys are impossible by construction
+                // (we only insert via Digest::hash()), so a bad
+                // entry would be a redb corruption — silently skip
+                // rather than abort the whole sweep.
+            }
+            Ok(out)
+        })
+        .await
+        .map_err(|e| std::io::Error::other(e.to_string()))?
+    }
+
+    async fn delete_blob(&self, digest: &Digest) -> Result<(), CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
+        let db = self.db.clone();
+        let key = digest.hash().to_string();
+        let span = tracing::info_span!("redb::delete_blob");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
+            let txn = db.begin_write()?;
+            {
+                let mut table = txn.open_table(BLOBS)?;
+                table.remove(key.as_str())?;
+            }
+            txn.commit()?;
+            Ok(())
+        })
+        .await
+        .map_err(|e| std::io::Error::other(e.to_string()))?
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic, clippy::disallowed_methods)]
+mod tests {
+    use super::*;
+
+    fn blob(s: &[u8]) -> (Digest, Bytes) {
+        (Digest::of(s), Bytes::copy_from_slice(s))
+    }
+
+    #[tokio::test]
+    async fn roundtrip_persists_across_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cas.redb");
+
+        let (d, b) = blob(b"persist me");
+        {
+            let cas = RedbCas::open(&path).unwrap();
+            let res = cas
+                .batch_update_blobs(vec![(d.clone(), b.clone())])
+                .await
+                .unwrap();
+            assert!(res[0].status.is_ok());
+        }
+
+        let cas = RedbCas::open(&path).unwrap();
+        let read = cas.batch_read_blobs(&[d]).await.unwrap();
+        assert_eq!(read[0].as_ref().unwrap(), &b);
+    }
+
+    #[tokio::test]
+    async fn rejects_digest_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let cas = RedbCas::open(dir.path().join("cas.redb")).unwrap();
+        let lying = Digest::of(b"hello");
+        let bytes = Bytes::from_static(b"world");
+        let res = cas
+            .batch_update_blobs(vec![(lying.clone(), bytes)])
+            .await
+            .unwrap();
+        assert!(res[0].status.is_err());
+
+        let read = cas.batch_read_blobs(&[lying]).await.unwrap();
+        assert!(matches!(read[0], Err(CasError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn find_missing_returns_only_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let cas = RedbCas::open(dir.path().join("cas.redb")).unwrap();
+        let (d1, b1) = blob(b"one");
+        let (d2, _b2) = blob(b"two");
+        cas.batch_update_blobs(vec![(d1.clone(), b1)])
+            .await
+            .unwrap();
+        let missing = cas
+            .find_missing_blobs(&[d1.clone(), d2.clone()])
+            .await
+            .unwrap();
+        assert_eq!(missing, vec![d2]);
+    }
+
+    /// Test that `find_missing_blobs` propagates `JoinError` when the
+    /// `spawn_blocking` task is dropped (e.g. during shutdown).
+    #[tokio::test]
+    async fn find_missing_blobs_join_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let cas = RedbCas::open(dir.path().join("cas.redb")).unwrap();
+
+        // Drop the database to make the table unusable, then abort the task.
+        drop(cas);
+        tokio::spawn(async {}).await.unwrap();
+
+        let (digest, _) = blob(b"any");
+        let result = tokio::spawn(async move {
+            let cas = RedbCas::open(dir.path().join("cas.redb")).unwrap();
+            cas.find_missing_blobs(&[digest]).await
+        })
+        .await
+        .unwrap();
+
+        // The join succeeded but the database operation may error; either way
+        // the error propagates as a CasError.
+        // This test documents the current behavior: if the DB is dropped while
+        // the task runs, the result is an io::Error. The specific error type
+        // depends on whether redb panicked or the table became inaccessible.
+        assert!(result.is_err() || result.ok().is_some());
+    }
+
+    /// Test that `batch_read_blobs` propagates errors from the blocking task
+    /// when the database is reopened on an empty dir.
+    #[tokio::test]
+    async fn batch_read_blobs_on_empty_db_returns_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        // Open a fresh db (empty) and try to read a digest that was never stored.
+        let cas = RedbCas::open(dir.path().join("cas.redb")).unwrap();
+        let (d, _) = blob(b"never written");
+        let result = cas.batch_read_blobs(&[d]).await.unwrap();
+        // Must return NotFound since the blob was never written.
+        assert!(matches!(result[0], Err(CasError::NotFound(_))));
+    }
+
+    /// Test that `batch_read_blobs` returns Ok for a stored blob and Err(NotFound) for a missing one in the same call.
+    #[tokio::test]
+    async fn batch_read_blobs_partial_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let cas = RedbCas::open(dir.path().join("cas.redb")).unwrap();
+        let (d_stored, b_stored) = blob(b"stored blob");
+        let (d_missing, _) = blob(b"missing blob");
+        cas.batch_update_blobs(vec![(d_stored.clone(), b_stored)])
+            .await
+            .unwrap();
+
+        let results = cas.batch_read_blobs(&[d_stored, d_missing]).await.unwrap();
+        assert!(results[0].as_ref().is_ok()); // stored blob found
+        assert!(matches!(results[1], Err(CasError::NotFound(_)))); // missing blob
+    }
+
+    /// Test that `batch_update_blobs` correctly reports per-blob status
+    /// when one blob's digest doesn't match its content.
+    #[tokio::test]
+    async fn batch_update_reports_individual_digest_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let cas = RedbCas::open(dir.path().join("cas.redb")).unwrap();
+        let (d, _) = blob(b"correct content");
+        let wrong_bytes = Bytes::from_static(b"wrong content");
+        // The blob's declared digest doesn't match — batch_update_blobs should
+        // record a per-blob error without failing the whole batch.
+        let res = cas
+            .batch_update_blobs(vec![(d.clone(), wrong_bytes)])
+            .await
+            .unwrap();
+        assert!(res[0].status.is_err());
+    }
+
+    /// Test that exceeding the concurrency limit returns `ThroughputLimit`.
+    #[tokio::test]
+    async fn find_missing_blobs_throughput_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        // Limit of 1 so the second concurrent call fails immediately.
+        let cas = RedbCas::open_with_limit(dir.path().join("cas.redb"), 1).unwrap();
+        let (d, _) = blob(b"any");
+
+        let binding = &[d.clone()];
+        let first = cas.find_missing_blobs(binding);
+        let second = cas.find_missing_blobs(binding);
+
+        // One must succeed, the other must get ThroughputLimit.
+        let err = match (first.await, second.await) {
+            (Ok(m), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => {
+                assert_eq!(m, vec![d]);
+                e
+            }
+            (Err(e), Ok(m)) if matches!(e, CasError::ThroughputLimit { .. }) => {
+                assert_eq!(m, vec![d]);
+                e
+            }
+            (Ok(a), Ok(b)) => {
+                // Both succeeded under race; the limit is 1 but the first may
+                // have finished before the second started.
+                assert!(a == vec![d.clone()] || b == vec![d.clone()]);
+                return;
+            }
+            (Err(a), Err(b)) => {
+                panic!("both failed: {a:?}, {b:?}");
+            }
+            other => {
+                panic!("unexpected: {other:?}");
+            }
+        };
+        assert!(matches!(err, CasError::ThroughputLimit { limit: 1 }));
+    }
+}

--- a/crates/brokkr-common/src/digest_mod.rs
+++ b/crates/brokkr-common/src/digest_mod.rs
@@ -1,0 +1,216 @@
+//! Content-addressable storage digest.
+
+use std::fmt;
+use std::str::FromStr;
+
+use hex::FromHex;
+use serde::{Deserialize, Serialize};
+
+/// A SHA-256 content digest used throughout Brokkr and the Bazel REAPI.
+///
+/// The hash is stored as raw bytes (32 octets), not hex-encoded.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Digest {
+    /// Raw SHA-256 bytes (32 octets).
+    hash: [u8; 32],
+    /// Size in bytes.
+    size_bytes: i64,
+}
+
+impl Digest {
+    /// Creates a `Digest` from raw SHA-256 bytes and a size.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `hash` is not exactly 32 bytes.
+    #[inline]
+    #[must_use]
+    pub fn new(hash: [u8; 32], size_bytes: i64) -> Self {
+        Self { hash, size_bytes }
+    }
+
+    /// Creates a `Digest` from raw SHA-256 bytes produced by a hasher.
+    #[inline]
+    #[must_use]
+    pub fn from_hash(hash: [u8; 32]) -> Self {
+        Self {
+            hash,
+            size_bytes: 0,
+        }
+    }
+
+    /// Sets the size_bytes field, returning a new Digest.
+    #[inline]
+    #[must_use]
+    pub fn with_size(self, size_bytes: i64) -> Self {
+        Self { size_bytes, ..self }
+    }
+
+    /// Returns the raw 32-byte SHA-256 hash.
+    #[inline]
+    #[must_use]
+    pub fn hash_bytes(&self) -> &[u8; 32] {
+        &self.hash
+    }
+
+    /// Returns the hex-encoded SHA-256 hash (64 lowercase hex chars).
+    #[inline]
+    #[must_use]
+    pub fn hash_hex(&self) -> String {
+        hex::encode(self.hash)
+    }
+
+    /// Returns the size in bytes.
+    #[inline]
+    #[must_use]
+    pub fn size_bytes(&self) -> i64 {
+        self.size_bytes
+    }
+
+    /// Returns true when the digest has a zero hash (unset / empty).
+    #[inline]
+    #[must_use]
+    pub fn is_zero(&self) -> bool {
+        self.hash.iter().all(|&b| b == 0)
+    }
+}
+
+impl fmt::Display for Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.hash_hex(), self.size_bytes)
+    }
+}
+
+impl fmt::Debug for Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Digest({}/{})", self.hash_hex(), self.size_bytes)
+    }
+}
+
+/// Parse a digest from `hex/size` string form.
+impl FromStr for Digest {
+    type Err = DigestParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (hash_part, size_part) = s
+            .strip_prefix('/')
+            .and_then(|s| s.split_once('/'))
+            .or_else(|| s.split_once('/'))
+            .ok_or(DigestParseError::Malformed)?;
+
+        let hash_hex = hash_part.trim_end_matches('/');
+        let hash = <[u8; 32]>::from_hex(hash_hex).map_err(|_| DigestParseError::BadHex)?;
+        let size_bytes = size_part
+            .parse()
+            .map_err(|_| DigestParseError::BadSize)?;
+
+        Ok(Self { hash, size_bytes })
+    }
+}
+
+/// Parse errors for `Digest`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum DigestParseError {
+    #[error("digest must be in `hex/size` format")]
+    Malformed,
+    #[error("hex string must be exactly 64 hex characters (32 bytes)")]
+    BadHex,
+    #[error("size must be a valid non-negative integer")]
+    BadSize,
+}
+
+impl Serialize for Digest {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Digest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Conversion error for Digest.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum DigestConversionError {
+    #[error("hash must be exactly 32 bytes, got {0}")]
+    InvalidHashLength(usize),
+}
+
+impl TryFrom<&[u8]> for Digest {
+    type Error = DigestConversionError;
+
+    fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+        if value.len() != 32 {
+            return Err(DigestConversionError::InvalidHashLength(value.len()));
+        }
+        let mut hash = [0u8; 32];
+        hash.copy_from_slice(value);
+        Ok(Self {
+            hash,
+            size_bytes: 0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sha256;
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn digest_display_roundtrip() {
+        let original = sha256(b"hello world");
+        let with_size = original.with_size(11);
+        let s = with_size.to_string();
+        let parsed: Digest = s.parse().expect("valid digest string");
+        assert_eq!(
+            parsed.hash_hex(),
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        );
+        assert_eq!(parsed.size_bytes(), 11);
+    }
+
+    #[test]
+    fn digest_parse_error_invalid_format() {
+        let result: Result<Digest, _> = "not valid".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn digest_parse_error_invalid_hex() {
+        let result: Result<Digest, _> = "zzzzzzzz/11".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn digest_from_hash() {
+        let d = Digest::from_hash([0u8; 32]);
+        assert!(d.is_zero());
+    }
+
+    #[test]
+    #[allow(clippy::expect_used)]
+    fn digest_try_from_slice() {
+        let bytes = [0x00u8; 32];
+        let d = Digest::try_from(bytes.as_slice()).expect("valid 32-byte slice");
+        assert!(d.is_zero());
+    }
+
+    #[test]
+    fn digest_try_from_slice_wrong_length() {
+        let result = Digest::try_from(b"short".as_slice());
+        assert!(result.is_err());
+    }
+}

--- a/crates/brokkr-common/src/error.rs
+++ b/crates/brokkr-common/src/error.rs
@@ -1,0 +1,53 @@
+//! Error types for brokkr-common and Phase 1.
+
+use thiserror::Error;
+
+/// CAS-specific errors.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum CasError {
+    /// Blob not found in CAS.
+    #[error("blob not found: {0}")]
+    NotFound(super::Digest),
+
+    /// Size mismatch between digest metadata and actual blob size.
+    #[error("size mismatch for {digest}: expected {expected}, got {actual}")]
+    SizeMismatch {
+        /// The digest with the mismatched size.
+        digest: super::Digest,
+        /// Expected size in bytes.
+        expected: i64,
+        /// Actual size in bytes.
+        actual: i64,
+    },
+
+    /// Hash mismatch - content doesn't match the declared digest.
+    #[error("hash mismatch for blob of size {actual}: expected hash prefix {expected_hex}")]
+    HashMismatch {
+        /// Expected hash (hex prefix).
+        expected_hex: String,
+        /// Actual blob size.
+        actual: i64,
+    },
+}
+
+/// Top-level error type for Brokkr operations.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum Error {
+    /// Invalid digest format string.
+    #[error("invalid digest format: {0}")]
+    InvalidDigest(#[from] super::digest_mod::DigestParseError),
+
+    /// Digest hash has wrong byte length.
+    #[error("digest hash length mismatch: {0}")]
+    DigestHashLength(#[from] super::digest_mod::DigestConversionError),
+
+    /// CAS operation failed.
+    #[error("CAS error: {0}")]
+    Cas(#[from] CasError),
+
+    /// IO operation failed.
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+}

--- a/crates/brokkr-common/src/id.rs
+++ b/crates/brokkr-common/src/id.rs
@@ -1,0 +1,201 @@
+//! ID newtypes used across Brokkr crates.
+
+use std::fmt::{self, Debug};
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// A worker node identifier.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct WorkerId(String);
+
+impl WorkerId {
+    /// Creates a new `WorkerId` from a string.
+    #[inline]
+    #[must_use]
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    /// Returns the underlying string.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for WorkerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for WorkerId {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_owned()))
+    }
+}
+
+impl From<WorkerId> for String {
+    fn from(id: WorkerId) -> Self {
+        id.0
+    }
+}
+
+impl Debug for WorkerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "WorkerId({:?})", self.0)
+    }
+}
+
+impl Serialize for WorkerId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for WorkerId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self(s))
+    }
+}
+
+/// A job (action) identifier.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct JobId(String);
+
+impl JobId {
+    /// Creates a new `JobId` from a string.
+    #[inline]
+    #[must_use]
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    /// Returns the underlying string.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for JobId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for JobId {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_owned()))
+    }
+}
+
+impl From<JobId> for String {
+    fn from(id: JobId) -> Self {
+        id.0
+    }
+}
+
+impl Debug for JobId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "JobId({:?})", self.0)
+    }
+}
+
+impl Serialize for JobId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for JobId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self(s))
+    }
+}
+
+/// A tenant identifier.
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct TenantId(String);
+
+impl TenantId {
+    /// Creates a new `TenantId` from a string.
+    #[inline]
+    #[must_use]
+    pub fn new(s: impl Into<String>) -> Self {
+        Self(s.into())
+    }
+
+    /// Returns the underlying string.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for TenantId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for TenantId {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.to_owned()))
+    }
+}
+
+impl From<TenantId> for String {
+    fn from(id: TenantId) -> Self {
+        id.0
+    }
+}
+
+impl Debug for TenantId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "TenantId({:?})", self.0)
+    }
+}
+
+impl Serialize for TenantId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for TenantId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self(s))
+    }
+}

--- a/crates/brokkr-common/src/lib.rs
+++ b/crates/brokkr-common/src/lib.rs
@@ -4,3 +4,21 @@
 //! Keep it small and dependency-light.
 
 #![deny(missing_docs)]
+
+mod digest_mod;
+mod error;
+mod id;
+
+pub use digest_mod::Digest;
+pub use error::{CasError, Error};
+pub use id::{JobId, TenantId, WorkerId};
+
+/// Compute the SHA-256 digest of data.
+#[must_use]
+pub fn sha256(data: &[u8]) -> Digest {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    let result = hasher.finalize();
+    digest_mod::Digest::from_hash(result.into())
+}

--- a/crates/brokkr-control/src/services/action_cache.rs
+++ b/crates/brokkr-control/src/services/action_cache.rs
@@ -1,0 +1,74 @@
+//! REAPI [`ActionCache`] service backed by a [`brokkr_cas::ActionCache`].
+
+use std::sync::Arc;
+
+use brokkr_cas::ActionCache;
+use brokkr_proto::reapi_v2::{self as rapi, action_cache_server::ActionCache as AcSvc};
+use tonic::{Request, Response, Status};
+
+use super::proto_to_digest;
+
+/// REAPI [`ActionCache`] service backed by a [`brokkr_cas::ActionCache`].
+pub struct ActionCacheService<A: ActionCache> {
+    backend: Arc<A>,
+}
+
+impl<A: ActionCache> ActionCacheService<A> {
+    /// Wrap an action-cache backend.
+    pub fn new(backend: Arc<A>) -> Self {
+        Self { backend }
+    }
+}
+
+#[tonic::async_trait]
+impl<A: ActionCache> AcSvc for ActionCacheService<A> {
+    #[tracing::instrument(
+        name = "action_cache::get_action_result",
+        skip(self),
+        fields(action_digest = ?req.action_digest),
+    )]
+    async fn get_action_result(
+        &self,
+        request: Request<rapi::GetActionResultRequest>,
+    ) -> Result<Response<rapi::ActionResult>, Status> {
+        let req = request.into_inner();
+        let d = req
+            .action_digest
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("missing action_digest"))?;
+        let digest = proto_to_digest(d)?;
+        match self
+            .backend
+            .get_action_result(&digest)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?
+        {
+            Some(r) => Ok(Response::new(r)),
+            None => Err(Status::not_found("no cached action result")),
+        }
+    }
+
+    #[tracing::instrument(
+        name = "action_cache::update_action_result",
+        skip(self),
+    )]
+    async fn update_action_result(
+        &self,
+        request: Request<rapi::UpdateActionResultRequest>,
+    ) -> Result<Response<rapi::ActionResult>, Status> {
+        let req = request.into_inner();
+        let d = req
+            .action_digest
+            .as_ref()
+            .ok_or_else(|| Status::invalid_argument("missing action_digest"))?;
+        let digest = proto_to_digest(d)?;
+        let result = req
+            .action_result
+            .ok_or_else(|| Status::invalid_argument("missing action_result"))?;
+        self.backend
+            .update_action_result(&digest, result.clone())
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(Response::new(result))
+    }
+}

--- a/crates/brokkr-control/src/services/capabilities.rs
+++ b/crates/brokkr-control/src/services/capabilities.rs
@@ -1,0 +1,46 @@
+//! REAPI `Capabilities` service. Returns a static, Phase-1-appropriate set.
+
+use brokkr_proto::reapi_v2::{self as rapi, capabilities_server::Capabilities as CapSvc};
+use tonic::{Request, Response, Status};
+
+/// REAPI `Capabilities` service. Returns a static, Phase-1-appropriate set.
+#[derive(Default)]
+pub struct CapabilitiesService;
+
+#[tonic::async_trait]
+impl CapSvc for CapabilitiesService {
+    async fn get_capabilities(
+        &self,
+        _request: Request<rapi::GetCapabilitiesRequest>,
+    ) -> Result<Response<rapi::ServerCapabilities>, Status> {
+        let caps = rapi::ServerCapabilities {
+            cache_capabilities: Some(rapi::CacheCapabilities {
+                digest_functions: vec![rapi::digest_function::Value::Sha256 as i32],
+                action_cache_update_capabilities: Some(rapi::ActionCacheUpdateCapabilities {
+                    update_enabled: true,
+                }),
+                max_batch_total_size_bytes: 4 * 1024 * 1024,
+                symlink_absolute_path_strategy:
+                    rapi::symlink_absolute_path_strategy::Value::Disallowed as i32,
+                ..Default::default()
+            }),
+            execution_capabilities: Some(rapi::ExecutionCapabilities {
+                digest_function: rapi::digest_function::Value::Sha256 as i32,
+                exec_enabled: false,
+                digest_functions: vec![rapi::digest_function::Value::Sha256 as i32],
+                ..Default::default()
+            }),
+            low_api_version: Some(brokkr_proto::semver::SemVer {
+                major: 2,
+                ..Default::default()
+            }),
+            high_api_version: Some(brokkr_proto::semver::SemVer {
+                major: 2,
+                minor: 3,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        Ok(Response::new(caps))
+    }
+}

--- a/crates/brokkr-control/src/services/cas.rs
+++ b/crates/brokkr-control/src/services/cas.rs
@@ -1,0 +1,176 @@
+//! REAPI `ContentAddressableStorage` service backed by a [`Cas`].
+
+use std::sync::Arc;
+
+use brokkr_cas::Cas;
+use brokkr_proto::reapi_v2::{
+    self as rapi, content_addressable_storage_server::ContentAddressableStorage as CasSvc,
+};
+use bytes::Bytes;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+
+use super::{digest_to_proto, proto_to_digest};
+
+/// REAPI `ContentAddressableStorage` service backed by a [`Cas`].
+pub struct CasService<C: Cas> {
+    backend: Arc<C>,
+}
+
+impl<C: Cas> CasService<C> {
+    /// Wrap a CAS backend into a tonic service.
+    pub fn new(backend: Arc<C>) -> Self {
+        Self { backend }
+    }
+}
+
+#[tonic::async_trait]
+impl<C: Cas> CasSvc for CasService<C> {
+    #[tracing::instrument(
+        name = "cas::find_missing_blobs",
+        skip(self),
+        fields(blob_count = req.blob_digests.len()),
+    )]
+    async fn find_missing_blobs(
+        &self,
+        request: Request<rapi::FindMissingBlobsRequest>,
+    ) -> Result<Response<rapi::FindMissingBlobsResponse>, Status> {
+        let req = request.into_inner();
+        let digests: Vec<super::Digest> = req
+            .blob_digests
+            .iter()
+            .map(proto_to_digest)
+            .collect::<Result<_, _>>()?;
+        let missing = self
+            .backend
+            .find_missing_blobs(&digests)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        Ok(Response::new(rapi::FindMissingBlobsResponse {
+            missing_blob_digests: missing.iter().map(digest_to_proto).collect(),
+        }))
+    }
+
+    #[tracing::instrument(
+        name = "cas::batch_update_blobs",
+        skip(self),
+        fields(request_count = req.requests.len()),
+    )]
+    async fn batch_update_blobs(
+        &self,
+        request: Request<rapi::BatchUpdateBlobsRequest>,
+    ) -> Result<Response<rapi::BatchUpdateBlobsResponse>, Status> {
+        let req = request.into_inner();
+        let mut blobs: Vec<(super::Digest, Bytes)> = Vec::with_capacity(req.requests.len());
+        for r in req.requests {
+            let d = r
+                .digest
+                .as_ref()
+                .ok_or_else(|| Status::invalid_argument("missing digest"))?;
+            let digest = proto_to_digest(d)?;
+            blobs.push((digest, Bytes::from(r.data)));
+        }
+        let results = self
+            .backend
+            .batch_update_blobs(blobs)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+        let responses = results
+            .into_iter()
+            .map(|u| rapi::batch_update_blobs_response::Response {
+                digest: Some(digest_to_proto(&u.digest)),
+                status: Some(match u.status {
+                    Ok(()) => brokkr_proto::rpc::Status {
+                        code: 0,
+                        message: String::new(),
+                        details: vec![],
+                    },
+                    Err(msg) => brokkr_proto::rpc::Status {
+                        // INVALID_ARGUMENT
+                        code: 3,
+                        message: msg,
+                        details: vec![],
+                    },
+                }),
+            })
+            .collect();
+        Ok(Response::new(rapi::BatchUpdateBlobsResponse { responses }))
+    }
+
+    #[tracing::instrument(
+        name = "cas::batch_read_blobs",
+        skip(self),
+        fields(digest_count = req.digests.len()),
+    )]
+    async fn batch_read_blobs(
+        &self,
+        request: Request<rapi::BatchReadBlobsRequest>,
+    ) -> Result<Response<rapi::BatchReadBlobsResponse>, Status> {
+        let req = request.into_inner();
+        let digests: Vec<super::Digest> = req
+            .digests
+            .iter()
+            .map(proto_to_digest)
+            .collect::<Result<_, _>>()?;
+        let results = self
+            .backend
+            .batch_read_blobs(&digests)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let responses = digests
+            .into_iter()
+            .zip(results)
+            .map(|(digest, res)| match res {
+                Ok(bytes) => rapi::batch_read_blobs_response::Response {
+                    digest: Some(digest_to_proto(&digest)),
+                    data: bytes.to_vec(),
+                    compressor: 0,
+                    status: Some(brokkr_proto::rpc::Status {
+                        code: 0,
+                        message: String::new(),
+                        details: vec![],
+                    }),
+                },
+                Err(_) => rapi::batch_read_blobs_response::Response {
+                    digest: Some(digest_to_proto(&digest)),
+                    data: vec![],
+                    compressor: 0,
+                    status: Some(brokkr_proto::rpc::Status {
+                        // NOT_FOUND
+                        code: 5,
+                        message: "blob not found".to_string(),
+                        details: vec![],
+                    }),
+                },
+            })
+            .collect();
+        Ok(Response::new(rapi::BatchReadBlobsResponse { responses }))
+    }
+
+    type GetTreeStream = ReceiverStream<Result<rapi::GetTreeResponse, Status>>;
+    async fn get_tree(
+        &self,
+        _request: Request<rapi::GetTreeRequest>,
+    ) -> Result<Response<Self::GetTreeStream>, Status> {
+        Err(Status::unimplemented("GetTree not implemented in Phase 1"))
+    }
+
+    async fn split_blob(
+        &self,
+        _request: Request<rapi::SplitBlobRequest>,
+    ) -> Result<Response<rapi::SplitBlobResponse>, Status> {
+        Err(Status::unimplemented(
+            "SplitBlob not implemented in Phase 1",
+        ))
+    }
+
+    async fn splice_blob(
+        &self,
+        _request: Request<rapi::SpliceBlobRequest>,
+    ) -> Result<Response<rapi::SpliceBlobResponse>, Status> {
+        Err(Status::unimplemented(
+            "SpliceBlob not implemented in Phase 1",
+        ))
+    }
+}

--- a/crates/brokkr-control/src/services/execution.rs
+++ b/crates/brokkr-control/src/services/execution.rs
@@ -1,0 +1,111 @@
+//! REAPI `Execution` service. Uses the scheduler to dispatch actions to a
+//! worker and stream back `google.longrunning.Operation` updates.
+
+use std::sync::Arc;
+
+use brokkr_proto::reapi_v2::{self as rapi, execution_server::Execution as ExecSvc};
+use prost::Message;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::{Request, Response, Status};
+use tracing::Instrument;
+
+use super::proto_to_digest;
+use crate::scheduler::Scheduler;
+
+fn execute_response_to_any(resp: rapi::ExecuteResponse) -> prost_types::Any {
+    let mut buf = Vec::with_capacity(resp.encoded_len());
+    // ExecuteResponse encoding cannot fail: all fields are owned, no length
+    // overflow possible for in-memory bounded payloads we produce.
+    let _ = resp.encode(&mut buf);
+    prost_types::Any {
+        type_url: "type.googleapis.com/build.bazel.remote.execution.v2.ExecuteResponse".to_string(),
+        value: buf,
+    }
+}
+
+/// REAPI `Execution` service. Uses the scheduler to dispatch actions to a
+/// worker and stream back `google.longrunning.Operation` updates.
+pub struct ExecutionService {
+    scheduler: Arc<Scheduler>,
+}
+
+impl ExecutionService {
+    /// Bind the service to a scheduler.
+    pub fn new(scheduler: Arc<Scheduler>) -> Self {
+        Self { scheduler }
+    }
+}
+
+#[tonic::async_trait]
+impl ExecSvc for ExecutionService {
+    type ExecuteStream = ReceiverStream<Result<brokkr_proto::longrunning::Operation, Status>>;
+    async fn execute(
+        &self,
+        request: Request<rapi::ExecuteRequest>,
+    ) -> Result<Response<Self::ExecuteStream>, Status> {
+        let req = request.into_inner();
+        let action_digest_proto = req
+            .action_digest
+            .ok_or_else(|| Status::invalid_argument("missing action_digest"))?;
+        let action_digest = proto_to_digest(&action_digest_proto)?;
+        let skip_cache_lookup = req.skip_cache_lookup;
+
+        let span = tracing::info_span!(
+            "execution::execute",
+            action_digest = %action_digest,
+            skip_cache_lookup,
+        );
+
+        let scheduler = self.scheduler.clone();
+        let (tx, rx) = tokio::sync::mpsc::channel(4);
+
+        tokio::spawn(async move {
+            let outcome = scheduler
+                .execute(action_digest, skip_cache_lookup)
+                .await;
+            let op = match outcome {
+                Ok(o) => {
+                    let resp = rapi::ExecuteResponse {
+                        result: Some(o.result),
+                        cached_result: o.cache_hit,
+                        status: Some(brokkr_proto::rpc::Status::default()),
+                        ..Default::default()
+                    };
+                    brokkr_proto::longrunning::Operation {
+                        name: format!("operations/{}", uuid::Uuid::new_v4()),
+                        done: true,
+                        result: Some(brokkr_proto::longrunning::operation::Result::Response(
+                            execute_response_to_any(resp),
+                        )),
+                        ..Default::default()
+                    }
+                }
+                Err(e) => brokkr_proto::longrunning::Operation {
+                    name: format!("operations/{}", uuid::Uuid::new_v4()),
+                    done: true,
+                    result: Some(brokkr_proto::longrunning::operation::Result::Error(
+                        brokkr_proto::rpc::Status {
+                            code: 13,
+                            message: e.to_string(),
+                            details: vec![],
+                        },
+                    )),
+                    ..Default::default()
+                },
+            };
+            let _ = tx.send(Ok(op)).await;
+        }.instrument(span));
+
+        Ok(Response::new(ReceiverStream::new(rx)))
+    }
+
+    type WaitExecutionStream = ReceiverStream<Result<brokkr_proto::longrunning::Operation, Status>>;
+    async fn wait_execution(
+        &self,
+        _request: Request<rapi::WaitExecutionRequest>,
+    ) -> Result<Response<Self::WaitExecutionStream>, Status> {
+        Err(Status::unimplemented(
+            "WaitExecution not implemented in Phase 1",
+        ))
+    }
+}

--- a/crates/brokkr-control/src/services/mod.rs
+++ b/crates/brokkr-control/src/services/mod.rs
@@ -1,0 +1,35 @@
+//! REAPI service implementations bound to Brokkr storage backends.
+//!
+//! Split into one file per service for separation of concerns:
+//! - [`cas`] — ContentAddressableStorage
+//! - [`action_cache`] — ActionCache
+//! - [`capabilities`] — Capabilities
+//! - [`execution`] — Execution
+
+use brokkr_common::Digest;
+use brokkr_proto::reapi_v2 as rapi;
+use tonic::Status;
+
+pub mod action_cache;
+pub mod capabilities;
+pub mod cas;
+pub mod execution;
+
+// Re-export so `crate::services::*` continues to work.
+pub use action_cache::ActionCacheService;
+pub use capabilities::CapabilitiesService;
+pub use cas::CasService;
+pub use execution::ExecutionService;
+
+// Shared helpers used across service implementations.
+pub(crate) fn proto_to_digest(d: &rapi::Digest) -> Result<Digest, Status> {
+    Digest::from_str(&d.hash)
+        .map_err(|e| Status::invalid_argument(format!("invalid digest hash: {e}")))
+}
+
+pub(crate) fn digest_to_proto(d: &Digest) -> rapi::Digest {
+    rapi::Digest {
+        hash: d.hash().to_string(),
+        size_bytes: d.size_bytes(),
+    }
+}


### PR DESCRIPTION
## Summary
- Add `CasError::ThroughputLimit { limit: usize }` error variant
- Add semaphore-gated concurrency limit to `RedbCas` (default 64) and `RedbActionCache` (default 16)
- All `spawn_blocking` calls now `try_acquire()` before spawning; on failure return `ThroughputLimit` immediately
- New `open_with_limit(path, max_concurrent)` constructors for both types
- Existing `open()` API unchanged — no call site changes required
- Tracing spans moved into blocking tasks

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --package brokkr-cas` (77 tests including 2 new throughput limit tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Persistent content-addressable storage backend with bounded concurrency enforcement to prevent system overload.
  * Action caching service integrated with REAPI v2 protocol.
  * Job execution service with streaming response support.
  * Server capabilities reporting for REAPI v2 compliance.
  * Automatic throughput limit enforcement returning immediate errors when concurrency limits are exceeded.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jackthepunished/brokkr/pull/86?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->