### PR TITLE
fix(cas): bound spawn_blocking concurrency in RedbCas and RedbActionCache

### DIFF
--- a/crates/brokkr-cas/src/action_cache.rs
+++ b/crates/brokkr-cas/src/action_cache.rs
@@ -276,7 +276,7 @@ mod tests {
         let first = cache.get_action_result(&d);
         let second = cache.get_action_result(&d);
 
-        let err = match (first.await, second.await) {
+        let err = match tokio::join!(first, second) {
             (Ok(Some(_)), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
             (Err(e), Ok(Some(_))) if matches!(e, CasError::ThroughputLimit { .. }) => e,
             (Ok(Some(_)), Ok(Some(_))) => {
@@ -300,7 +300,7 @@ mod tests {
         let first = cache.update_action_result(&d, sample_result());
         let second = cache.update_action_result(&d, sample_result());
 
-        let err = match (first.await, second.await) {
+        let err = match tokio::join!(first, second) {
             (Ok(()), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
             (Err(e), Ok(())) if matches!(e, CasError::ThroughputLimit { .. }) => e,
             (Ok(_a), Ok(_b)) => {
@@ -331,7 +331,7 @@ mod tests {
         let first = cache.list_entries();
         let second = cache.list_entries();
 
-        let err = match (first.await, second.await) {
+        let err = match tokio::join!(first, second) {
             (Ok(_), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
             (Err(e), Ok(_)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
             (Ok(_a), Ok(_b)) => {

--- a/crates/brokkr-cas/src/action_cache.rs
+++ b/crates/brokkr-cas/src/action_cache.rs
@@ -289,4 +289,62 @@ mod tests {
         };
         assert!(matches!(err, CasError::ThroughputLimit { limit: 1 }));
     }
+
+    /// Test that exceeding the concurrency limit returns `ThroughputLimit`.
+    #[tokio::test]
+    async fn update_action_result_throughput_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = RedbActionCache::open_with_limit(dir.path().join("ac.redb"), 1).unwrap();
+        let d = Digest::of(b"any-action");
+
+        let first = cache.update_action_result(&d, sample_result());
+        let second = cache.update_action_result(&d, sample_result());
+
+        let err = match (first.await, second.await) {
+            (Ok(()), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
+            (Err(e), Ok(())) if matches!(e, CasError::ThroughputLimit { .. }) => e,
+            (Ok(_a), Ok(_b)) => {
+                // Both ok — one finished before the other started.
+                return;
+            }
+            (Err(a), Err(b)) => {
+                panic!("both failed: {a:?}, {b:?}");
+            }
+            other => {
+                panic!("unexpected: {other:?}");
+            }
+        };
+        assert!(matches!(err, CasError::ThroughputLimit { limit: 1 }));
+    }
+
+    /// Test that exceeding the concurrency limit returns `ThroughputLimit`.
+    #[tokio::test]
+    async fn list_entries_throughput_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = RedbActionCache::open_with_limit(dir.path().join("ac.redb"), 1).unwrap();
+        let d = Digest::of(b"any-action");
+        cache
+            .update_action_result(&d, sample_result())
+            .await
+            .unwrap();
+
+        let first = cache.list_entries();
+        let second = cache.list_entries();
+
+        let err = match (first.await, second.await) {
+            (Ok(_), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
+            (Err(e), Ok(_)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
+            (Ok(_a), Ok(_b)) => {
+                // Both ok — one finished before the other started.
+                return;
+            }
+            (Err(a), Err(b)) => {
+                panic!("both failed: {a:?}, {b:?}");
+            }
+            other => {
+                panic!("unexpected: {other:?}");
+            }
+        };
+        assert!(matches!(err, CasError::ThroughputLimit { limit: 1 }));
+    }
 }

--- a/crates/brokkr-cas/src/action_cache.rs
+++ b/crates/brokkr-cas/src/action_cache.rs
@@ -12,10 +12,14 @@ use brokkr_common::Digest;
 use brokkr_proto::reapi_v2::ActionResult;
 use prost::Message;
 use redb::{Database, ReadableTable, TableDefinition};
+use tokio::sync::Semaphore;
 
 use crate::error::CasError;
 
 const ACTION_RESULTS: TableDefinition<&str, &[u8]> = TableDefinition::new("action_results");
+
+/// Default max concurrent `spawn_blocking` tasks for [`RedbActionCache`].
+const DEFAULT_ACTION_CACHE_CONCURRENCY: usize = 16;
 
 /// REAPI Action Cache backend.
 #[async_trait]
@@ -48,18 +52,36 @@ pub trait ActionCache: Send + Sync + 'static {
 #[derive(Debug, Clone)]
 pub struct RedbActionCache {
     db: Arc<Database>,
+    semaphore: Arc<Semaphore>,
+    max_concurrent: usize,
 }
 
 impl RedbActionCache {
-    /// Open or create an action-cache database at `path`.
+    /// Open or create an action-cache database at `path` with the default concurrency limit.
     pub fn open(path: impl AsRef<Path>) -> Result<Self, CasError> {
+        Self::open_with_limit(path, DEFAULT_ACTION_CACHE_CONCURRENCY)
+    }
+
+    /// Open or create an action-cache database at `path` with a custom concurrency limit.
+    ///
+    /// `max_concurrent` bounds the number of simultaneous `spawn_blocking` tasks
+    /// for redb I/O. Requests that would exceed this limit return
+    /// `CasError::ThroughputLimit`.
+    pub fn open_with_limit(
+        path: impl AsRef<Path>,
+        max_concurrent: usize,
+    ) -> Result<Self, CasError> {
         let db = Database::create(path.as_ref())?;
         let txn = db.begin_write()?;
         {
             let _ = txn.open_table(ACTION_RESULTS)?;
         }
         txn.commit()?;
-        Ok(Self { db: Arc::new(db) })
+        Ok(Self {
+            db: Arc::new(db),
+            semaphore: Arc::new(Semaphore::new(max_concurrent)),
+            max_concurrent,
+        })
     }
 }
 
@@ -69,9 +91,17 @@ impl ActionCache for RedbActionCache {
         &self,
         action_digest: &Digest,
     ) -> Result<Option<ActionResult>, CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
         let db = self.db.clone();
         let key = action_digest.hash().to_string();
-        tokio::task::spawn_blocking(move || -> Result<Option<ActionResult>, CasError> {
+        let span = tracing::info_span!("redb::get_action_result");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
             let txn = db.begin_read()?;
             let table = txn.open_table(ACTION_RESULTS)?;
             let Some(entry) = table.get(key.as_str())? else {
@@ -91,13 +121,21 @@ impl ActionCache for RedbActionCache {
         action_digest: &Digest,
         result: ActionResult,
     ) -> Result<(), CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
         let db = self.db.clone();
         let key = action_digest.hash().to_string();
         let mut buf = Vec::with_capacity(result.encoded_len());
         result
             .encode(&mut buf)
             .map_err(|e| CasError::Redb(format!("ActionResult encode: {e}")))?;
-        tokio::task::spawn_blocking(move || -> Result<(), CasError> {
+        let span = tracing::info_span!("redb::update_action_result");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
             let txn = db.begin_write()?;
             {
                 let mut table = txn.open_table(ACTION_RESULTS)?;
@@ -111,8 +149,16 @@ impl ActionCache for RedbActionCache {
     }
 
     async fn list_entries(&self) -> Result<Vec<(Digest, ActionResult)>, CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
         let db = self.db.clone();
-        tokio::task::spawn_blocking(move || -> Result<Vec<(Digest, ActionResult)>, CasError> {
+        let span = tracing::info_span!("redb::list_entries");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
             let txn = db.begin_read()?;
             let table = txn.open_table(ACTION_RESULTS)?;
             let mut out = Vec::new();
@@ -215,5 +261,32 @@ mod tests {
         let cache = RedbActionCache::open(&path).unwrap();
         let got = cache.get_action_result(&d).await.unwrap().unwrap();
         assert_eq!(got.stdout_raw, b"hello world\n");
+    }
+
+    /// Test that exceeding the concurrency limit returns `ThroughputLimit`.
+    #[tokio::test]
+    async fn get_action_result_throughput_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        // Limit of 1 so the second concurrent call fails immediately.
+        let cache = RedbActionCache::open_with_limit(dir.path().join("ac.redb"), 1).unwrap();
+        let d = Digest::of(b"any-action");
+        let r = sample_result();
+        cache.update_action_result(&d, r).await.unwrap();
+
+        let first = cache.get_action_result(&d);
+        let second = cache.get_action_result(&d);
+
+        let err = match (first.await, second.await) {
+            (Ok(Some(_)), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
+            (Err(e), Ok(Some(_))) if matches!(e, CasError::ThroughputLimit { .. }) => e,
+            (Ok(Some(_)), Ok(Some(_))) => {
+                // Both ok — one finished before the other started.
+                return;
+            }
+            other => {
+                panic!("unexpected: {other:?}");
+            }
+        };
+        assert!(matches!(err, CasError::ThroughputLimit { limit: 1 }));
     }
 }

--- a/crates/brokkr-cas/src/error.rs
+++ b/crates/brokkr-cas/src/error.rs
@@ -26,6 +26,14 @@ pub enum CasError {
     /// (proto decode failures, malformed tree entries, etc.).
     #[error("{0}")]
     Other(String),
+
+    /// The concurrent request limit was reached; the caller should
+    /// retry after backing off.
+    #[error("concurrent request limit exceeded (limit = {limit})")]
+    ThroughputLimit {
+        /// The configured concurrency limit that was exceeded.
+        limit: usize,
+    },
 }
 
 impl From<redb::Error> for CasError {

--- a/crates/brokkr-cas/src/redb_backend.rs
+++ b/crates/brokkr-cas/src/redb_backend.rs
@@ -370,8 +370,7 @@ mod tests {
         let first = cas.find_missing_blobs(binding);
         let second = cas.find_missing_blobs(binding);
 
-        // One must succeed, the other must get ThroughputLimit.
-        let err = match (first.await, second.await) {
+        let err = match tokio::join!(first, second) {
             (Ok(m), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => {
                 assert_eq!(m, vec![d]);
                 e
@@ -407,7 +406,7 @@ mod tests {
         let first = cas.batch_update_blobs(vec![(d1.clone(), b1)]);
         let second = cas.batch_update_blobs(vec![(d2.clone(), b2)]);
 
-        let err = match (first.await, second.await) {
+        let err = match tokio::join!(first, second) {
             (Ok(r), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => {
                 assert!(r[0].status.is_ok());
                 e
@@ -443,7 +442,7 @@ mod tests {
         let first = cas.batch_read_blobs(&binding);
         let second = cas.batch_read_blobs(&binding);
 
-        let err = match (first.await, second.await) {
+        let err = match tokio::join!(first, second) {
             (Ok(r), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => {
                 assert!(r[0].as_ref().is_ok());
                 e
@@ -476,7 +475,7 @@ mod tests {
         let first = cas.list_digests();
         let second = cas.list_digests();
 
-        let err = match (first.await, second.await) {
+        let err = match tokio::join!(first, second) {
             (Ok(_), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
             (Err(e), Ok(_)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
             (Ok(a), Ok(b)) => {
@@ -505,7 +504,7 @@ mod tests {
         let first = cas.delete_blob(&d);
         let second = cas.delete_blob(&d);
 
-        let err = match (first.await, second.await) {
+        let err = match tokio::join!(first, second) {
             (Ok(()), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
             (Err(e), Ok(())) if matches!(e, CasError::ThroughputLimit { .. }) => e,
             (Ok(()), Ok(())) => {

--- a/crates/brokkr-cas/src/redb_backend.rs
+++ b/crates/brokkr-cas/src/redb_backend.rs
@@ -10,9 +10,13 @@ use async_trait::async_trait;
 use brokkr_common::Digest;
 use bytes::Bytes;
 use redb::{Database, ReadableTable, TableDefinition};
+use tokio::sync::Semaphore;
 
 use crate::error::CasError;
 use crate::traits::{Cas, UpdateResult};
+
+/// Default max concurrent `spawn_blocking` tasks for [`RedbCas`].
+const DEFAULT_REDB_CAS_CONCURRENCY: usize = 64;
 
 /// Table mapping `digest_hash_hex` → blob bytes.
 const BLOBS: TableDefinition<&str, &[u8]> = TableDefinition::new("blobs");
@@ -21,11 +25,25 @@ const BLOBS: TableDefinition<&str, &[u8]> = TableDefinition::new("blobs");
 #[derive(Debug, Clone)]
 pub struct RedbCas {
     db: Arc<Database>,
+    semaphore: Arc<Semaphore>,
+    max_concurrent: usize,
 }
 
 impl RedbCas {
-    /// Open or create a CAS database at `path`.
+    /// Open or create a CAS database at `path` with the default concurrency limit.
     pub fn open(path: impl AsRef<Path>) -> Result<Self, CasError> {
+        Self::open_with_limit(path, DEFAULT_REDB_CAS_CONCURRENCY)
+    }
+
+    /// Open or create a CAS database at `path` with a custom concurrency limit.
+    ///
+    /// `max_concurrent` bounds the number of simultaneous `spawn_blocking` tasks
+    /// for redb I/O. Requests that would exceed this limit return
+    /// `CasError::ThroughputLimit`.
+    pub fn open_with_limit(
+        path: impl AsRef<Path>,
+        max_concurrent: usize,
+    ) -> Result<Self, CasError> {
         let db = Database::create(path.as_ref())?;
         // Ensure the table exists by opening a write txn that defines it.
         let txn = db.begin_write()?;
@@ -33,16 +51,28 @@ impl RedbCas {
             let _ = txn.open_table(BLOBS)?;
         }
         txn.commit()?;
-        Ok(Self { db: Arc::new(db) })
+        Ok(Self {
+            db: Arc::new(db),
+            semaphore: Arc::new(Semaphore::new(max_concurrent)),
+            max_concurrent,
+        })
     }
 }
 
 #[async_trait]
 impl Cas for RedbCas {
     async fn find_missing_blobs(&self, digests: &[Digest]) -> Result<Vec<Digest>, CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
         let db = self.db.clone();
         let digests = digests.to_vec();
-        tokio::task::spawn_blocking(move || -> Result<Vec<Digest>, CasError> {
+        let span = tracing::info_span!("redb::find_missing_blobs");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
             let txn = db.begin_read()?;
             let table = txn.open_table(BLOBS)?;
             let mut missing = Vec::new();
@@ -61,8 +91,16 @@ impl Cas for RedbCas {
         &self,
         blobs: Vec<(Digest, Bytes)>,
     ) -> Result<Vec<UpdateResult>, CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
         let db = self.db.clone();
-        tokio::task::spawn_blocking(move || -> Result<Vec<UpdateResult>, CasError> {
+        let span = tracing::info_span!("redb::batch_update_blobs");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
             let txn = db.begin_write()?;
             let mut results = Vec::with_capacity(blobs.len());
             {
@@ -89,9 +127,17 @@ impl Cas for RedbCas {
         &self,
         digests: &[Digest],
     ) -> Result<Vec<Result<Bytes, CasError>>, CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
         let db = self.db.clone();
         let digests = digests.to_vec();
-        tokio::task::spawn_blocking(move || -> Result<Vec<Result<Bytes, CasError>>, CasError> {
+        let span = tracing::info_span!("redb::batch_read_blobs");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
             let txn = db.begin_read()?;
             let table = txn.open_table(BLOBS)?;
             let mut out = Vec::with_capacity(digests.len());
@@ -109,8 +155,16 @@ impl Cas for RedbCas {
     }
 
     async fn list_digests(&self) -> Result<Vec<Digest>, CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
         let db = self.db.clone();
-        tokio::task::spawn_blocking(move || -> Result<Vec<Digest>, CasError> {
+        let span = tracing::info_span!("redb::list_digests");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
             let txn = db.begin_read()?;
             let table = txn.open_table(BLOBS)?;
             let mut out = Vec::new();
@@ -135,9 +189,17 @@ impl Cas for RedbCas {
     }
 
     async fn delete_blob(&self, digest: &Digest) -> Result<(), CasError> {
+        let _permit = self
+            .semaphore
+            .try_acquire()
+            .map_err(|_| CasError::ThroughputLimit {
+                limit: self.max_concurrent,
+            })?;
         let db = self.db.clone();
         let key = digest.hash().to_string();
-        tokio::task::spawn_blocking(move || -> Result<(), CasError> {
+        let span = tracing::info_span!("redb::delete_blob");
+        tokio::task::spawn_blocking(move || {
+            let _guard = span.enter();
             let txn = db.begin_write()?;
             {
                 let mut table = txn.open_table(BLOBS)?;
@@ -283,5 +345,43 @@ mod tests {
             .await
             .unwrap();
         assert!(res[0].status.is_err());
+    }
+
+    /// Test that exceeding the concurrency limit returns `ThroughputLimit`.
+    #[tokio::test]
+    async fn find_missing_blobs_throughput_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        // Limit of 1 so the second concurrent call fails immediately.
+        let cas = RedbCas::open_with_limit(dir.path().join("cas.redb"), 1).unwrap();
+        let (d, _) = blob(b"any");
+
+        let binding = &[d.clone()];
+        let first = cas.find_missing_blobs(binding);
+        let second = cas.find_missing_blobs(binding);
+
+        // One must succeed, the other must get ThroughputLimit.
+        let err = match (first.await, second.await) {
+            (Ok(m), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => {
+                assert_eq!(m, vec![d]);
+                e
+            }
+            (Err(e), Ok(m)) if matches!(e, CasError::ThroughputLimit { .. }) => {
+                assert_eq!(m, vec![d]);
+                e
+            }
+            (Ok(a), Ok(b)) => {
+                // Both succeeded under race; the limit is 1 but the first may
+                // have finished before the second started.
+                assert!(a == vec![d.clone()] || b == vec![d.clone()]);
+                return;
+            }
+            (Err(a), Err(b)) => {
+                panic!("both failed: {a:?}, {b:?}");
+            }
+            other => {
+                panic!("unexpected: {other:?}");
+            }
+        };
+        assert!(matches!(err, CasError::ThroughputLimit { limit: 1 }));
     }
 }

--- a/crates/brokkr-cas/src/redb_backend.rs
+++ b/crates/brokkr-cas/src/redb_backend.rs
@@ -3,6 +3,7 @@
 //! Single-node, embedded, ACID. Phase 1 storage default for the dev control
 //! plane. Phase 3 replaces this with a sharded, replicated CAS.
 
+use std::fmt;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -22,11 +23,21 @@ const DEFAULT_REDB_CAS_CONCURRENCY: usize = 64;
 const BLOBS: TableDefinition<&str, &[u8]> = TableDefinition::new("blobs");
 
 /// On-disk CAS backed by a `redb` database.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct RedbCas {
     db: Arc<Database>,
     semaphore: Arc<Semaphore>,
     max_concurrent: usize,
+}
+
+impl fmt::Debug for RedbCas {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RedbCas")
+            .field("db", &self.db)
+            .field("semaphore", &"<Semaphore>")
+            .field("max_concurrent", &self.max_concurrent)
+            .finish()
+    }
 }
 
 impl RedbCas {
@@ -373,6 +384,132 @@ mod tests {
                 // Both succeeded under race; the limit is 1 but the first may
                 // have finished before the second started.
                 assert!(a == vec![d.clone()] || b == vec![d.clone()]);
+                return;
+            }
+            (Err(a), Err(b)) => {
+                panic!("both failed: {a:?}, {b:?}");
+            }
+            other => {
+                panic!("unexpected: {other:?}");
+            }
+        };
+        assert!(matches!(err, CasError::ThroughputLimit { limit: 1 }));
+    }
+
+    /// Test that exceeding the concurrency limit returns `ThroughputLimit`.
+    #[tokio::test]
+    async fn batch_update_blobs_throughput_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let cas = RedbCas::open_with_limit(dir.path().join("cas.redb"), 1).unwrap();
+        let (d1, b1) = blob(b"one");
+        let (d2, b2) = blob(b"two");
+
+        let first = cas.batch_update_blobs(vec![(d1.clone(), b1)]);
+        let second = cas.batch_update_blobs(vec![(d2.clone(), b2)]);
+
+        let err = match (first.await, second.await) {
+            (Ok(r), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => {
+                assert!(r[0].status.is_ok());
+                e
+            }
+            (Err(e), Ok(r)) if matches!(e, CasError::ThroughputLimit { .. }) => {
+                assert!(r[0].status.is_ok());
+                e
+            }
+            (Ok(a), Ok(b)) => {
+                // Both ok — one finished before the other started.
+                assert!(a[0].status.is_ok() || b[0].status.is_ok());
+                return;
+            }
+            (Err(a), Err(b)) => {
+                panic!("both failed: {a:?}, {b:?}");
+            }
+            other => {
+                panic!("unexpected: {other:?}");
+            }
+        };
+        assert!(matches!(err, CasError::ThroughputLimit { limit: 1 }));
+    }
+
+    /// Test that exceeding the concurrency limit returns `ThroughputLimit`.
+    #[tokio::test]
+    async fn batch_read_blobs_throughput_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let cas = RedbCas::open_with_limit(dir.path().join("cas.redb"), 1).unwrap();
+        let (d, b) = blob(b"read me");
+        cas.batch_update_blobs(vec![(d.clone(), b)]).await.unwrap();
+
+        let binding = [d.clone()];
+        let first = cas.batch_read_blobs(&binding);
+        let second = cas.batch_read_blobs(&binding);
+
+        let err = match (first.await, second.await) {
+            (Ok(r), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => {
+                assert!(r[0].as_ref().is_ok());
+                e
+            }
+            (Err(e), Ok(r)) if matches!(e, CasError::ThroughputLimit { .. }) => {
+                assert!(r[0].as_ref().is_ok());
+                e
+            }
+            (Ok(a), Ok(b)) => {
+                // Both ok — one finished before the other started.
+                assert!(a[0].as_ref().is_ok() || b[0].as_ref().is_ok());
+                return;
+            }
+            (Err(a), Err(b)) => {
+                panic!("both failed: {a:?}, {b:?}");
+            }
+            other => {
+                panic!("unexpected: {other:?}");
+            }
+        };
+        assert!(matches!(err, CasError::ThroughputLimit { limit: 1 }));
+    }
+
+    /// Test that exceeding the concurrency limit returns `ThroughputLimit`.
+    #[tokio::test]
+    async fn list_digests_throughput_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let cas = RedbCas::open_with_limit(dir.path().join("cas.redb"), 1).unwrap();
+
+        let first = cas.list_digests();
+        let second = cas.list_digests();
+
+        let err = match (first.await, second.await) {
+            (Ok(_), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
+            (Err(e), Ok(_)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
+            (Ok(a), Ok(b)) => {
+                // Both ok — one finished before the other started.
+                assert!(a.is_empty() || b.is_empty());
+                return;
+            }
+            (Err(a), Err(b)) => {
+                panic!("both failed: {a:?}, {b:?}");
+            }
+            other => {
+                panic!("unexpected: {other:?}");
+            }
+        };
+        assert!(matches!(err, CasError::ThroughputLimit { limit: 1 }));
+    }
+
+    /// Test that exceeding the concurrency limit returns `ThroughputLimit`.
+    #[tokio::test]
+    async fn delete_blob_throughput_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let cas = RedbCas::open_with_limit(dir.path().join("cas.redb"), 1).unwrap();
+        let (d, b) = blob(b"delete me");
+        cas.batch_update_blobs(vec![(d.clone(), b)]).await.unwrap();
+
+        let first = cas.delete_blob(&d);
+        let second = cas.delete_blob(&d);
+
+        let err = match (first.await, second.await) {
+            (Ok(()), Err(e)) if matches!(e, CasError::ThroughputLimit { .. }) => e,
+            (Err(e), Ok(())) if matches!(e, CasError::ThroughputLimit { .. }) => e,
+            (Ok(()), Ok(())) => {
+                // Both ok — one finished before the other started.
                 return;
             }
             (Err(a), Err(b)) => {


### PR DESCRIPTION
Add a semaphore-gated concurrency limit to all spawn_blocking calls in
RedbCas (default 64) and RedbActionCache (default 16). Requests that
cannot acquire a permit return CasError::ThroughputLimit immediately
instead of queuing unboundedly and risking OS thread-pool exhaustion.

New open_with_limit() constructors allow callers to override the limit.
Tracing spans are moved into the blocking tasks. Fixes issue #65 / H1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configurable concurrency limits for CAS I/O operations via new `open_with_limit` constructors
  * Default concurrency limits applied automatically with standard constructors

* **Improvements**
  * New `ThroughputLimit` error provides clear feedback when concurrent request limits are exceeded

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jackthepunished/brokkr/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->