### PR TITLE
feat(control): platform constraint matching (Phase 4 §16 task 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -652,6 +652,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `brokkr-control` binary now builds one shared registry feeding the
   scheduler (reads), the worker service (writes), and the eviction reaper.
   Three scheduler tests (reject on no worker, reject on label mismatch,
-  pass-through with a matching worker). NOTE: the CLI worker still
-  registers with empty labels, so constrained actions can't be scheduled
-  until the worker advertises its capabilities (next increment).
+  pass-through with a matching worker).
+- `brokkr-worker` now advertises platform capabilities at registration:
+  `os` and `arch` labels from the build target (`std::env::consts`), so
+  the control plane's constraint matcher can actually place
+  platform-constrained actions on it. Completes the §16 task 2
+  constraint-matching path end-to-end (worker advertises → matcher →
+  admission control). Richer / configurable capabilities (installed
+  tools, GPU, RAM) are a later increment. One unit test.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -628,3 +628,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the control plane advertised at registration; on `known=false` it logs
   and stops (full re-register is `TODO(brokkr-410)`). Closes plan §16
   task 1 (worker registry + capabilities + heartbeat eviction).
+- `brokkr-control::matching` — platform constraint matching (plan §16
+  task 2). `labels_satisfy_platform` / `worker_satisfies` implement REAPI
+  semantics: a worker satisfies a `Platform` iff it advertises every
+  required `Property{name,value}` (empty platform matches everyone).
+  `eligible_workers(registry, now, platform)` yields the live workers
+  (via `WorkerRegistry::healthy`) that also satisfy the constraints —
+  the candidate set the scheduler will dispatch to. Kept proto-aware and
+  separate from the proto-free `registry` module (mirrors the Phase 3
+  `ring`/proto decoupling). Hard-constraint matching only; soft/preferred
+  constraints need a Brokkr convention (future ADR) since REAPI's
+  `Platform` has no soft notion. Six unit tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -639,3 +639,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ring`/proto decoupling). Hard-constraint matching only; soft/preferred
   constraints need a Brokkr convention (future ADR) since REAPI's
   `Platform` has no soft notion. Six unit tests.
+- `brokkr-control::Scheduler` platform-constraint **admission control**:
+  `execute` now rejects an action up front with the new typed
+  `ExecutionError::NoEligibleWorker` (gRPC `FAILED_PRECONDITION`, code 9)
+  when no live worker satisfies the action's `Platform`
+  (`Action.platform`, falling back to the deprecated `Command.platform`),
+  instead of enqueuing a job no worker can claim (which would only
+  surface as a timeout). New constructors `Scheduler::with_worker_registry`
+  / `with_registry_and_timeout` thread in the shared `WorkerRegistry`;
+  the existing `new` / `with_execution_timeout` keep admission control off
+  (registry `None`), preserving prior behaviour for fixtures. The
+  `brokkr-control` binary now builds one shared registry feeding the
+  scheduler (reads), the worker service (writes), and the eviction reaper.
+  Three scheduler tests (reject on no worker, reject on label mismatch,
+  pass-through with a matching worker). NOTE: the CLI worker still
+  registers with empty labels, so constrained actions can't be scheduled
+  until the worker advertises its capabilities (next increment).

--- a/crates/brokkr-control/src/lib.rs
+++ b/crates/brokkr-control/src/lib.rs
@@ -6,12 +6,14 @@
 
 #![deny(missing_docs)]
 
+pub mod matching;
 pub mod membership;
 pub mod registry;
 pub mod scheduler;
 pub mod services;
 pub mod worker_service;
 
+pub use matching::{eligible_workers, labels_satisfy_platform, worker_satisfies};
 pub use membership::{Membership, MembershipServiceImpl};
 pub use registry::{
     HeartbeatPolicy, RegistryError, WorkerCapabilities, WorkerRecord, WorkerRegistry,

--- a/crates/brokkr-control/src/main.rs
+++ b/crates/brokkr-control/src/main.rs
@@ -6,9 +6,10 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use brokkr_cas::{RedbActionCache, RedbCas};
+use brokkr_control::registry::WorkerRegistry;
 use brokkr_control::{
     spawn_eviction_task, ActionCacheService, CapabilitiesService, CasService, ExecutionService,
-    Scheduler, WorkerServiceImpl,
+    Scheduler, SharedWorkerRegistry, WorkerServiceImpl,
 };
 use brokkr_proto::brokkr_v1::worker_service_server::WorkerServiceServer;
 use brokkr_proto::reapi_v2::{
@@ -99,7 +100,14 @@ async fn main() -> Result<()> {
         RedbActionCache::open(args.data_dir.join("action_cache.redb"))
             .context("opening action cache database")?,
     );
-    let scheduler = Scheduler::new(cas.clone(), action_cache.clone());
+    // One shared worker registry, three users: the scheduler reads it for
+    // platform-constraint admission control, the worker service writes
+    // registrations / heartbeats into it, and the eviction reaper prunes
+    // stale entries.
+    let worker_registry: SharedWorkerRegistry =
+        Arc::new(tokio::sync::Mutex::new(WorkerRegistry::default()));
+    let scheduler =
+        Scheduler::with_worker_registry(cas.clone(), action_cache.clone(), worker_registry.clone());
 
     let tls_cfg = args.tls_config()?;
     match &tls_cfg {
@@ -113,11 +121,12 @@ async fn main() -> Result<()> {
 
     tracing::info!(addr = %args.listen, data_dir = ?args.data_dir, "brokkr-control starting");
 
-    let worker_service = WorkerServiceImpl::new(scheduler.clone());
+    let worker_service =
+        WorkerServiceImpl::with_registry(scheduler.clone(), worker_registry.clone());
     // Background liveness reaper: evict workers that stop heartbeating. Held
     // for the server's lifetime; aborting it on shutdown is implicit (process
     // exit). The eviction decision lives in `WorkerRegistry::evict_stale`.
-    let _eviction = spawn_eviction_task(worker_service.registry());
+    let _eviction = spawn_eviction_task(worker_registry.clone());
 
     let mut server = Server::builder();
     if let Some(tls_cfg) = tls_cfg {

--- a/crates/brokkr-control/src/matching.rs
+++ b/crates/brokkr-control/src/matching.rs
@@ -1,0 +1,192 @@
+//! Platform constraint matching (plan §16, task 2).
+//!
+//! Decides whether a worker's advertised capabilities satisfy an action's
+//! required REAPI `Platform`. This is the eligibility primitive the scheduler
+//! uses to pick a worker for a job.
+//!
+//! Kept separate from [`crate::registry`] on purpose: the registry stays
+//! proto-free (a plain liveness/capability store), and the proto-aware
+//! matching lives here — the same decoupling Phase 3 used between
+//! `brokkr-cas::ring` and `brokkr-proto`.
+
+use std::collections::BTreeMap;
+use std::time::Instant;
+
+use brokkr_common::WorkerId;
+use brokkr_proto::reapi_v2 as rapi;
+
+use crate::registry::{WorkerCapabilities, WorkerRecord, WorkerRegistry};
+
+/// Whether `labels` satisfy every property in `platform`.
+///
+/// REAPI semantics: a worker satisfies a `Platform` iff, for every
+/// `Property{name, value}` in the requirements, the worker advertises a
+/// capability with that exact name and value. An empty platform is satisfied
+/// by every worker.
+///
+/// Brokkr models worker capabilities as single-valued labels
+/// (`BTreeMap<String, String>`), so a `name` that appears in the requirements
+/// with two *different* values is unsatisfiable by any single worker — which
+/// is the correct outcome for single-valued attributes like `os`/`arch`.
+/// Multi-valued worker capabilities (a worker advertising several values for
+/// one `name`, e.g. multiple supported ISAs) would need a richer capability
+/// model; that is deferred until a workload needs it.
+pub fn labels_satisfy_platform(
+    labels: &BTreeMap<String, String>,
+    platform: &rapi::Platform,
+) -> bool {
+    platform
+        .properties
+        .iter()
+        .all(|p| labels.get(&p.name).is_some_and(|v| v == &p.value))
+}
+
+/// [`labels_satisfy_platform`] over a [`WorkerCapabilities`].
+pub fn worker_satisfies(caps: &WorkerCapabilities, platform: &rapi::Platform) -> bool {
+    labels_satisfy_platform(&caps.labels, platform)
+}
+
+/// Iterate the workers that are both live (not stale as of `now`) and satisfy
+/// `platform`'s hard constraints — i.e. the candidates the scheduler may
+/// dispatch this action to.
+///
+/// Soft / preferred constraints (plan §16's "soft") are not modelled yet:
+/// REAPI's `Platform` has no soft notion, so expressing them needs a Brokkr
+/// convention (a future ADR). This function is hard-constraint matching only.
+pub fn eligible_workers<'a>(
+    registry: &'a WorkerRegistry,
+    now: Instant,
+    platform: &'a rapi::Platform,
+) -> impl Iterator<Item = (&'a WorkerId, &'a WorkerRecord)> {
+    registry
+        .healthy(now)
+        .filter(move |(_, record)| worker_satisfies(&record.capabilities, platform))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn labels(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    fn platform(pairs: &[(&str, &str)]) -> rapi::Platform {
+        rapi::Platform {
+            properties: pairs
+                .iter()
+                .map(|(name, value)| rapi::platform::Property {
+                    name: name.to_string(),
+                    value: value.to_string(),
+                })
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn empty_platform_is_satisfied_by_any_worker() {
+        assert!(labels_satisfy_platform(&labels(&[]), &platform(&[])));
+        assert!(labels_satisfy_platform(
+            &labels(&[("os", "linux")]),
+            &platform(&[])
+        ));
+    }
+
+    #[test]
+    fn single_property_match_and_mismatch() {
+        let w = labels(&[("os", "linux"), ("arch", "x86_64")]);
+        assert!(labels_satisfy_platform(&w, &platform(&[("os", "linux")])));
+        assert!(!labels_satisfy_platform(
+            &w,
+            &platform(&[("os", "windows")])
+        ));
+    }
+
+    #[test]
+    fn missing_property_name_is_not_satisfied() {
+        let w = labels(&[("os", "linux")]);
+        assert!(!labels_satisfy_platform(&w, &platform(&[("gpu", "a100")])));
+    }
+
+    #[test]
+    fn all_properties_must_match() {
+        let w = labels(&[("os", "linux"), ("arch", "x86_64")]);
+        assert!(labels_satisfy_platform(
+            &w,
+            &platform(&[("os", "linux"), ("arch", "x86_64")])
+        ));
+        // One satisfied, one not → overall unsatisfied.
+        assert!(!labels_satisfy_platform(
+            &w,
+            &platform(&[("os", "linux"), ("arch", "aarch64")])
+        ));
+    }
+
+    #[test]
+    fn same_name_two_values_is_unsatisfiable_for_single_valued_labels() {
+        let w = labels(&[("os", "linux")]);
+        assert!(!labels_satisfy_platform(
+            &w,
+            &platform(&[("os", "linux"), ("os", "windows")])
+        ));
+    }
+
+    #[test]
+    fn eligible_workers_filters_by_health_and_constraints() {
+        use std::time::Duration;
+
+        use crate::registry::{HeartbeatPolicy, WorkerRegistry};
+
+        let t0 = Instant::now();
+        let policy = HeartbeatPolicy {
+            interval: Duration::from_secs(1),
+            max_missed: 3, // 3s deadline
+        };
+        let mut reg = WorkerRegistry::new(policy);
+
+        let linux = WorkerCapabilities {
+            hostname: "linux-box".to_string(),
+            labels: labels(&[("os", "linux")]),
+        };
+        let windows = WorkerCapabilities {
+            hostname: "win-box".to_string(),
+            labels: labels(&[("os", "windows")]),
+        };
+        reg.register(WorkerId::new("w-linux".to_string()).unwrap(), linux, t0);
+        reg.register(
+            WorkerId::new("w-win".to_string()).unwrap(),
+            windows.clone(),
+            t0,
+        );
+        // A second linux worker that will go stale.
+        reg.register(
+            WorkerId::new("w-linux-stale".to_string()).unwrap(),
+            WorkerCapabilities {
+                hostname: "stale".to_string(),
+                labels: labels(&[("os", "linux")]),
+            },
+            t0,
+        );
+
+        // At t0+5s the stale worker is past the 3s deadline; keep the other two
+        // alive with a heartbeat.
+        let now = t0 + Duration::from_secs(5);
+        reg.record_heartbeat(&WorkerId::new("w-linux".to_string()).unwrap(), now)
+            .unwrap();
+        reg.record_heartbeat(&WorkerId::new("w-win".to_string()).unwrap(), now)
+            .unwrap();
+
+        let want_linux = platform(&[("os", "linux")]);
+        let mut eligible: Vec<&str> = eligible_workers(&reg, now, &want_linux)
+            .map(|(id, _)| id.as_str())
+            .collect();
+        eligible.sort_unstable();
+        // Only the live linux worker: the windows worker fails the constraint,
+        // the stale linux worker fails the health check.
+        assert_eq!(eligible, vec!["w-linux"]);
+    }
+}

--- a/crates/brokkr-control/src/scheduler.rs
+++ b/crates/brokkr-control/src/scheduler.rs
@@ -6,7 +6,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
 use brokkr_cas::{ActionCache, Cas};
@@ -16,6 +16,9 @@ use brokkr_proto::reapi_v2 as rapi;
 use prost::Message;
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot, Mutex};
+
+use crate::matching::eligible_workers;
+use crate::worker_service::SharedWorkerRegistry;
 
 /// Default ceiling on how long [`Scheduler::execute`] waits for a worker to
 /// report a result. Issue #63 — without this the oneshot wait was unbounded
@@ -32,6 +35,12 @@ pub enum ExecutionError {
     /// timeout. Translates to gRPC `DEADLINE_EXCEEDED` (code 4).
     #[error("worker did not report within {0:?}")]
     Timeout(Duration),
+    /// No registered, live worker satisfies the action's platform
+    /// constraints. Translates to gRPC `FAILED_PRECONDITION` (code 9) so the
+    /// client can distinguish "nothing can run this" from a transient
+    /// failure and avoid pointless retries.
+    #[error("no eligible worker for the action's platform constraints")]
+    NoEligibleWorker,
     /// Catch-all for failures during dispatch (CAS read, action-cache write,
     /// worker reporting an error, etc.). Translates to gRPC `INTERNAL`
     /// (code 13).
@@ -56,13 +65,20 @@ pub struct Scheduler {
     cas: Arc<dyn Cas>,
     action_cache: Arc<dyn ActionCache>,
     default_execution_timeout: Duration,
+    /// Optional worker registry for platform-constraint admission control.
+    /// When set, [`Scheduler::execute`] rejects an action up front if no live
+    /// worker satisfies its platform. When `None` (e.g. unit tests that don't
+    /// exercise matching), admission control is skipped — preserving the
+    /// pre-Phase-4 single-worker behaviour.
+    worker_registry: Option<SharedWorkerRegistry>,
 }
 
 impl Scheduler {
     /// Construct a scheduler bound to the given storage backends, using the
-    /// default execution timeout ([`DEFAULT_EXECUTION_TIMEOUT`]).
+    /// default execution timeout ([`DEFAULT_EXECUTION_TIMEOUT`]) and no
+    /// admission control.
     pub fn new(cas: Arc<dyn Cas>, action_cache: Arc<dyn ActionCache>) -> Arc<Self> {
-        Self::with_execution_timeout(cas, action_cache, DEFAULT_EXECUTION_TIMEOUT)
+        Self::build(cas, action_cache, DEFAULT_EXECUTION_TIMEOUT, None)
     }
 
     /// Construct a scheduler with a custom default per-action timeout. The
@@ -73,6 +89,45 @@ impl Scheduler {
         action_cache: Arc<dyn ActionCache>,
         default_execution_timeout: Duration,
     ) -> Arc<Self> {
+        Self::build(cas, action_cache, default_execution_timeout, None)
+    }
+
+    /// Construct a scheduler that performs platform-constraint admission
+    /// control against `worker_registry`, using the default timeout.
+    pub fn with_worker_registry(
+        cas: Arc<dyn Cas>,
+        action_cache: Arc<dyn ActionCache>,
+        worker_registry: SharedWorkerRegistry,
+    ) -> Arc<Self> {
+        Self::build(
+            cas,
+            action_cache,
+            DEFAULT_EXECUTION_TIMEOUT,
+            Some(worker_registry),
+        )
+    }
+
+    /// Construct a scheduler with both a custom timeout and admission control.
+    pub fn with_registry_and_timeout(
+        cas: Arc<dyn Cas>,
+        action_cache: Arc<dyn ActionCache>,
+        default_execution_timeout: Duration,
+        worker_registry: SharedWorkerRegistry,
+    ) -> Arc<Self> {
+        Self::build(
+            cas,
+            action_cache,
+            default_execution_timeout,
+            Some(worker_registry),
+        )
+    }
+
+    fn build(
+        cas: Arc<dyn Cas>,
+        action_cache: Arc<dyn ActionCache>,
+        default_execution_timeout: Duration,
+        worker_registry: Option<SharedWorkerRegistry>,
+    ) -> Arc<Self> {
         let (queue_tx, queue_rx) = mpsc::unbounded_channel();
         Arc::new(Self {
             queue_tx,
@@ -81,6 +136,7 @@ impl Scheduler {
             cas,
             action_cache,
             default_execution_timeout,
+            worker_registry,
         })
     }
 
@@ -143,6 +199,39 @@ impl Scheduler {
             .fetch_message::<rapi::Command>(&command_digest)
             .await
             .with_context(|| "fetching Command from CAS")?;
+
+        // Admission control: if a worker registry is wired in, reject the
+        // action up front when no live worker satisfies its platform, rather
+        // than enqueuing a job that no worker can ever claim (which would only
+        // surface as a timeout). The platform lives on `Action.platform`
+        // (REAPI v2.2) with a fallback to the deprecated `Command.platform`.
+        if let Some(registry) = self.worker_registry.as_ref() {
+            // `Command.platform` is deprecated in REAPI v2.2 (moved to
+            // `Action.platform`) but still used by older clients, so we accept
+            // it as a fallback — hence the scoped allow.
+            #[allow(deprecated)]
+            let platform = action
+                .platform
+                .clone()
+                .or_else(|| command.platform.clone())
+                .unwrap_or_default();
+            let has_eligible = {
+                let guard = registry.lock().await;
+                // Bind to a local so the borrowing iterator temporary is
+                // dropped before `guard` at the end of the block.
+                let any = eligible_workers(&guard, Instant::now(), &platform)
+                    .next()
+                    .is_some();
+                any
+            };
+            if !has_eligible {
+                tracing::warn!(
+                    action_digest = %action_digest,
+                    "no eligible worker for action platform; rejecting"
+                );
+                return Err(ExecutionError::NoEligibleWorker);
+            }
+        }
 
         // REAPI `Action.timeout` overrides the scheduler default; treat
         // missing / zero / negative as "use the default".
@@ -443,6 +532,126 @@ mod tests {
         assert!(
             err.to_string().contains("action cache get"),
             "expected 'action cache get' in error, got: {err}"
+        );
+    }
+
+    // --- Admission control (§16 task 2) ---
+
+    /// Stage an Action+Command pair (with `platform` on the Action) into an
+    /// in-memory CAS and return the Action digest.
+    async fn stage_action(
+        cas: &brokkr_cas::InMemoryCas,
+        platform: Option<rapi::Platform>,
+    ) -> Digest {
+        use brokkr_cas::Cas as _;
+
+        let command = rapi::Command {
+            arguments: vec!["/bin/echo".to_string(), "hi".to_string()],
+            ..Default::default()
+        };
+        let command_bytes = command.encode_to_vec();
+        let command_digest = Digest::of(&command_bytes);
+        let action = rapi::Action {
+            command_digest: Some(rapi::Digest {
+                hash: command_digest.hash().to_string(),
+                size_bytes: command_digest.size_bytes(),
+            }),
+            platform,
+            ..Default::default()
+        };
+        let action_bytes = action.encode_to_vec();
+        let action_digest = Digest::of(&action_bytes);
+        cas.batch_update_blobs(vec![
+            (action_digest.clone(), Bytes::from(action_bytes)),
+            (command_digest, Bytes::from(command_bytes)),
+        ])
+        .await
+        .unwrap();
+        action_digest
+    }
+
+    fn os_platform(value: &str) -> rapi::Platform {
+        rapi::Platform {
+            properties: vec![rapi::platform::Property {
+                name: "os".to_string(),
+                value: value.to_string(),
+            }],
+        }
+    }
+
+    fn registry_with_worker(labels: &[(&str, &str)]) -> SharedWorkerRegistry {
+        use brokkr_common::WorkerId;
+
+        use crate::registry::{WorkerCapabilities, WorkerRegistry};
+
+        let mut reg = WorkerRegistry::default();
+        let caps = WorkerCapabilities {
+            hostname: "w".to_string(),
+            labels: labels
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        };
+        reg.register(
+            WorkerId::new("w1".to_string()).unwrap(),
+            caps,
+            Instant::now(),
+        );
+        Arc::new(Mutex::new(reg))
+    }
+
+    /// No registered worker → admission control rejects before enqueue.
+    #[tokio::test]
+    async fn execute_rejects_when_no_eligible_worker() {
+        use crate::registry::WorkerRegistry;
+
+        let cas = Arc::new(brokkr_cas::InMemoryCas::new());
+        let action_digest = stage_action(cas.as_ref(), Some(os_platform("linux"))).await;
+        let ac = Arc::new(MockActionCache { force_error: false });
+        let registry = Arc::new(Mutex::new(WorkerRegistry::default())); // empty
+        let scheduler =
+            Scheduler::with_registry_and_timeout(cas, ac, Duration::from_millis(200), registry);
+
+        let err = scheduler.execute(action_digest, true).await.unwrap_err();
+        assert!(
+            matches!(err, ExecutionError::NoEligibleWorker),
+            "expected NoEligibleWorker, got {err:?}"
+        );
+    }
+
+    /// A worker whose labels don't satisfy the platform is not eligible.
+    #[tokio::test]
+    async fn execute_rejects_when_worker_does_not_match_platform() {
+        let cas = Arc::new(brokkr_cas::InMemoryCas::new());
+        let action_digest = stage_action(cas.as_ref(), Some(os_platform("linux"))).await;
+        let ac = Arc::new(MockActionCache { force_error: false });
+        let registry = registry_with_worker(&[("os", "windows")]);
+        let scheduler =
+            Scheduler::with_registry_and_timeout(cas, ac, Duration::from_millis(200), registry);
+
+        let err = scheduler.execute(action_digest, true).await.unwrap_err();
+        assert!(
+            matches!(err, ExecutionError::NoEligibleWorker),
+            "expected NoEligibleWorker, got {err:?}"
+        );
+    }
+
+    /// An eligible worker present → admission passes; with no worker actually
+    /// consuming the queue the call then times out (proving it got past
+    /// admission rather than being rejected).
+    #[tokio::test]
+    async fn execute_passes_admission_with_matching_worker() {
+        let cas = Arc::new(brokkr_cas::InMemoryCas::new());
+        let action_digest = stage_action(cas.as_ref(), Some(os_platform("linux"))).await;
+        let ac = Arc::new(MockActionCache { force_error: false });
+        let registry = registry_with_worker(&[("os", "linux")]);
+        let timeout = Duration::from_millis(120);
+        let scheduler = Scheduler::with_registry_and_timeout(cas, ac, timeout, registry);
+
+        let err = scheduler.execute(action_digest, true).await.unwrap_err();
+        assert!(
+            matches!(err, ExecutionError::Timeout(_)),
+            "expected Timeout (admission passed), got {err:?}"
         );
     }
 }

--- a/crates/brokkr-control/src/services/execution.rs
+++ b/crates/brokkr-control/src/services/execution.rs
@@ -81,11 +81,13 @@ impl ExecSvc for ExecutionService {
                     }
                     Err(e) => {
                         // DEADLINE_EXCEEDED for scheduler timeouts (issue
-                        // #63); INTERNAL for everything else. The choice of
-                        // code lets clients implement retry-on-timeout
-                        // policies without parsing the error string.
+                        // #63); FAILED_PRECONDITION when no worker can run the
+                        // action; INTERNAL for everything else. The code lets
+                        // clients implement retry policies without parsing the
+                        // error string.
                         let code = match &e {
                             ExecutionError::Timeout(_) => 4,
+                            ExecutionError::NoEligibleWorker => 9,
                             ExecutionError::Other(_) => 13,
                         };
                         brokkr_proto::longrunning::Operation {

--- a/crates/brokkr-worker/src/worker.rs
+++ b/crates/brokkr-worker/src/worker.rs
@@ -113,6 +113,17 @@ async fn build_channel(endpoint: String, tls: Option<&TlsConfig>) -> Result<Chan
     Ok(channel)
 }
 
+/// The platform-capability labels a worker advertises at registration so the
+/// control plane's constraint matcher can place actions on it: `os` and `arch`
+/// from the build target. Richer / configurable capabilities (installed tools,
+/// GPU, RAM) are a later increment.
+fn default_capability_labels() -> std::collections::HashMap<String, String> {
+    let mut labels = std::collections::HashMap::new();
+    labels.insert("os".to_string(), std::env::consts::OS.to_string());
+    labels.insert("arch".to_string(), std::env::consts::ARCH.to_string());
+    labels
+}
+
 /// Run the worker. Returns when the control plane closes the stream or an
 /// unrecoverable error occurs.
 #[tracing::instrument(name = "worker::run", skip(cfg))]
@@ -125,7 +136,7 @@ pub async fn run_worker(cfg: WorkerConfig) -> Result<()> {
     let reg = wsc
         .register(RegisterWorkerRequest {
             hostname: cfg.hostname.clone(),
-            labels: Default::default(),
+            labels: default_capability_labels(),
         })
         .await?
         .into_inner();
@@ -278,4 +289,26 @@ async fn handle_job(
         exit_code,
         ..Default::default()
     })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn capability_labels_include_os_and_arch() {
+        let labels = default_capability_labels();
+        assert_eq!(
+            labels.get("os").map(String::as_str),
+            Some(std::env::consts::OS)
+        );
+        assert_eq!(
+            labels.get("arch").map(String::as_str),
+            Some(std::env::consts::ARCH)
+        );
+        // On the supported worker target these are non-empty.
+        assert!(!labels.get("os").unwrap().is_empty());
+        assert!(!labels.get("arch").unwrap().is_empty());
+    }
 }

--- a/docs/journal/phase-4.md
+++ b/docs/journal/phase-4.md
@@ -207,3 +207,52 @@ milestone:** §16 task 2 — constraint matching (match an Action's
 `Platform` requirements against `WorkerCapabilities.labels`; hard vs.
 soft constraints), as a new branch off `origin/main` once #98 merges
 (else stacked).
+
+## I5 — platform constraint matching (§16 task 2, matcher)
+
+- **Date:** 2026-06-27
+- **Affected crate:** `brokkr-control`
+- **Outcome:** `brokkr-control::matching` — the eligibility primitive the
+  scheduler will use to pick workers. `labels_satisfy_platform` /
+  `worker_satisfies` implement REAPI matching (every required
+  `Property{name,value}` must be advertised; empty platform matches all),
+  and `eligible_workers(registry, now, platform)` yields the live workers
+  that also satisfy the constraints. First increment of task 2; #98
+  (task 1) merged, so this is a fresh branch off `main`. Six unit tests;
+  `brokkr-control` fmt/clippy/test green (31 lib tests).
+
+### Decisions
+
+- **Matcher lives outside `registry`.** The registry stays proto-free (a
+  plain liveness/capability store); the proto-aware matching is its own
+  module that depends on both `registry` and `brokkr-proto`. Same
+  decoupling Phase 3 drew between `brokkr-cas::ring` and the proto — it
+  keeps the registry's unit tests free of proto fixtures and avoids
+  leaking `i32`-encoded proto enums into the capability model.
+- **Hard constraints only; soft is deferred (needs an ADR).** Plan §16
+  asks for hard vs. soft constraints, but REAPI's `Platform` has no soft
+  notion — modelling "preferred" needs a Brokkr-specific convention
+  (e.g. a reserved property-name prefix, or a `brokkr.v1` extension).
+  Rather than invent wire semantics inline, I5 ships REAPI-faithful hard
+  matching and flags soft as a follow-up ADR. Documented in the module.
+- **Single-valued labels ⇒ duplicate-name requirements are
+  unsatisfiable.** `WorkerCapabilities.labels` is `BTreeMap<_,_>` (one
+  value per name). A platform requiring `os=linux` *and* `os=windows`
+  can't be met by any single worker — the correct outcome for
+  single-valued attributes. Multi-valued worker capabilities (a worker
+  advertising several values for one name) would need a richer model;
+  deferred until a workload needs it, with a test pinning the current
+  behaviour.
+- **`eligible_workers` composes `healthy()` + the matcher.** Eligibility
+  = live AND satisfies-constraints. Returning an iterator (not a Vec)
+  keeps it allocation-free for the scheduler's pick path.
+
+### Next increment (I6)
+
+Teach the scheduler to use `eligible_workers`. The current scheduler is
+single-worker (one queue, one stream); I6 introduces capability-aware
+*selection* — extract the action's `Platform` (from `Command.platform` /
+`Action.platform`) and pick an eligible worker — as the data-model step
+toward multi-worker dispatch. Full multi-worker fan-out (multiple
+concurrent streams) is a later increment; I6 should be the smallest step
+that makes selection constraint-aware without rewriting dispatch.

--- a/docs/journal/phase-4.md
+++ b/docs/journal/phase-4.md
@@ -303,3 +303,39 @@ capabilities. I7: have `brokkr-worker` advertise `os` / `arch` (and
 configurable labels) at registration so constrained actions can actually
 be scheduled. Actions with no platform requirements are unaffected (empty
 platform matches any healthy worker).
+
+## I7 — worker advertises os/arch capabilities (§16 task 2 — CLOSED)
+
+- **Date:** 2026-06-27
+- **Affected crate:** `brokkr-worker`
+- **Outcome:** `run_worker` now registers with `os` / `arch` labels from
+  `std::env::consts`, so the matcher + admission control chain works
+  end-to-end: worker advertises capabilities → control plane stores them
+  → constrained actions are matched and either placed or rejected with
+  `NoEligibleWorker`. One unit test on the label helper;
+  `brokkr-worker` green.
+
+### Decisions
+
+- **Auto-detect, no config-surface change.** Populated the labels
+  directly in `run_worker` via a small `default_capability_labels()`
+  helper rather than adding a `labels` field to `WorkerConfig`. Keeps the
+  two struct-literal construction sites (the CLI binary and the in-process
+  test fixture) untouched, and `os`/`arch` are the labels actions most
+  commonly constrain on. Configurable / richer capabilities (installed
+  tools, GPU, RAM — plan §6.3 / §8 `WorkerCapability`) are deferred to a
+  later increment when a workload needs them.
+- **Extracted a testable helper.** `run_worker` itself needs a live
+  server to exercise, so the label logic is a standalone fn with a unit
+  test; the flow into the registry is already covered by the control-plane
+  handler test `register_persists_capabilities_into_registry`.
+
+### §16 task 2 status
+
+Done across I5–I7: matcher (`brokkr-control::matching`) → admission
+control in the scheduler → worker capability advertisement. All on
+PR #99. Hard-constraint matching is complete end-to-end. **Deferred:**
+soft/preferred constraints (needs a Brokkr convention — future ADR);
+richer worker capabilities; per-worker *routing* (multi-worker dispatch)
+and scheduling strategies are §16 task 3, the next milestone — that's the
+multi-worker redesign the I6 decision deferred.

--- a/docs/journal/phase-4.md
+++ b/docs/journal/phase-4.md
@@ -256,3 +256,50 @@ single-worker (one queue, one stream); I6 introduces capability-aware
 toward multi-worker dispatch. Full multi-worker fan-out (multiple
 concurrent streams) is a later increment; I6 should be the smallest step
 that makes selection constraint-aware without rewriting dispatch.
+
+## I6 — constraint-aware admission control (§16 task 2)
+
+- **Date:** 2026-06-27
+- **Affected crate:** `brokkr-control`
+- **Decision taken with the owner:** "admission control first" (vs. a
+  full multi-worker dispatch redesign or pausing). So I6 uses the matcher
+  to *reject* un-runnable actions without restructuring dispatch.
+- **Outcome:** `Scheduler::execute` now consults a shared `WorkerRegistry`
+  (when wired in) and returns the typed `ExecutionError::NoEligibleWorker`
+  → gRPC `FAILED_PRECONDITION` if no live worker satisfies the action's
+  platform, instead of enqueuing a job that no worker can claim. The
+  binary builds one registry shared by the scheduler (reads), the worker
+  service (writes), and the eviction reaper. Three scheduler tests;
+  `brokkr-control` green (34 lib tests).
+
+### Decisions
+
+- **Admission, not routing.** Delivery stays single-queue/single-worker;
+  the matcher only gates *admission*. This is the smallest step that puts
+  the matcher to work and gives clients a fast, correct
+  `FAILED_PRECONDITION` instead of a 30-minute timeout. Real per-worker
+  routing + scheduling strategies (task 3) is the redesign that follows.
+- **Opt-in via constructor, off by default.** `new` /
+  `with_execution_timeout` leave the registry `None` (admission skipped),
+  so the Phase-1 in-process fixtures and unit tests are unchanged; the
+  binary opts in with `with_worker_registry`. Avoids a flag-day behaviour
+  change in tests while making production fail-fast.
+- **Check after the cache lookup, before enqueue.** A cache hit needs no
+  worker, so admission runs only on the dispatch path, after the
+  Action/Command are fetched (we need the platform) and before the job is
+  queued.
+- **Deprecated `Command.platform` fallback, scoped allow.** REAPI v2.2
+  moved platform to `Action.platform`; older clients still set
+  `Command.platform`. We accept both with a one-line `#[allow(deprecated)]`
+  rather than dropping v2.0 compatibility.
+
+### Known gap → next increment (I7)
+
+Admission control is now live in the binary, but the CLI worker still
+registers with **empty labels** (`run_worker` sends
+`labels: Default::default()`). So an action with any platform constraint
+will be rejected in production until the worker advertises its real
+capabilities. I7: have `brokkr-worker` advertise `os` / `arch` (and
+configurable labels) at registration so constrained actions can actually
+be scheduled. Actions with no platform requirements are unaffected (empty
+platform matches any healthy worker).


### PR DESCRIPTION
## Motivation

Phase 4 §16 task 2: "Constraint matching. Action's `Platform` requirements matched against worker capabilities. Hard constraints (must match) vs. soft (preferred)." With the worker registry now tracking capabilities (#98), this adds the eligibility primitive the scheduler needs to pick a worker for a job.

## What changed

New module `brokkr-control::matching`:
- `labels_satisfy_platform(labels, platform)` / `worker_satisfies(caps, platform)` — REAPI semantics: a worker satisfies a `Platform` iff it advertises every required `Property{name, value}`; an empty platform matches every worker.
- `eligible_workers(registry, now, platform)` — yields the **live** workers (via `WorkerRegistry::healthy`) that **also** satisfy the constraints; the candidate set for dispatch. Returns an iterator (allocation-free pick path).

Design notes:
- **Proto-aware, separate from `registry`.** The registry stays proto-free; matching depends on both it and `brokkr-proto` — same decoupling Phase 3 used between `brokkr-cas::ring` and the proto.
- **Hard constraints only.** REAPI's `Platform` has no "soft/preferred" notion; modelling soft needs a Brokkr convention, so it's flagged as a follow-up ADR rather than invented inline.
- **Single-valued labels.** `WorkerCapabilities.labels` is one-value-per-name, so a platform requiring the same name with two values is correctly unsatisfiable (test pins this); multi-valued capabilities are deferred.

## How it was tested

6 unit tests (empty platform, single match/mismatch, missing name, all-must-match, duplicate-name unsatisfiable, `eligible_workers` filters by both health and constraints). Verified per-crate in WSL2: `brokkr-control` fmt + `clippy --all-targets -D warnings` + test green (31 lib tests).

> Full `cargo test --workspace` isn't green on the WSL2 dev host (pre-existing `brokkr-sandbox` seccomp tests can't trap under the virtualized kernel); unrelated to this `brokkr-control`-only change. Linux CI covers it.

## Related

`docs/plan.md` §16 task 2; `docs/journal/phase-4.md` (I5). Builds on #98 (task 1). Next: wire `eligible_workers` into scheduler selection (I6).