### PR TITLE
docs(phase3): correct journal wrap-up to match shipped code

### DIFF
--- a/docs/journal/phase-3.md
+++ b/docs/journal/phase-3.md
@@ -568,7 +568,7 @@ M7:
 |---|---|---|
 | 1 | 3-node CAS cluster boots < 30s | n/a — no server binary; in-process fixture brings up the equivalent in ms (M1, M4, M7) |
 | 2 | Killing any single CAS node doesn't interrupt builds | ✅ exercised by the M7 soak (99 churn cycles, zero data loss) |
-| 3 | 5 GiB tree mounts via FUSE in < 100 ms; only-read bytes transfer | ✅ M6b — perf bound asserted on the integration test path; the 5 GiB number falls out of the inode-table walk being one CAS read per directory |
+| 3 | 5 GiB tree mounts via FUSE in < 100 ms; only-read bytes transfer | ❌ deferred — M6a ships eager tree materialisation (`brokkr-cas::tree`), which copies every byte up-front. FUSE-based lazy materialisation (M6b) was **not** implemented; no `fuse` module, no `fuser`/`memmap2` deps. Routed to Phase 4 |
 | 4 | `brokk admin gc` evicts unreachable + stale blobs | partial — M5a ships the GC primitive (`brokkr-cas::gc`); the `brokk admin gc` CLI subcommand is queued for Phase 4 along with the control-plane daemon |
 | 5 | M7 soak runs 1h with no loss | ✅ default-budget passes in 28 s; release-gate budget (`BROKKR_SOAK_OPS=1000000 BROKKR_SOAK_DURATION_S=3600`) is wired for CI |
 | 6 | `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace` green | ✅ verified each milestone, including M7 |
@@ -590,21 +590,28 @@ get lost):
 - **Cross-process / two-binary cluster boot.** Needs a
   `brokkr-cas` server binary that doesn't exist yet; that's
   Phase 4 too.
+- **M6b FUSE lazy materialisation.** Only M6a's eager
+  `tree::materialize_tree` shipped. The FUSE filesystem that
+  mounts multi-GiB trees in ~ms and fetches only the bytes the
+  action reads (DoD item #3) was never built. Picks up in Phase 4
+  alongside the worker materialisation path.
 
 **Phase 3 in numbers** (rough):
 
-- 8 milestones shipped (M0 plan, M1 membership/ring, M2
+- 9 milestones shipped (M0 plan, M1 membership/ring, M2
   bloom, M3a tiered, M4 replicated, M5a GC, M5b peer-repair,
-  M6a tree, M6b FUSE, M7 soak). M6 split into M6a+M6b
-  during execution; everything else hit the original
-  milestone scope.
+  M6a tree, M7 soak). M3 split into M3a (hot+warm) + M3b
+  (cold/S3, deferred); M6 split into M6a (eager tree) + M6b
+  (FUSE, deferred). Both deferred halves are routed to Phase 4.
 - ~4 kLOC new code + tests in `brokkr-cas` and
   `brokkr-worker`, broadly matching the §8 estimate.
 - Zero existing tests broken; Phase 1 + 2 suites still green
   end-to-end.
-- No new external deps that weren't on the plan: `fuser`,
-  `memmap2`, `parking_lot` (dev), `rand` (dev). `OpenDAL`
-  punted with the cold tier.
+- No new external non-dev deps: `parking_lot` (dev) and
+  `rand` (dev) are the only additions, both test-only.
+  `OpenDAL` punted with the cold tier (M3b); `fuser` /
+  `memmap2` punted with FUSE (M6b) — neither is in the
+  manifests or lockfile.
 
 **What's next.** Phase 4 — REAPI conformance + Bazel
 client interop + per-tenant accounting, per `docs/plan.md`


### PR DESCRIPTION
## Motivation

The Phase 3 journal wrap-up (`docs/journal/phase-3.md`) overstated what shipped. It marked DoD item #3 (FUSE lazy materialisation) as done via "M6b" and listed `fuser`/`memmap2` as added dependencies. None of that is real:

- There is **no** `fuse` module in `crates/brokkr-cas/src/` — only `tree.rs` (the M6a *eager* materialisation foundation, which copies every byte up-front).
- Neither `fuser` nor `memmap2` appears in any `Cargo.toml` or in `Cargo.lock`.

This left the project's own retrospective claiming a headline Phase 3 deliverable that was actually punted to Phase 4.

## What changed

Documentation only — `docs/journal/phase-3.md`:

- **DoD table item #3:** flipped from ✅ done to ❌ deferred, noting only M6a eager materialisation landed.
- **Deferred-to-Phase-4 list:** added an explicit M6b FUSE entry so it isn't lost.
- **"Phase 3 in numbers":** fixed the milestone count (said "8" but listed 10), removed M6b from the shipped list, and clarified that both M3b (cold tier) and M6b (FUSE) are deferred halves.
- **Deps line:** removed the false `fuser`/`memmap2` claim; the only additions are dev-only `parking_lot` + `rand`.

## How it was tested

No code touched — docs only. Verified against the tree that no `fuse` module exists and that `fuser`/`memmap2` are absent from the manifests and lockfile.

## Related

`docs/plan.md` §15 (Phase 3), `docs/phase-3-plan.md` §11 (DoD).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Phase 3 project milestones documentation to accurately reflect completed features and defer unfinished work to Phase 4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->