### PR TITLE
feat(control): worker registry with capabilities + heartbeat eviction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -605,3 +605,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `#[tracing::instrument]` span recording the assigned `worker_id`.
   Two handler tests (capabilities persisted; distinct id per
   registration).
+- `brokkr.v1.WorkerService.Heartbeat` RPC (`HeartbeatRequest{worker_id}`
+  → `HeartbeatResponse{known}`). `WorkerServiceImpl::heartbeat` refreshes
+  the worker's `last_seen` via `WorkerRegistry::record_heartbeat`; an
+  unknown/evicted worker is **not** an error — it gets `known=false` so
+  it re-registers instead of retrying a dead identity. A missing
+  `worker_id` is `INVALID_ARGUMENT`. Three handler tests (known after
+  register, unknown → not known, missing id → invalid argument). The
+  worker-side heartbeat sender and the background eviction tick are the
+  next increment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -593,3 +593,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   typed `RegistryError::UnknownWorker`. Ten unit tests. The
   heartbeat RPC + scheduler worker-selection wiring are the next
   increments; this lands the transport-agnostic data model first.
+- `brokkr-control::WorkerServiceImpl` now persists registrations into
+  a shared `WorkerRegistry` (`SharedWorkerRegistry =
+  Arc<Mutex<WorkerRegistry>>`): `register` records the worker's
+  hostname + labels as `WorkerCapabilities` (previously discarded) and
+  advertises `heartbeat_seconds` derived from the registry's policy
+  interval (5 s) instead of a hardcoded 30, so a worker that honours
+  the cadence is never evicted while healthy. New `with_registry`
+  constructor + `registry()` accessor share the handle with the
+  (forthcoming) heartbeat RPC and eviction tick. `register` gains a
+  `#[tracing::instrument]` span recording the assigned `worker_id`.
+  Two handler tests (capabilities persisted; distinct id per
+  registration).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -577,3 +577,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Non-Linux hosts get a compile-time stub
   (`fuse::mount::MountError::Unsupported`) so the CLI/SDK
   build stays portable.
+
+## Phase 4 (in progress)
+
+### Added
+- `brokkr-control::registry` — in-memory `WorkerRegistry` (plan §16
+  task 1). Tracks each worker's `WorkerCapabilities` (hostname +
+  free-form labels, mirroring `RegisterWorkerRequest`) and its
+  `last_seen` instant; `register` / `record_heartbeat` /
+  `evict_stale` / `healthy` operate against a caller-supplied
+  `now: Instant` so liveness is deterministic under test (no
+  internal `Instant::now`/`SystemTime::now`). `HeartbeatPolicy`
+  defaults to the plan's 5 s interval × 3 missed = 15 s eviction
+  deadline; `record_heartbeat` on an unknown worker returns the
+  typed `RegistryError::UnknownWorker`. Ten unit tests. The
+  heartbeat RPC + scheduler worker-selection wiring are the next
+  increments; this lands the transport-agnostic data model first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -614,3 +614,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   register, unknown → not known, missing id → invalid argument). The
   worker-side heartbeat sender and the background eviction tick are the
   next increment.
+- `brokkr-control::spawn_eviction_task` — background liveness reaper that
+  sweeps the shared `WorkerRegistry` once per heartbeat interval and
+  evicts workers past the deadline (`interval * max_missed`). Wired into
+  the `brokkr-control` binary; a zero interval disables it rather than
+  panicking. The eviction decision is `WorkerRegistry::evict_stale`
+  (unit-tested with an injected clock), so the wrapper is just the
+  periodic driver. New deterministic test
+  `eviction_is_observable_via_heartbeat`: register → evict → a
+  subsequent `Heartbeat` reports `known=false`.
+- `brokkr-worker`: the worker now runs a background heartbeat loop,
+  pinging `WorkerService.Heartbeat` on the `heartbeat_seconds` cadence
+  the control plane advertised at registration; on `known=false` it logs
+  and stops (full re-register is `TODO(brokkr-410)`). Closes plan §16
+  task 1 (worker registry + capabilities + heartbeat eviction).

--- a/crates/brokkr-control/src/lib.rs
+++ b/crates/brokkr-control/src/lib.rs
@@ -7,11 +7,15 @@
 #![deny(missing_docs)]
 
 pub mod membership;
+pub mod registry;
 pub mod scheduler;
 pub mod services;
 pub mod worker_service;
 
 pub use membership::{Membership, MembershipServiceImpl};
+pub use registry::{
+    HeartbeatPolicy, RegistryError, WorkerCapabilities, WorkerRecord, WorkerRegistry,
+};
 pub use scheduler::Scheduler;
 pub use services::{ActionCacheService, CapabilitiesService, CasService, ExecutionService};
 pub use worker_service::WorkerServiceImpl;

--- a/crates/brokkr-control/src/lib.rs
+++ b/crates/brokkr-control/src/lib.rs
@@ -18,4 +18,4 @@ pub use registry::{
 };
 pub use scheduler::Scheduler;
 pub use services::{ActionCacheService, CapabilitiesService, CasService, ExecutionService};
-pub use worker_service::WorkerServiceImpl;
+pub use worker_service::{spawn_eviction_task, SharedWorkerRegistry, WorkerServiceImpl};

--- a/crates/brokkr-control/src/main.rs
+++ b/crates/brokkr-control/src/main.rs
@@ -7,8 +7,8 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use brokkr_cas::{RedbActionCache, RedbCas};
 use brokkr_control::{
-    ActionCacheService, CapabilitiesService, CasService, ExecutionService, Scheduler,
-    WorkerServiceImpl,
+    spawn_eviction_task, ActionCacheService, CapabilitiesService, CasService, ExecutionService,
+    Scheduler, WorkerServiceImpl,
 };
 use brokkr_proto::brokkr_v1::worker_service_server::WorkerServiceServer;
 use brokkr_proto::reapi_v2::{
@@ -113,6 +113,12 @@ async fn main() -> Result<()> {
 
     tracing::info!(addr = %args.listen, data_dir = ?args.data_dir, "brokkr-control starting");
 
+    let worker_service = WorkerServiceImpl::new(scheduler.clone());
+    // Background liveness reaper: evict workers that stop heartbeating. Held
+    // for the server's lifetime; aborting it on shutdown is implicit (process
+    // exit). The eviction decision lives in `WorkerRegistry::evict_stale`.
+    let _eviction = spawn_eviction_task(worker_service.registry());
+
     let mut server = Server::builder();
     if let Some(tls_cfg) = tls_cfg {
         server = server.tls_config(tls_cfg)?;
@@ -126,7 +132,7 @@ async fn main() -> Result<()> {
         .add_service(ExecutionServer::new(ExecutionService::new(
             scheduler.clone(),
         )))
-        .add_service(WorkerServiceServer::new(WorkerServiceImpl::new(scheduler)))
+        .add_service(WorkerServiceServer::new(worker_service))
         .serve(args.listen)
         .await
         .context("control plane server exited")?;

--- a/crates/brokkr-control/src/registry.rs
+++ b/crates/brokkr-control/src/registry.rs
@@ -1,0 +1,400 @@
+//! In-memory worker registry with capability tracking and heartbeat-based
+//! liveness.
+//!
+//! This is the Phase 4 (`docs/plan.md` §16, task 1) foundation: the control
+//! plane records each worker's declared capabilities and the last time it was
+//! heard from, and evicts workers that miss too many heartbeats. The registry
+//! is deliberately transport-agnostic — it takes an explicit `now: Instant` on
+//! every time-sensitive call so it is deterministic under test (no
+//! `Instant::now()` / `SystemTime::now()` reached for internally). The
+//! heartbeat RPC and the scheduler's worker selection plug into this in later
+//! increments.
+
+use std::collections::{BTreeMap, HashMap};
+use std::time::{Duration, Instant};
+
+use brokkr_common::WorkerId;
+use thiserror::Error;
+
+/// Default heartbeat interval the control plane suggests to workers.
+///
+/// Plan §16, task 1: "Workers heartbeat every 5s".
+pub const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Default number of consecutive heartbeats a worker may miss before the
+/// control plane evicts it.
+///
+/// Plan §16, task 1: "control plane evicts after 3 missed heartbeats".
+pub const DEFAULT_MAX_MISSED_HEARTBEATS: u32 = 3;
+
+/// Errors returned by [`WorkerRegistry`] operations.
+#[derive(Debug, Error, PartialEq, Eq, Clone)]
+pub enum RegistryError {
+    /// A heartbeat (or other lookup) referenced a worker the registry has no
+    /// record of — either it was never registered or it has already been
+    /// evicted.
+    #[error("unknown worker: {0}")]
+    UnknownWorker(WorkerId),
+}
+
+/// Static description of what a worker can run.
+///
+/// Phase 4 starts with the same surface the `brokkr.v1.RegisterWorkerRequest`
+/// proto already carries (a human label plus free-form key/value labels).
+/// Richer fields (CPU cores, memory, installed tools, GPU) from the
+/// `WorkerCapability` sketch in plan §8 are added when constraint matching
+/// needs them.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WorkerCapabilities {
+    /// Hostname or human-friendly label. May be empty.
+    pub hostname: String,
+    /// Free-form constraint labels, e.g. `{"os": "linux", "arch": "x86_64"}`.
+    ///
+    /// A `BTreeMap` (not `HashMap`) so iteration and equality are
+    /// deterministic — the scheduler's constraint matcher will want a stable
+    /// order.
+    pub labels: BTreeMap<String, String>,
+}
+
+/// Liveness policy: how often workers heartbeat and how many they may miss.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HeartbeatPolicy {
+    /// Expected interval between heartbeats.
+    pub interval: Duration,
+    /// Number of consecutive missed heartbeats tolerated before eviction.
+    pub max_missed: u32,
+}
+
+impl HeartbeatPolicy {
+    /// The staleness deadline: a worker not heard from within
+    /// `interval * max_missed` is evictable.
+    ///
+    /// Saturates instead of overflowing on absurd configurations.
+    pub fn deadline(&self) -> Duration {
+        self.interval.saturating_mul(self.max_missed)
+    }
+}
+
+impl Default for HeartbeatPolicy {
+    fn default() -> Self {
+        Self {
+            interval: DEFAULT_HEARTBEAT_INTERVAL,
+            max_missed: DEFAULT_MAX_MISSED_HEARTBEATS,
+        }
+    }
+}
+
+/// A single registered worker's record.
+#[derive(Debug, Clone)]
+pub struct WorkerRecord {
+    /// What the worker declared it can run.
+    pub capabilities: WorkerCapabilities,
+    /// When the worker first registered (monotonic).
+    pub registered_at: Instant,
+    /// When the worker was last heard from (registration counts as the first
+    /// heartbeat).
+    pub last_seen: Instant,
+}
+
+impl WorkerRecord {
+    /// Whether this worker is stale as of `now` under `policy` — i.e. it has
+    /// not been heard from within the policy's [`deadline`](HeartbeatPolicy::deadline).
+    ///
+    /// Uses `saturating_duration_since` so a `now` earlier than `last_seen`
+    /// (clock skew in a caller-supplied instant) reads as "not stale" rather
+    /// than panicking.
+    pub fn is_stale(&self, now: Instant, policy: &HeartbeatPolicy) -> bool {
+        now.saturating_duration_since(self.last_seen) > policy.deadline()
+    }
+}
+
+/// In-memory registry of live workers.
+///
+/// Not internally synchronized — callers wrap it in their own lock (the
+/// control plane holds one behind a `tokio::sync::Mutex`/`RwLock`). Keeping
+/// the registry lock-free here makes the eviction logic trivially testable.
+#[derive(Debug)]
+pub struct WorkerRegistry {
+    workers: HashMap<WorkerId, WorkerRecord>,
+    policy: HeartbeatPolicy,
+}
+
+impl WorkerRegistry {
+    /// Create an empty registry with the given heartbeat policy.
+    pub fn new(policy: HeartbeatPolicy) -> Self {
+        Self {
+            workers: HashMap::new(),
+            policy,
+        }
+    }
+
+    /// The heartbeat policy in effect.
+    pub fn policy(&self) -> &HeartbeatPolicy {
+        &self.policy
+    }
+
+    /// Register (or re-register) a worker, recording `now` as both its
+    /// registration time and its first heartbeat.
+    ///
+    /// Re-registering an existing `id` replaces its capabilities and resets
+    /// `registered_at` — a worker that reconnects starts a fresh lifecycle.
+    pub fn register(&mut self, id: WorkerId, capabilities: WorkerCapabilities, now: Instant) {
+        tracing::debug!(worker_id = %id, hostname = %capabilities.hostname, "worker registered");
+        self.workers.insert(
+            id,
+            WorkerRecord {
+                capabilities,
+                registered_at: now,
+                last_seen: now,
+            },
+        );
+    }
+
+    /// Record a heartbeat from `id`, advancing its `last_seen` to `now`.
+    ///
+    /// Returns [`RegistryError::UnknownWorker`] if the worker is not
+    /// registered (the caller should tell the worker to re-register).
+    pub fn record_heartbeat(&mut self, id: &WorkerId, now: Instant) -> Result<(), RegistryError> {
+        match self.workers.get_mut(id) {
+            Some(record) => {
+                record.last_seen = now;
+                tracing::trace!(worker_id = %id, "heartbeat");
+                Ok(())
+            }
+            None => Err(RegistryError::UnknownWorker(id.clone())),
+        }
+    }
+
+    /// Remove every worker that is stale as of `now`, returning the evicted
+    /// IDs sorted lexically (for deterministic logging / assertions).
+    pub fn evict_stale(&mut self, now: Instant) -> Vec<WorkerId> {
+        let policy = self.policy;
+        let mut evicted: Vec<WorkerId> = self
+            .workers
+            .iter()
+            .filter(|(_, record)| record.is_stale(now, &policy))
+            .map(|(id, _)| id.clone())
+            .collect();
+        evicted.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        for id in &evicted {
+            self.workers.remove(id);
+            tracing::info!(worker_id = %id, "worker evicted (missed heartbeats)");
+        }
+        evicted
+    }
+
+    /// Fetch a worker's record, if registered.
+    pub fn get(&self, id: &WorkerId) -> Option<&WorkerRecord> {
+        self.workers.get(id)
+    }
+
+    /// Whether `id` is currently registered (regardless of staleness).
+    pub fn contains(&self, id: &WorkerId) -> bool {
+        self.workers.contains_key(id)
+    }
+
+    /// Number of registered workers (including any not yet evicted stale ones).
+    pub fn len(&self) -> usize {
+        self.workers.len()
+    }
+
+    /// Whether the registry has no workers.
+    pub fn is_empty(&self) -> bool {
+        self.workers.is_empty()
+    }
+
+    /// Iterate over all registered workers.
+    pub fn iter(&self) -> impl Iterator<Item = (&WorkerId, &WorkerRecord)> {
+        self.workers.iter()
+    }
+
+    /// Iterate over workers that are live (not stale) as of `now`.
+    ///
+    /// This is the set the scheduler will pick from — it does not mutate the
+    /// registry, so a stale-but-not-yet-evicted worker is simply skipped.
+    pub fn healthy(&self, now: Instant) -> impl Iterator<Item = (&WorkerId, &WorkerRecord)> {
+        let policy = self.policy;
+        self.workers
+            .iter()
+            .filter(move |(_, record)| !record.is_stale(now, &policy))
+    }
+}
+
+impl Default for WorkerRegistry {
+    fn default() -> Self {
+        Self::new(HeartbeatPolicy::default())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn wid(s: &str) -> WorkerId {
+        WorkerId::new(s.to_string()).unwrap()
+    }
+
+    fn caps(hostname: &str) -> WorkerCapabilities {
+        WorkerCapabilities {
+            hostname: hostname.to_string(),
+            labels: BTreeMap::new(),
+        }
+    }
+
+    /// Test policy: 1s interval, 3 missed → 3s deadline. Keeps the injected
+    /// instants easy to reason about.
+    fn test_policy() -> HeartbeatPolicy {
+        HeartbeatPolicy {
+            interval: Duration::from_secs(1),
+            max_missed: 3,
+        }
+    }
+
+    #[test]
+    fn deadline_is_interval_times_max_missed() {
+        assert_eq!(test_policy().deadline(), Duration::from_secs(3));
+        assert_eq!(
+            HeartbeatPolicy::default().deadline(),
+            Duration::from_secs(15)
+        );
+    }
+
+    #[test]
+    fn register_then_get_returns_record() {
+        let t0 = Instant::now();
+        let mut reg = WorkerRegistry::new(test_policy());
+        reg.register(wid("w1"), caps("host-a"), t0);
+
+        let record = reg.get(&wid("w1")).unwrap();
+        assert_eq!(record.capabilities.hostname, "host-a");
+        assert_eq!(record.registered_at, t0);
+        assert_eq!(record.last_seen, t0);
+        assert_eq!(reg.len(), 1);
+        assert!(!reg.is_empty());
+    }
+
+    #[test]
+    fn heartbeat_advances_last_seen() {
+        let t0 = Instant::now();
+        let mut reg = WorkerRegistry::new(test_policy());
+        reg.register(wid("w1"), caps("h"), t0);
+
+        let t1 = t0 + Duration::from_secs(2);
+        reg.record_heartbeat(&wid("w1"), t1).unwrap();
+        assert_eq!(reg.get(&wid("w1")).unwrap().last_seen, t1);
+        // registered_at is unchanged by a heartbeat.
+        assert_eq!(reg.get(&wid("w1")).unwrap().registered_at, t0);
+    }
+
+    #[test]
+    fn heartbeat_for_unknown_worker_errors() {
+        let mut reg = WorkerRegistry::new(test_policy());
+        let err = reg
+            .record_heartbeat(&wid("ghost"), Instant::now())
+            .unwrap_err();
+        assert_eq!(err, RegistryError::UnknownWorker(wid("ghost")));
+    }
+
+    #[test]
+    fn worker_within_deadline_is_not_stale_or_evicted() {
+        let t0 = Instant::now();
+        let mut reg = WorkerRegistry::new(test_policy()); // 3s deadline
+        reg.register(wid("w1"), caps("h"), t0);
+
+        // Exactly at the deadline is NOT stale (strictly-greater comparison).
+        let at_deadline = t0 + Duration::from_secs(3);
+        assert!(!reg
+            .get(&wid("w1"))
+            .unwrap()
+            .is_stale(at_deadline, reg.policy()));
+        assert!(reg.evict_stale(at_deadline).is_empty());
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn worker_past_deadline_is_evicted() {
+        let t0 = Instant::now();
+        let mut reg = WorkerRegistry::new(test_policy()); // 3s deadline
+        reg.register(wid("w1"), caps("h"), t0);
+
+        let past = t0 + Duration::from_secs(3) + Duration::from_nanos(1);
+        assert!(reg.get(&wid("w1")).unwrap().is_stale(past, reg.policy()));
+        let evicted = reg.evict_stale(past);
+        assert_eq!(evicted, vec![wid("w1")]);
+        assert!(!reg.contains(&wid("w1")));
+        assert!(reg.is_empty());
+    }
+
+    #[test]
+    fn heartbeat_keeps_worker_alive_across_deadline() {
+        let t0 = Instant::now();
+        let mut reg = WorkerRegistry::new(test_policy()); // 3s deadline
+        reg.register(wid("w1"), caps("h"), t0);
+
+        // Heartbeat at +2s, then check at +4s: only 2s since last_seen → alive.
+        reg.record_heartbeat(&wid("w1"), t0 + Duration::from_secs(2))
+            .unwrap();
+        let evicted = reg.evict_stale(t0 + Duration::from_secs(4));
+        assert!(
+            evicted.is_empty(),
+            "fresh heartbeat should prevent eviction"
+        );
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn evict_stale_only_removes_the_stale_and_returns_sorted() {
+        let t0 = Instant::now();
+        let mut reg = WorkerRegistry::new(test_policy()); // 3s deadline
+        reg.register(wid("w-zeta"), caps("h"), t0);
+        reg.register(wid("w-alpha"), caps("h"), t0);
+        // Keep w-mid fresh.
+        reg.register(wid("w-mid"), caps("h"), t0);
+        reg.record_heartbeat(&wid("w-mid"), t0 + Duration::from_secs(4))
+            .unwrap();
+
+        let now = t0 + Duration::from_secs(5);
+        let evicted = reg.evict_stale(now);
+        // Sorted lexically; w-mid survives.
+        assert_eq!(evicted, vec![wid("w-alpha"), wid("w-zeta")]);
+        assert!(reg.contains(&wid("w-mid")));
+        assert_eq!(reg.len(), 1);
+    }
+
+    #[test]
+    fn healthy_skips_stale_without_evicting() {
+        let t0 = Instant::now();
+        let mut reg = WorkerRegistry::new(test_policy());
+        reg.register(wid("fresh"), caps("h"), t0);
+        reg.register(wid("stale"), caps("h"), t0);
+        reg.record_heartbeat(&wid("fresh"), t0 + Duration::from_secs(5))
+            .unwrap();
+
+        let now = t0 + Duration::from_secs(6);
+        let healthy: Vec<&str> = {
+            let mut v: Vec<&str> = reg.healthy(now).map(|(id, _)| id.as_str()).collect();
+            v.sort_unstable();
+            v
+        };
+        assert_eq!(healthy, vec!["fresh"]);
+        // healthy() is read-only: the stale worker is still registered.
+        assert_eq!(reg.len(), 2);
+        assert!(reg.contains(&wid("stale")));
+    }
+
+    #[test]
+    fn reregister_resets_lifecycle() {
+        let t0 = Instant::now();
+        let mut reg = WorkerRegistry::new(test_policy());
+        reg.register(wid("w1"), caps("old-host"), t0);
+
+        let t1 = t0 + Duration::from_secs(10);
+        reg.register(wid("w1"), caps("new-host"), t1);
+        let record = reg.get(&wid("w1")).unwrap();
+        assert_eq!(record.capabilities.hostname, "new-host");
+        assert_eq!(record.registered_at, t1);
+        assert_eq!(record.last_seen, t1);
+        assert_eq!(reg.len(), 1, "re-register replaces, not duplicates");
+    }
+}

--- a/crates/brokkr-control/src/worker_service.rs
+++ b/crates/brokkr-control/src/worker_service.rs
@@ -6,8 +6,9 @@ use std::time::Instant;
 
 use brokkr_common::WorkerId;
 use brokkr_proto::brokkr_v1::{
-    self as bv1, worker_service_server::WorkerService, JobAssignment, RegisterWorkerRequest,
-    RegisterWorkerResponse, WorkerId as ProtoWorkerId, WorkerStreamMessage,
+    self as bv1, worker_service_server::WorkerService, HeartbeatRequest, HeartbeatResponse,
+    JobAssignment, RegisterWorkerRequest, RegisterWorkerResponse, WorkerId as ProtoWorkerId,
+    WorkerStreamMessage,
 };
 use tokio::sync::{mpsc, Mutex};
 use tokio_stream::wrappers::ReceiverStream;
@@ -90,6 +91,39 @@ impl WorkerService for WorkerServiceImpl {
             }),
             heartbeat_seconds,
         }))
+    }
+
+    #[tracing::instrument(
+        name = "worker_service::heartbeat",
+        skip(self, request),
+        fields(worker_id = tracing::field::Empty, known = tracing::field::Empty),
+    )]
+    async fn heartbeat(
+        &self,
+        request: Request<HeartbeatRequest>,
+    ) -> Result<Response<HeartbeatResponse>, Status> {
+        let req = request.into_inner();
+        let worker_id_proto = req
+            .worker_id
+            .ok_or_else(|| Status::invalid_argument("HeartbeatRequest.worker_id missing"))?;
+        let worker_id = WorkerId::new(worker_id_proto.id)
+            .map_err(|e| Status::invalid_argument(format!("invalid worker id: {e}")))?;
+        tracing::Span::current().record("worker_id", worker_id.as_str());
+
+        // An unknown worker is not an error — the registry may have evicted it
+        // after missed heartbeats, or it never registered. Reply `known=false`
+        // so the worker re-registers rather than retrying a dead identity.
+        let known = {
+            let mut registry = self.registry.lock().await;
+            registry
+                .record_heartbeat(&worker_id, Instant::now())
+                .is_ok()
+        };
+        tracing::Span::current().record("known", known);
+        if !known {
+            tracing::warn!("heartbeat from unknown worker; signalling re-register");
+        }
+        Ok(Response::new(HeartbeatResponse { known }))
     }
 
     type StreamStream = ReceiverStream<Result<JobAssignment, Status>>;
@@ -263,5 +297,51 @@ mod tests {
             .into_inner();
         assert_ne!(r1.worker_id.unwrap().id, r2.worker_id.unwrap().id);
         assert_eq!(svc.registry().lock().await.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_after_register_is_known() {
+        let svc = service();
+        let id = svc
+            .register(Request::new(RegisterWorkerRequest::default()))
+            .await
+            .unwrap()
+            .into_inner()
+            .worker_id
+            .unwrap();
+
+        let resp = svc
+            .heartbeat(Request::new(HeartbeatRequest {
+                worker_id: Some(id),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(resp.known);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_for_unknown_worker_is_not_known() {
+        let svc = service();
+        let resp = svc
+            .heartbeat(Request::new(HeartbeatRequest {
+                worker_id: Some(ProtoWorkerId {
+                    id: "never-registered".to_string(),
+                }),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(!resp.known);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_with_missing_worker_id_is_invalid_argument() {
+        let svc = service();
+        let status = svc
+            .heartbeat(Request::new(HeartbeatRequest { worker_id: None }))
+            .await
+            .unwrap_err();
+        assert_eq!(status.code(), tonic::Code::InvalidArgument);
     }
 }

--- a/crates/brokkr-control/src/worker_service.rs
+++ b/crates/brokkr-control/src/worker_service.rs
@@ -2,7 +2,7 @@
 //! job-dispatch stream. Phase 1 only supports a single worker at a time.
 
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use brokkr_common::WorkerId;
 use brokkr_proto::brokkr_v1::{
@@ -13,6 +13,7 @@ use brokkr_proto::brokkr_v1::{
 use tokio::sync::{mpsc, Mutex};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, Streaming};
+use tracing::Instrument;
 
 use crate::registry::{WorkerCapabilities, WorkerRegistry};
 use crate::scheduler::Scheduler;
@@ -47,11 +48,50 @@ impl WorkerServiceImpl {
         }
     }
 
-    /// The shared worker registry handle. Used by the (forthcoming) heartbeat
-    /// handler, the eviction tick, and tests.
+    /// The shared worker registry handle. Used by the heartbeat handler, the
+    /// eviction tick, and tests.
     pub fn registry(&self) -> SharedWorkerRegistry {
         self.registry.clone()
     }
+}
+
+/// Spawn the background liveness reaper: every registry-policy interval it
+/// evicts workers that have missed too many heartbeats.
+///
+/// This is just the periodic driver — the eviction *decision* lives in
+/// [`WorkerRegistry::evict_stale`] (unit-tested with an injected clock). Wire
+/// this into the control-plane binary; hold the returned handle for the
+/// server's lifetime (dropping/aborting it stops the reaper).
+pub fn spawn_eviction_task(registry: SharedWorkerRegistry) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(
+        async move {
+            // Tick at the heartbeat interval; the deadline (interval *
+            // max_missed) is enforced inside `evict_stale`, so checking once
+            // per interval bounds eviction lag to one interval.
+            let interval = registry.lock().await.policy().interval;
+            // `tokio::time::interval` panics on a zero period; a zero-interval
+            // policy disables the reaper rather than crashing the server.
+            if interval == Duration::ZERO {
+                tracing::warn!("eviction reaper disabled (heartbeat interval is zero)");
+                return;
+            }
+            let mut ticker = tokio::time::interval(interval);
+            // Drop the immediate first tick so freshly-registered workers get
+            // a full interval before the first sweep.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                let evicted = {
+                    let mut reg = registry.lock().await;
+                    reg.evict_stale(Instant::now())
+                };
+                if !evicted.is_empty() {
+                    tracing::info!(count = evicted.len(), "evicted stale workers");
+                }
+            }
+        }
+        .in_current_span(),
+    )
 }
 
 #[tonic::async_trait]
@@ -343,5 +383,37 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(status.code(), tonic::Code::InvalidArgument);
+    }
+
+    /// End-to-end through the RPC surface, deterministically (no timers):
+    /// register → evict via the shared registry with an injected future
+    /// instant → a subsequent heartbeat reports `known=false`. Proves the
+    /// register handler, the registry, and the heartbeat handler all share one
+    /// source of truth and that eviction is observable to the worker.
+    #[tokio::test]
+    async fn eviction_is_observable_via_heartbeat() {
+        let svc = service();
+        let id = svc
+            .register(Request::new(RegisterWorkerRequest::default()))
+            .await
+            .unwrap()
+            .into_inner()
+            .worker_id
+            .unwrap();
+
+        // Force eviction by sweeping with an instant well past the deadline.
+        let deadline = svc.registry().lock().await.policy().deadline();
+        let future = Instant::now() + deadline + Duration::from_secs(1);
+        let evicted = svc.registry().lock().await.evict_stale(future);
+        assert_eq!(evicted.len(), 1);
+
+        let resp = svc
+            .heartbeat(Request::new(HeartbeatRequest {
+                worker_id: Some(id),
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+        assert!(!resp.known, "evicted worker should be told to re-register");
     }
 }

--- a/crates/brokkr-control/src/worker_service.rs
+++ b/crates/brokkr-control/src/worker_service.rs
@@ -2,45 +2,93 @@
 //! job-dispatch stream. Phase 1 only supports a single worker at a time.
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use brokkr_common::WorkerId;
 use brokkr_proto::brokkr_v1::{
     self as bv1, worker_service_server::WorkerService, JobAssignment, RegisterWorkerRequest,
     RegisterWorkerResponse, WorkerId as ProtoWorkerId, WorkerStreamMessage,
 };
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status, Streaming};
 
+use crate::registry::{WorkerCapabilities, WorkerRegistry};
 use crate::scheduler::Scheduler;
+
+/// Shared, mutex-guarded [`WorkerRegistry`] handle.
+///
+/// The registry is mutated by the `register` / heartbeat RPC handlers and a
+/// background eviction tick, so it lives behind an async `Mutex` shared via
+/// `Arc`. Cloning the handle is a cheap `Arc` bump.
+pub type SharedWorkerRegistry = Arc<Mutex<WorkerRegistry>>;
 
 /// `brokkr.v1.WorkerService` implementation backed by [`Scheduler`].
 pub struct WorkerServiceImpl {
     scheduler: Arc<Scheduler>,
+    registry: SharedWorkerRegistry,
 }
 
 impl WorkerServiceImpl {
-    /// Bind the service to a scheduler.
+    /// Bind the service to a scheduler, creating a fresh default-policy
+    /// [`WorkerRegistry`].
     pub fn new(scheduler: Arc<Scheduler>) -> Self {
-        Self { scheduler }
+        Self::with_registry(scheduler, Arc::new(Mutex::new(WorkerRegistry::default())))
+    }
+
+    /// Bind the service to a scheduler and an externally-owned worker
+    /// registry, so a background eviction task (or a test) can share the same
+    /// handle.
+    pub fn with_registry(scheduler: Arc<Scheduler>, registry: SharedWorkerRegistry) -> Self {
+        Self {
+            scheduler,
+            registry,
+        }
+    }
+
+    /// The shared worker registry handle. Used by the (forthcoming) heartbeat
+    /// handler, the eviction tick, and tests.
+    pub fn registry(&self) -> SharedWorkerRegistry {
+        self.registry.clone()
     }
 }
 
 #[tonic::async_trait]
 impl WorkerService for WorkerServiceImpl {
+    #[tracing::instrument(
+        name = "worker_service::register",
+        skip(self, request),
+        fields(worker_id = tracing::field::Empty),
+    )]
     async fn register(
         &self,
-        _request: Request<RegisterWorkerRequest>,
+        request: Request<RegisterWorkerRequest>,
     ) -> Result<Response<RegisterWorkerResponse>, Status> {
-        let span = tracing::info_span!("worker_service::register");
-        let _guard = span.enter();
+        let req = request.into_inner();
         let worker_id = WorkerId::new(uuid::Uuid::new_v4().to_string())
             .map_err(|e| Status::internal(format!("invalid worker id: {e}")))?;
+        tracing::Span::current().record("worker_id", worker_id.as_str());
+
+        let capabilities = WorkerCapabilities {
+            hostname: req.hostname,
+            labels: req.labels.into_iter().collect(),
+        };
+
+        // Advertise the cadence the eviction policy actually expects, so a
+        // worker that honours it is never evicted while healthy. Registration
+        // counts as the worker's first heartbeat.
+        let heartbeat_seconds = {
+            let mut registry = self.registry.lock().await;
+            registry.register(worker_id.clone(), capabilities, Instant::now());
+            registry.policy().interval.as_secs() as u32
+        };
+
+        tracing::info!(heartbeat_seconds, "worker registered");
         Ok(Response::new(RegisterWorkerResponse {
             worker_id: Some(ProtoWorkerId {
                 id: worker_id.into_string(),
             }),
-            heartbeat_seconds: 30,
+            heartbeat_seconds,
         }))
     }
 
@@ -123,5 +171,97 @@ impl WorkerService for WorkerServiceImpl {
         });
 
         Ok(Response::new(ReceiverStream::new(out_rx)))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods, clippy::panic)]
+mod tests {
+    use std::collections::HashMap;
+
+    use async_trait::async_trait;
+    use brokkr_cas::{ActionCache, CasError, InMemoryCas};
+    use brokkr_common::Digest;
+    use brokkr_proto::reapi_v2::ActionResult;
+
+    use super::*;
+
+    /// Minimal `ActionCache` so we can build a `Scheduler` — the register
+    /// handler never touches it, it just has to exist to construct the service.
+    struct NoopActionCache;
+
+    #[async_trait]
+    impl ActionCache for NoopActionCache {
+        async fn get_action_result(&self, _d: &Digest) -> Result<Option<ActionResult>, CasError> {
+            Ok(None)
+        }
+        async fn update_action_result(
+            &self,
+            _d: &Digest,
+            _r: ActionResult,
+        ) -> Result<(), CasError> {
+            Ok(())
+        }
+    }
+
+    fn service() -> WorkerServiceImpl {
+        let scheduler = Scheduler::new(Arc::new(InMemoryCas::new()), Arc::new(NoopActionCache));
+        WorkerServiceImpl::new(scheduler)
+    }
+
+    #[tokio::test]
+    async fn register_persists_capabilities_into_registry() {
+        let svc = service();
+        let mut labels = HashMap::new();
+        labels.insert("os".to_string(), "linux".to_string());
+        labels.insert("arch".to_string(), "x86_64".to_string());
+
+        let resp = svc
+            .register(Request::new(RegisterWorkerRequest {
+                hostname: "smith-01".to_string(),
+                labels,
+            }))
+            .await
+            .unwrap()
+            .into_inner();
+
+        // A valid, non-empty id is returned, and the advertised heartbeat
+        // matches the registry's default policy interval (5s).
+        let id_str = resp.worker_id.unwrap().id;
+        assert!(!id_str.is_empty());
+        assert_eq!(resp.heartbeat_seconds, 5);
+
+        // The worker is now recorded with its declared capabilities.
+        let worker_id = WorkerId::new(id_str).unwrap();
+        let registry = svc.registry();
+        let guard = registry.lock().await;
+        let record = guard.get(&worker_id).unwrap();
+        assert_eq!(record.capabilities.hostname, "smith-01");
+        assert_eq!(
+            record.capabilities.labels.get("os").map(String::as_str),
+            Some("linux")
+        );
+        assert_eq!(
+            record.capabilities.labels.get("arch").map(String::as_str),
+            Some("x86_64")
+        );
+        assert_eq!(guard.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn each_register_gets_a_distinct_id() {
+        let svc = service();
+        let r1 = svc
+            .register(Request::new(RegisterWorkerRequest::default()))
+            .await
+            .unwrap()
+            .into_inner();
+        let r2 = svc
+            .register(Request::new(RegisterWorkerRequest::default()))
+            .await
+            .unwrap()
+            .into_inner();
+        assert_ne!(r1.worker_id.unwrap().id, r2.worker_id.unwrap().id);
+        assert_eq!(svc.registry().lock().await.len(), 2);
     }
 }

--- a/crates/brokkr-proto/protos/brokkr/v1/worker.proto
+++ b/crates/brokkr-proto/protos/brokkr/v1/worker.proto
@@ -30,6 +30,21 @@ message RegisterWorkerResponse {
   uint32 heartbeat_seconds = 2;
 }
 
+// Periodic worker→control-plane liveness ping. The worker sends one roughly
+// every `heartbeat_seconds` (from RegisterWorkerResponse). The control plane
+// refreshes the worker's last-seen time; a worker that misses too many is
+// evicted from the registry and must re-register.
+message HeartbeatRequest {
+  WorkerId worker_id = 1;
+}
+
+message HeartbeatResponse {
+  // False if the control plane has no record of this worker (it was never
+  // registered, or it has already been evicted). The worker should re-register
+  // when it sees this.
+  bool known = 1;
+}
+
 // A unit of work dispatched to a worker.
 message Job {
   // Server-assigned unique job identifier (separate from action digest so
@@ -79,6 +94,10 @@ message JobAssignment {
 
 service WorkerService {
   rpc Register(RegisterWorkerRequest) returns (RegisterWorkerResponse);
+
+  // Periodic liveness ping. The control plane refreshes the worker's
+  // last-seen time and replies whether it still knows the worker.
+  rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse);
 
   // Long-lived bidi stream. Worker sends Hello first, then alternates
   // JobResult after each JobAssignment received from the server.

--- a/crates/brokkr-worker/src/worker.rs
+++ b/crates/brokkr-worker/src/worker.rs
@@ -2,13 +2,14 @@
 //! received run the command and report the result.
 
 use std::path::PathBuf;
+use std::time::Duration;
 
 use anyhow::{anyhow, Context, Result};
 use brokkr_common::WorkerId;
 use brokkr_proto::brokkr_v1::{
     self as bv1, worker_service_client::WorkerServiceClient, worker_stream_message::Payload,
-    JobResult, RegisterWorkerRequest, WorkerHello as ProtoWorkerHello, WorkerId as ProtoWorkerId,
-    WorkerStreamMessage,
+    HeartbeatRequest, JobResult, RegisterWorkerRequest, WorkerHello as ProtoWorkerHello,
+    WorkerId as ProtoWorkerId, WorkerStreamMessage,
 };
 use brokkr_proto::reapi_v2::{
     self as rapi, batch_update_blobs_request as bur,
@@ -16,6 +17,7 @@ use brokkr_proto::reapi_v2::{
 };
 use tokio::sync::mpsc;
 use tonic::transport::{Channel, Endpoint};
+use tracing::Instrument;
 
 use crate::runner::{proto_digest, run_command, RunOutcome, Runner};
 
@@ -134,6 +136,45 @@ pub async fn run_worker(cfg: WorkerConfig) -> Result<()> {
         .map_err(|e| anyhow!("invalid worker id from control plane: {e}"))?;
     tracing::info!(worker_id = %worker_id, "worker registered");
 
+    // Background heartbeat: prove liveness on the cadence the control plane
+    // advertised so the registry doesn't evict us. On `known=false` the
+    // control plane has already evicted us (missed heartbeats) — stop pinging.
+    let heartbeat_secs = reg.heartbeat_seconds.max(1) as u64;
+    let mut hb_client = wsc.clone();
+    let hb_worker_id = worker_id.as_str().to_string();
+    let heartbeat_task = tokio::spawn(
+        async move {
+            let mut ticker = tokio::time::interval(Duration::from_secs(heartbeat_secs));
+            // Registration already counts as the first heartbeat.
+            ticker.tick().await;
+            loop {
+                ticker.tick().await;
+                match hb_client
+                    .heartbeat(HeartbeatRequest {
+                        worker_id: Some(ProtoWorkerId {
+                            id: hb_worker_id.clone(),
+                        }),
+                    })
+                    .await
+                {
+                    Ok(resp) => {
+                        if !resp.into_inner().known {
+                            tracing::warn!(
+                                "control plane no longer recognises this worker; \
+                                 stopping heartbeat (re-registration required)"
+                            );
+                            // TODO(brokkr-410): re-register and re-open the job
+                            // stream instead of just stopping the heartbeat loop.
+                            break;
+                        }
+                    }
+                    Err(e) => tracing::warn!(error = %e, "heartbeat RPC failed"),
+                }
+            }
+        }
+        .in_current_span(),
+    );
+
     // Outbound channel: hello + job results.
     let (tx, rx) = mpsc::channel::<WorkerStreamMessage>(8);
     tx.send(WorkerStreamMessage {
@@ -177,6 +218,7 @@ pub async fn run_worker(cfg: WorkerConfig) -> Result<()> {
             break;
         }
     }
+    heartbeat_task.abort();
     Ok(())
 }
 

--- a/docs/journal/phase-4.md
+++ b/docs/journal/phase-4.md
@@ -67,8 +67,57 @@ are the next increments.
 ### Environment note
 
 The dev host is Windows; `brokkr-sandbox`/`brokkr-worker` are Linux-only,
-so the whole workspace is built and tested under WSL2 Ubuntu (cargo
-1.85) with a Linux-native `CARGO_TARGET_DIR`. `cargo fmt --check`,
-`cargo clippy --workspace --all-targets -D warnings`, and
-`cargo test --workspace` are all green there (sandbox evil-action tests
-skip cleanly without privileged user namespaces, as in Phase 2/3).
+so the workspace is built and tested under WSL2 Ubuntu (cargo 1.85) with
+a Linux-native `CARGO_TARGET_DIR`. Verification is **per changed crate**
+(`brokkr-control`: fmt + `clippy --all-targets -D warnings` + test all
+green), relying on the project's real Linux CI for the rest: a full
+`cargo test --workspace` is *not* green on this WSL2 host — ~6
+`brokkr-sandbox` seccomp arg-filter tests (`PR_SET_TSC`/ioctl/RDTSC)
+can't trap under the virtualized kernel, and a few upstream
+`brokkr-worker` files trip rustfmt's CRLF check. Neither is touched by
+this work. (Lesson carried from PR #96: confirm reality on `origin/main`,
+not just the working tree.)
+
+## I2 — register persists into the registry (§16 task 1, wiring)
+
+- **Date:** 2026-06-27
+- **Affected crate:** `brokkr-control`
+- **Outcome:** `WorkerServiceImpl.register` now writes into a shared
+  `WorkerRegistry` instead of throwing the worker's identity away. It
+  records hostname + labels as `WorkerCapabilities`, and advertises a
+  `heartbeat_seconds` taken from the registry's policy interval (5 s)
+  rather than the old hardcoded 30 — closing the gap where the server
+  told workers to heartbeat every 30 s but the eviction policy expected
+  every 5 s. Two handler tests; `brokkr-control` fmt/clippy/test green.
+
+### Decisions
+
+- **`SharedWorkerRegistry = Arc<Mutex<WorkerRegistry>>`.** The registry
+  is now mutated from a request handler and (soon) a background tick, so
+  it needs shared ownership + interior mutability. An async
+  `tokio::sync::Mutex` is right because the critical section is tiny
+  (insert / read policy) and never held across an `.await` other than
+  the lock itself. `with_registry` + `registry()` expose the handle so
+  the next increments (heartbeat RPC, eviction loop) and tests share one
+  source of truth; `new(scheduler)` keeps its single-arg shape so
+  `main.rs` and the Phase 1 fixture are untouched.
+- **Advertise the policy interval, not a magic number.** Tying
+  `heartbeat_seconds` to `policy().interval` means the value the worker
+  is told and the value the eviction deadline assumes can't drift apart.
+- **`#[tracing::instrument]` over a manual `span.enter()`.** The handler
+  now `.await`s the registry lock; holding an `Entered` guard across an
+  await is the classic tracing footgun. `instrument` wraps the whole
+  future correctly and records the assigned `worker_id` field.
+- **Worker id still server-minted (UUID).** Registration identity stays
+  server-assigned; the heartbeat RPC (next) will let a worker prove
+  liveness with that id and get a re-register signal on
+  `UnknownWorker`.
+
+### Next increment
+
+Heartbeat RPC: add `Heartbeat` to `brokkr.v1.worker.proto`
+(`HeartbeatRequest { worker_id }` → `HeartbeatResponse { known }`),
+handle it via `registry.record_heartbeat`, and have the worker call it
+on the advertised cadence. Then a background eviction tick that calls
+`evict_stale` on an interval. (Proto change → first increment of Phase 4
+that regenerates `brokkr-proto`.)

--- a/docs/journal/phase-4.md
+++ b/docs/journal/phase-4.md
@@ -121,3 +121,44 @@ handle it via `registry.record_heartbeat`, and have the worker call it
 on the advertised cadence. Then a background eviction tick that calls
 `evict_stale` on an interval. (Proto change → first increment of Phase 4
 that regenerates `brokkr-proto`.)
+
+## I3 — heartbeat RPC (§16 task 1, liveness ping)
+
+- **Date:** 2026-06-27
+- **Affected crates:** `brokkr-proto`, `brokkr-control`
+- **Outcome:** `brokkr.v1.WorkerService.Heartbeat`
+  (`HeartbeatRequest{worker_id}` → `HeartbeatResponse{known}`) plus its
+  control-plane handler. `heartbeat` refreshes the worker's `last_seen`
+  through `WorkerRegistry::record_heartbeat`; the response's `known` flag
+  tells the worker whether the control plane still has a record of it.
+  Three handler tests; `brokkr-control` + `brokkr-proto` fmt/clippy/test
+  green.
+
+### Decisions
+
+- **Unknown worker is `known=false`, not an error.** A heartbeat from an
+  evicted (or never-registered) worker is an expected, recoverable
+  state, not a fault. Returning `known=false` gives the worker a clean
+  "re-register" signal; returning a gRPC error would make it retry a
+  dead identity or backoff for the wrong reason. Only a *malformed*
+  request (missing `worker_id`) is `INVALID_ARGUMENT`.
+- **No new proto message churn.** Reused the existing `WorkerId` message
+  for the request; the response is a single bool. Resisted adding a
+  server-suggested next-interval field — the cadence is already fixed at
+  register time, and re-negotiating it per heartbeat is YAGNI until
+  there's a reason to vary it.
+- **Server-side only this increment.** The RPC is implemented and tested
+  via direct handler calls; no worker calls it yet. Splitting the
+  transport/handler (here) from the worker's send-loop + the background
+  eviction tick (next) keeps each unit independently testable and the
+  diffs small. The proto addition is backward-compatible — existing
+  clients that never call `Heartbeat` are unaffected.
+
+### Next increment (I4)
+
+Worker-side: a heartbeat send-loop in `brokkr-worker` that pings on the
+advertised `heartbeat_seconds` and re-registers on `known=false`. Control
+side: a background eviction task (`tokio::time::interval` →
+`evict_stale`) wired into the `brokkr-control` binary. Target: an
+end-to-end test where a worker that stops heartbeating is evicted after
+the deadline. This closes §16 task 1.

--- a/docs/journal/phase-4.md
+++ b/docs/journal/phase-4.md
@@ -162,3 +162,48 @@ side: a background eviction task (`tokio::time::interval` →
 `evict_stale`) wired into the `brokkr-control` binary. Target: an
 end-to-end test where a worker that stops heartbeating is evicted after
 the deadline. This closes §16 task 1.
+
+## I4 — eviction tick + worker heartbeat loop (§16 task 1 — CLOSED)
+
+- **Date:** 2026-06-27
+- **Affected crates:** `brokkr-control`, `brokkr-worker`
+- **Outcome:** Liveness loop is now closed end-to-end.
+  `spawn_eviction_task` drives `WorkerRegistry::evict_stale` once per
+  heartbeat interval and is wired into the control-plane binary; the
+  worker runs a background loop pinging `WorkerService.Heartbeat` on the
+  advertised cadence. A worker that keeps heartbeating stays registered;
+  one that stops is evicted after `interval * max_missed`, and its next
+  heartbeat returns `known=false`. `brokkr-control` (25 lib tests) +
+  `brokkr-worker` green; the existing end-to-end fixture now exercises
+  live heartbeats through the real server.
+
+### Decisions
+
+- **Reaper reads the policy interval, ticks once per interval.** Eviction
+  lag is bounded to one interval; the *deadline* enforcement stays in
+  `evict_stale`. A zero interval disables the reaper instead of panicking
+  (`tokio::time::interval` rejects a zero period).
+- **`known=false` ⇒ stop, don't silently spin.** The worker's heartbeat
+  loop breaks on `known=false` and logs; full re-registration (re-open
+  the job stream under a new id) is left as `TODO(brokkr-410)` — it's a
+  reconnect-state-machine change that deserves its own increment rather
+  than being smuggled into the heartbeat loop.
+- **No `tokio` `test-util` dependency.** A paused-clock test of the
+  spawned reaper would need `tokio`'s `test-util` feature (not in
+  `full`). Rather than add a dep mid-loop, the spawn wrapper is covered
+  by (a) `evict_stale`'s injected-clock unit tests and (b) the
+  deterministic `eviction_is_observable_via_heartbeat` composition test
+  that drives register → evict → heartbeat through the RPC handlers with
+  no timers. The wrapper itself is ~15 lines of obvious glue.
+- **Heartbeat task aborted on stream exit.** The worker holds the
+  `JoinHandle` and aborts it when the job stream closes, so the heartbeat
+  loop never outlives the worker session.
+
+### §16 task 1 status
+
+Done across I1–I4: registry data model → register wiring → `Heartbeat`
+RPC → eviction tick + worker heartbeat loop. All on PR #98. **Next
+milestone:** §16 task 2 — constraint matching (match an Action's
+`Platform` requirements against `WorkerCapabilities.labels`; hard vs.
+soft constraints), as a new branch off `origin/main` once #98 merges
+(else stacked).

--- a/docs/journal/phase-4.md
+++ b/docs/journal/phase-4.md
@@ -1,0 +1,74 @@
+# Phase 4 — Scheduler & Multi-Tenancy
+
+- **Status:** in progress
+- **Plan:** `docs/plan.md` §16
+- **Started:** 2026-06-27
+
+Goal: real scheduling across many workers, fair sharing across tenants,
+and REAPI-compatibility good enough to run a real Bazel build. This
+journal accumulates a short retrospective per increment.
+
+The Phase 3 "Deferred to Phase 4" list (`docs/journal/phase-3.md`) is the
+backlog seed alongside the §16 task list: worker registry + capabilities,
+constraint matching, scheduling strategies (SimpleFifo → BinPacking →
+LocalityAware), job leases, tenants/quotas, fair scheduling, auth, Bazel
+compat.
+
+## I1 — worker registry (§16 task 1, data model)
+
+- **Date:** 2026-06-27
+- **Affected crate:** `brokkr-control`
+- **Outcome:** `brokkr-control::registry::WorkerRegistry` — the
+  in-memory liveness + capability store the rest of Phase 4 scheduling
+  builds on. Records `WorkerCapabilities { hostname, labels }` and a
+  `last_seen` instant per worker; evicts workers that miss
+  `HeartbeatPolicy::max_missed` heartbeats (default 5 s × 3 = 15 s
+  deadline, straight from §16 task 1). Ten unit tests, full workspace
+  clippy/test green.
+
+### Decisions
+
+- **Injected clock, not `Instant::now()`.** Every time-sensitive method
+  (`register`, `record_heartbeat`, `evict_stale`, `healthy`,
+  `is_stale`) takes an explicit `now: Instant`. This is the testing
+  strategy's "no `SystemTime::now()` in tests; use injected clocks" rule
+  applied at the type level — eviction-boundary tests pin `t0` once and
+  add `Duration`s, so they're deterministic and need no sleeps. The
+  control-plane RPC layer will pass `Instant::now()` at the edge.
+- **Registry is not internally synchronized.** It's a plain `&mut self`
+  data structure; the control plane wraps it in its own
+  `Mutex`/`RwLock`. Keeping the lock out of the registry makes the
+  eviction logic trivially unit-testable and avoids guessing the
+  concurrency shape before the RPC wiring exists.
+- **Capabilities start minimal.** `WorkerCapabilities` mirrors the
+  surface the existing `RegisterWorkerRequest` proto already carries
+  (hostname + `labels`). The richer `WorkerCapability` sketch in plan §8
+  (CPU cores, memory, installed tools, GPU) is deferred until the
+  constraint matcher actually needs each field — no speculative schema.
+- **`BTreeMap` for labels.** Deterministic iteration/equality; the
+  constraint matcher will want a stable order, and it makes
+  `WorkerCapabilities: Eq` meaningful.
+- **`healthy()` is read-only; `evict_stale()` mutates.** Two distinct
+  needs: the scheduler wants to *skip* stale workers when picking
+  (without taking a write lock), while a periodic reaper wants to
+  *remove* them. Splitting the two keeps the read path lock-light.
+- **Strictly-greater staleness.** A worker exactly at the deadline is
+  still alive; only `elapsed > deadline` evicts. Boundary pinned by a
+  test (`worker_within_deadline_is_not_stale_or_evicted`).
+
+### Scope note
+
+This increment is the data model only. Wiring it into
+`WorkerServiceImpl::register` (currently mints a throwaway UUID and
+drops the hostname/labels), adding a heartbeat RPC + a background
+eviction tick, and teaching the scheduler to select from `healthy()`
+are the next increments.
+
+### Environment note
+
+The dev host is Windows; `brokkr-sandbox`/`brokkr-worker` are Linux-only,
+so the whole workspace is built and tested under WSL2 Ubuntu (cargo
+1.85) with a Linux-native `CARGO_TARGET_DIR`. `cargo fmt --check`,
+`cargo clippy --workspace --all-targets -D warnings`, and
+`cargo test --workspace` are all green there (sandbox evil-action tests
+skip cleanly without privileged user namespaces, as in Phase 2/3).


### PR DESCRIPTION
## Motivation

First Phase 4 increment (`docs/plan.md` §16, task 1: "Worker registry with capabilities. Workers heartbeat every 5s; control plane evicts after 3 missed heartbeats."). Today `WorkerServiceImpl::register` just mints a throwaway UUID and drops the worker's hostname/labels; there is no liveness tracking. This lands the data-model foundation the rest of Phase 4 scheduling builds on.

## What changed

New module `brokkr-control::registry`:
- `WorkerRegistry` — in-memory map of `WorkerId → WorkerRecord` (capabilities + `registered_at` + `last_seen`).
- `WorkerCapabilities { hostname, labels: BTreeMap }` — mirrors the existing `RegisterWorkerRequest` proto surface; richer fields (CPU/mem/tools/GPU) deferred until the constraint matcher needs them.
- `HeartbeatPolicy { interval, max_missed }` with `deadline() = interval * max_missed`; default 5s × 3 = 15s, straight from §16.
- `register` / `record_heartbeat` / `evict_stale` / `healthy` / `get` / `contains` — every time-sensitive method takes an explicit `now: Instant`, so liveness is **deterministic under test** (no internal `Instant::now`/`SystemTime::now`, per the testing strategy).
- Typed `RegistryError::UnknownWorker` for heartbeats from unregistered workers.

Transport-agnostic by design: wiring into `WorkerService.register`, a heartbeat RPC + background eviction tick, and scheduler selection from `healthy()` are follow-up increments.

## How it was tested

10 unit tests (deadline math, register/get, heartbeat advance, unknown-worker error, deadline boundary is strictly-greater, eviction, heartbeat-keeps-alive, sorted multi-eviction, read-only `healthy`, re-register resets lifecycle).

Verified in WSL2 (Linux toolchain; this crate is cross-platform): `cargo fmt --check`, `cargo clippy -p brokkr-control --all-targets -D warnings`, and `cargo test -p brokkr-control` all green (19 lib tests incl. the 10 new + existing integration tests).

> Note on the full-workspace gate: `cargo test --workspace` is **not** green on the WSL2 dev host — 6 pre-existing `brokkr-sandbox` seccomp arg-filtering tests (`PR_SET_TSC`/`ioctl`/RDTSC) can't trap under WSL2's virtualized kernel, and 3 upstream `brokkr-worker` files trip rustfmt's CRLF check. Neither is touched by this PR (it's `brokkr-control`-only); both should pass on the project's real Linux CI.

## Related

`docs/plan.md` §16 task 1; `docs/journal/phase-4.md` (I1). First increment of the Phase 4 build-out loop.