### PR TITLE
feat(sandbox): wire PR_SET_TSC and fill Phase 2 evil-action gaps

### DIFF
--- a/crates/brokkr-sandbox/src/outcome.rs
+++ b/crates/brokkr-sandbox/src/outcome.rs
@@ -40,6 +40,31 @@ pub enum ExitStatus {
     Timeout,
 }
 
+impl ExitStatus {
+    /// Returns true if the action was killed by a signal.
+    pub fn signaled(&self) -> bool {
+        matches!(self, ExitStatus::Signaled { .. })
+    }
+
+    /// Returns the exit code that shell conventions prescribe:
+    /// - `Exited(n)` → `n`
+    /// - `Signaled { signal }` → `128 + signal`
+    /// - `OutOfMemory` → `137` (SIGKILL)
+    /// - `Timeout` → `137` (SIGKILL)
+    pub fn code(&self) -> Option<i32> {
+        match self {
+            ExitStatus::Exited(n) => Some(*n),
+            ExitStatus::Signaled { signal } => Some(128 + signal),
+            ExitStatus::OutOfMemory | ExitStatus::Timeout => Some(137),
+        }
+    }
+
+    /// Returns true if the action exited with code 0.
+    pub fn is_success(&self) -> bool {
+        self.code() == Some(0)
+    }
+}
+
 /// Cgroup-derived resource counters for one action. M2 returns zeros; M6
 /// reads `cpu.stat`, `memory.peak`, `io.stat`, `pids.peak` after the action
 /// exits and populates these fields.

--- a/crates/brokkr-sandbox/src/runner/exec.rs
+++ b/crates/brokkr-sandbox/src/runner/exec.rs
@@ -37,6 +37,9 @@ use super::seccomp::install as install_seccomp;
 use super::userns::{setup_namespaces, UidGidMap};
 use super::{die, errno_message};
 
+/// PR_SET_TSC argument that causes the CPU to raise SIGSEGV on any rdtsc/rdtscp instruction.
+const PR_TSC_SIGSEGV: nix::libc::c_ulong = 1;
+
 /// File descriptor on which the host writes the JSON-encoded
 /// `SandboxConfig`. Hard-coded by convention on both sides; see
 /// `docs/phase-2-plan.md` §3.3.
@@ -133,6 +136,20 @@ fn chdir_and_exec(cfg: &SandboxConfig) -> ! {
     if !cfg.rootfs.is_empty() {
         if let Err(e) = drop_all_except(&cfg.retained_caps) {
             die("drop capabilities", &e.to_string());
+        }
+        // M9: disable the timestamp counter so any rdtsc/rdtscp instruction
+        // raises SIGSEGV. Done after dropping caps (so it can't be undone by
+        // the action) but before installing seccomp (so we are still
+        // privileged enough to call prctl).
+        #[allow(unsafe_code)]
+        {
+            let rc = unsafe { nix::libc::prctl(nix::libc::PR_SET_TSC, PR_TSC_SIGSEGV, 0, 0, 0) };
+            if rc != 0 {
+                die(
+                    "prctl(PR_SET_TSC)",
+                    &std::io::Error::last_os_error().to_string(),
+                );
+            }
         }
         if let Err(e) = install_seccomp(&cfg.extra_seccomp_allow) {
             die("install seccomp", &e.to_string());

--- a/crates/brokkr-sandbox/tests/evil_seccomp_caps.rs
+++ b/crates/brokkr-sandbox/tests/evil_seccomp_caps.rs
@@ -4,12 +4,8 @@
 //! - **EV-02** action calls `mount(2)` directly → EPERM (seccomp).
 //! - **EV-03** action calls `keyctl(2)` directly → EPERM (seccomp).
 //! - **EV-04** action calls `ptrace(PTRACE_TRACEME)` → EPERM (seccomp).
-//! - **EV-09** RDTSC. The plan ("SIGSYS or EPERM, CPU dependent") notes
-//!   this requires a kernel/CPU willing to honour `PR_SET_TSC`. seccomp
-//!   does not gate userland-only instructions like `rdtsc`, so this case
-//!   is `#[ignore]`d on M7 — we'd need argument-level `prctl` filtering
-//!   (TODO marked in `runner/seccomp.rs`) plus `PR_SET_TSC=PR_TSC_SIGSEGV`
-//!   to make it deterministic.
+//! - **EV-09** RDTSC. The runner calls `prctl(PR_SET_TSC, PR_TSC_SIGSEGV)`
+//!   before exec so any `rdtsc`/`rdtscp` instruction raises SIGSEGV.
 //! - **EV-10** the runner sets `PR_SET_NO_NEW_PRIVS`. We assert this via
 //!   `prctl(PR_GET_NO_NEW_PRIVS)`, which should return 1 inside the
 //!   sandboxed process.
@@ -421,9 +417,33 @@ async fn ev_ioctl_tiocptlck_blocked() {
 
 #[cfg(target_arch = "x86_64")]
 #[tokio::test]
-#[ignore = "TODO(M7+): EV-09 needs prctl(PR_SET_TSC) wiring; seccomp can't gate rdtsc on its own"]
 async fn ev09_rdtsc_blocked() {
-    // Body intentionally empty — re-enable once PR_SET_TSC is wired.
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    // rdtsc instruction → SIGSEGV (signal 11, exit code 139 = 128 + 11)
+    // when PR_TSC_SIGSEGV is active.
+    let cfg = SandboxConfig {
+        argv: vec![
+            "/usr/bin/python3".into(),
+            "-c".into(),
+            "import mmap, ctypes, struct; \
+             code = mmap.mmap(-1, 4096, prot=7, flags=34); \
+             code.write(struct.pack('15B', 0x0f, 0x01, 0xf9, 0xc3)); \
+             func = ctypes.CFUNCTYPE(ctypes.c_ulong)(ctypes.addressof(code)); \
+             func()"
+                .into(),
+        ],
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    // SIGSEGV = signal 11, exit code = 128 + 11 = 139
+    assert!(
+        outcome.exit_status.signaled() && outcome.exit_status.code() == Some(139),
+        "rdtsc should cause SIGSEGV (exit 139); got {:?}",
+        outcome.exit_status
+    );
 }
 
 #[tokio::test]

--- a/crates/brokkr-sandbox/tests/mount_ns.rs
+++ b/crates/brokkr-sandbox/tests/mount_ns.rs
@@ -131,6 +131,34 @@ async fn ev01_cat_etc_shadow_fails() {
 }
 
 #[tokio::test]
+async fn ev01_cat_etc_passwd_fails() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    // /etc/passwd doesn't exist inside the sandbox (empty tmpfs at /etc).
+    // The action should get ENOENT, not exit 0.
+    let cfg = SandboxConfig {
+        argv: vec!["/usr/bin/cat".to_string(), "/etc/passwd".into()],
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        ..Default::default()
+    };
+    let outcome = match sandbox.run(cfg).await {
+        Ok(o) => o,
+        Err(e) => panic!("sandbox.run failed: {e:#}"),
+    };
+    assert_ne!(
+        outcome.exit_status,
+        ExitStatus::Exited(0),
+        "/etc/passwd should not exist inside the sandbox"
+    );
+    let stderr = String::from_utf8_lossy(&outcome.stderr);
+    assert!(
+        stderr.contains("No such file") || stderr.contains("cannot open"),
+        "expected ENOENT; got: {stderr}"
+    );
+}
+
+#[tokio::test]
 async fn ls_root_shows_only_expected_entries() {
     skip_if_unsupported!();
     let sandbox = Sandbox::new(runner_path());

--- a/crates/brokkr-sandbox/tests/net_ns.rs
+++ b/crates/brokkr-sandbox/tests/net_ns.rs
@@ -129,6 +129,31 @@ async fn ev08_public_address_unreachable() {
 }
 
 #[tokio::test]
+async fn ev08_nslookup_blocked() {
+    skip_if_unsupported!();
+    let sandbox = Sandbox::new(runner_path());
+    // nslookup to a non-existent nameserver (10.255.255.1) in an isolated
+    // netns (no loopback, no upstream) should fail — either NXDOMAIN,
+    // SERVFAIL, or connection refused. We just assert non-zero exit.
+    let cfg = SandboxConfig {
+        argv: vec![
+            "/usr/bin/nslookup".into(),
+            "google.com".into(),
+            "10.255.255.1".into(),
+        ],
+        rootfs: minimal_linux_rootfs(),
+        workdir: Some(PathBuf::from("/work")),
+        ..Default::default()
+    };
+    let outcome = sandbox.run(cfg).await.unwrap();
+    assert!(
+        !outcome.exit_status.is_success(),
+        "nslookup should fail in isolated netns; got {:?}",
+        outcome.exit_status
+    );
+}
+
+#[tokio::test]
 async fn loopback_down_makes_127_0_0_1_unreachable() {
     skip_if_unsupported!();
     let sandbox = Sandbox::new(runner_path());


### PR DESCRIPTION
## Summary

Wires up `PR_SET_TSC = PR_TSC_SIGSEGV` in the sandbox runner and fills three Phase 2 evil-action testing gaps:

- **PR_SET_TSC prctl** (`exec.rs`): Called between capability drop and seccomp install so it is privileged but cannot be undone. Causes `rdtsc`/`rdtscp` to raise `SIGSEGV` in the action.
- **`ev09_rdtsc_blocked`** (`evil_seccomp_caps.rs`): Uses Python + mmap + ctypes to execute raw x86_64 machine code (`rdtsc; ret`). Expects exit 139 (SIGSEGV). Previously `#[ignore]`, now active.
- **`ev08_nslookup_blocked`** (`net_ns.rs`): Runs `nslookup google.com 10.255.255.1` in isolated netns. Expects non-zero exit.
- **`ev01_cat_etc_passwd_fails`** (`mount_ns.rs`): `cat /etc/passwd` returns ENOENT since `/etc` is an empty tmpfs (mirrors `ev01_cat_etc_shadow_fails`).

## Test plan

- [ ] `cargo test -p brokkr-sandbox -- ev09_rdtsc_blocked` — passes on x86_64
- [ ] `cargo test -p brokkr-sandbox -- ev08_nslookup_blocked` — passes
- [ ] `cargo test -p brokkr-sandbox -- ev01_cat_etc_passwd_fails` — passes
- [ ] `cargo test -p brokkr-sandbox` — full suite green
- [ ] `cargo clippy -p brokkr-sandbox --all-targets -- -D warnings` — clean