### PR TITLE
feat(control): multi-worker scheduling — ADR 0008 + foundation (Phase 4 §16 task 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -660,3 +660,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   constraint-matching path end-to-end (worker advertises → matcher →
   admission control). Richer / configurable capabilities (installed
   tools, GPU, RAM) are a later increment. One unit test.
+- ADR 0008 — multi-worker scheduling: per-worker job queues with
+  submit-time routing + a pluggable selection `Strategy` (chosen over a
+  central dispatcher / pull model). `docs/architecture/0008-multi-worker-scheduling.md`.
+- `brokkr-control::scheduling` (plan §16 task 3 foundation): the
+  `Strategy` trait + `LoadView` and a `SimpleFifo` strategy
+  (least-loaded candidate, deterministic id tie-break), plus
+  `ConnectedWorkers` — a registry of workers with a live stream, each
+  with its own job channel and in-flight count (distinct from
+  `WorkerRegistry`, which tracks liveness/capabilities). Pure
+  data-model + policy; the scheduler/worker-service wiring that routes
+  jobs through it is the next increment. Eight unit tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -671,3 +671,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `WorkerRegistry`, which tracks liveness/capabilities). Pure
   data-model + policy; the scheduler/worker-service wiring that routes
   jobs through it is the next increment. Eight unit tests.
+- Multi-worker dispatch wired through the scheduler (ADR 0008). The
+  single shared job queue (`Scheduler::take_receiver`) is gone:
+  `WorkerService.Stream` now reads the worker id from the worker's
+  `Hello`, registers a per-worker job channel in the shared
+  `ConnectedWorkers`, pumps that worker's jobs, and deregisters on
+  disconnect. `Scheduler::execute` routes each action to a specific
+  worker — candidates = connected workers, narrowed to the
+  platform-matching healthy ones when a registry is wired in, then
+  `Strategy::choose` (`SimpleFifo`) picks one; per-worker in-flight
+  counts are incremented on dispatch and decremented when the result or
+  timeout resolves. No eligible connected worker → `NoEligibleWorker`.
+  `Scheduler` gained `connected_workers()`; the binary shares one
+  `ConnectedWorkers` between the scheduler and the worker service (the
+  scheduler owns it). Five scheduler tests updated/added (reject when
+  none connected, reject on label mismatch, route-then-timeout, two-worker
+  spread) plus the existing real-gRPC end-to-end. In-flight job
+  reassignment when a worker disconnects is deferred to task 4 (leases).

--- a/crates/brokkr-control/src/lib.rs
+++ b/crates/brokkr-control/src/lib.rs
@@ -10,6 +10,7 @@ pub mod matching;
 pub mod membership;
 pub mod registry;
 pub mod scheduler;
+pub mod scheduling;
 pub mod services;
 pub mod worker_service;
 
@@ -19,5 +20,6 @@ pub use registry::{
     HeartbeatPolicy, RegistryError, WorkerCapabilities, WorkerRecord, WorkerRegistry,
 };
 pub use scheduler::Scheduler;
+pub use scheduling::{ConnectedWorkers, LoadView, SimpleFifo, Strategy};
 pub use services::{ActionCacheService, CapabilitiesService, CasService, ExecutionService};
 pub use worker_service::{spawn_eviction_task, SharedWorkerRegistry, WorkerServiceImpl};

--- a/crates/brokkr-control/src/scheduler.rs
+++ b/crates/brokkr-control/src/scheduler.rs
@@ -1,8 +1,11 @@
-//! Single-node, single-queue job scheduler for Phase 1.
+//! Job scheduler: bridges the REAPI `Execute` RPC (client-facing) to the
+//! internal `brokkr.v1.WorkerService.Stream` (worker-facing).
 //!
-//! Bridges the REAPI `Execute` RPC (client-facing) to the internal
-//! `brokkr.v1.WorkerService.Stream` (worker-facing). Multi-worker fan-out and
-//! priority queues are Phase 4.
+//! Multi-worker dispatch follows ADR 0008: each connected worker has its own
+//! job channel ([`crate::scheduling::ConnectedWorkers`]); `execute` filters to
+//! the eligible (matching + connected) workers and a pluggable
+//! [`crate::scheduling::Strategy`] picks one. Global queueing, leases, and fair
+//! scheduling are Phase 4 task 4.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -10,14 +13,15 @@ use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
 use brokkr_cas::{ActionCache, Cas};
-use brokkr_common::{Digest, JobId};
+use brokkr_common::{Digest, JobId, WorkerId};
 use brokkr_proto::brokkr_v1 as bv1;
 use brokkr_proto::reapi_v2 as rapi;
 use prost::Message;
 use thiserror::Error;
-use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::sync::{oneshot, Mutex};
 
 use crate::matching::eligible_workers;
+use crate::scheduling::{ConnectedWorkers, SharedConnectedWorkers, SimpleFifo, Strategy};
 use crate::worker_service::SharedWorkerRegistry;
 
 /// Default ceiling on how long [`Scheduler::execute`] waits for a worker to
@@ -57,19 +61,22 @@ pub struct ExecutionOutcome {
     pub cache_hit: bool,
 }
 
-/// Single-queue in-process job scheduler.
+/// Multi-worker job scheduler.
 pub struct Scheduler {
-    queue_tx: mpsc::UnboundedSender<bv1::Job>,
-    queue_rx: Mutex<Option<mpsc::UnboundedReceiver<bv1::Job>>>,
+    /// Workers with a live `Stream`, each with its own job channel + load.
+    /// `WorkerService.Stream` writes connect/disconnect; `execute` routes
+    /// through it.
+    connected: SharedConnectedWorkers,
+    /// Worker-selection policy (ADR 0008). Defaults to `SimpleFifo`.
+    strategy: Arc<dyn Strategy>,
     waiters: Mutex<HashMap<JobId, oneshot::Sender<bv1::JobResult>>>,
     cas: Arc<dyn Cas>,
     action_cache: Arc<dyn ActionCache>,
     default_execution_timeout: Duration,
-    /// Optional worker registry for platform-constraint admission control.
-    /// When set, [`Scheduler::execute`] rejects an action up front if no live
-    /// worker satisfies its platform. When `None` (e.g. unit tests that don't
-    /// exercise matching), admission control is skipped — preserving the
-    /// pre-Phase-4 single-worker behaviour.
+    /// Optional worker registry for platform-constraint filtering. When set,
+    /// candidates are narrowed to healthy workers whose capabilities satisfy
+    /// the action's platform; when `None` (e.g. fixtures that don't exercise
+    /// matching), any connected worker is a candidate.
     worker_registry: Option<SharedWorkerRegistry>,
 }
 
@@ -128,10 +135,9 @@ impl Scheduler {
         default_execution_timeout: Duration,
         worker_registry: Option<SharedWorkerRegistry>,
     ) -> Arc<Self> {
-        let (queue_tx, queue_rx) = mpsc::unbounded_channel();
         Arc::new(Self {
-            queue_tx,
-            queue_rx: Mutex::new(Some(queue_rx)),
+            connected: Arc::new(Mutex::new(ConnectedWorkers::new())),
+            strategy: Arc::new(SimpleFifo),
             waiters: Mutex::new(HashMap::new()),
             cas,
             action_cache,
@@ -140,11 +146,11 @@ impl Scheduler {
         })
     }
 
-    /// Take ownership of the job receiver. Returns `None` after the first call;
-    /// only one worker stream is supported in Phase 1.
-    #[tracing::instrument(name = "scheduler::take_receiver", skip(self))]
-    pub async fn take_receiver(&self) -> Option<mpsc::UnboundedReceiver<bv1::Job>> {
-        self.queue_rx.lock().await.take()
+    /// The shared connected-worker registry. `WorkerService.Stream` registers
+    /// each worker's job channel here on connect and removes it on disconnect;
+    /// `execute` routes jobs through it.
+    pub fn connected_workers(&self) -> SharedConnectedWorkers {
+        self.connected.clone()
     }
 
     /// Execute an action: look up the action cache, otherwise enqueue a job
@@ -158,6 +164,7 @@ impl Scheduler {
             cache_hit = tracing::field::Empty,
             exit_code = tracing::field::Empty,
             job_id = tracing::field::Empty,
+            worker_id = tracing::field::Empty,
         ),
     )]
     pub async fn execute(
@@ -200,38 +207,29 @@ impl Scheduler {
             .await
             .with_context(|| "fetching Command from CAS")?;
 
-        // Admission control: if a worker registry is wired in, reject the
-        // action up front when no live worker satisfies its platform, rather
-        // than enqueuing a job that no worker can ever claim (which would only
-        // surface as a timeout). The platform lives on `Action.platform`
-        // (REAPI v2.2) with a fallback to the deprecated `Command.platform`.
-        if let Some(registry) = self.worker_registry.as_ref() {
-            // `Command.platform` is deprecated in REAPI v2.2 (moved to
-            // `Action.platform`) but still used by older clients, so we accept
-            // it as a fallback — hence the scoped allow.
-            #[allow(deprecated)]
-            let platform = action
-                .platform
-                .clone()
-                .or_else(|| command.platform.clone())
-                .unwrap_or_default();
-            let has_eligible = {
-                let guard = registry.lock().await;
-                // Bind to a local so the borrowing iterator temporary is
-                // dropped before `guard` at the end of the block.
-                let any = eligible_workers(&guard, Instant::now(), &platform)
-                    .next()
-                    .is_some();
-                any
-            };
-            if !has_eligible {
-                tracing::warn!(
-                    action_digest = %action_digest,
-                    "no eligible worker for action platform; rejecting"
-                );
-                return Err(ExecutionError::NoEligibleWorker);
+        // Resolve the action's platform constraints. REAPI v2.2 carries them
+        // on `Action.platform`; older clients set the deprecated
+        // `Command.platform`, which we still accept as a fallback.
+        #[allow(deprecated)]
+        let platform = action
+            .platform
+            .clone()
+            .or_else(|| command.platform.clone())
+            .unwrap_or_default();
+
+        // Snapshot the registry-eligible worker ids (if a registry is wired
+        // in), releasing the registry lock before we touch the connected set —
+        // so the two locks are never held at once.
+        let eligible_ids: Option<Vec<WorkerId>> = match self.worker_registry.as_ref() {
+            Some(registry) => {
+                let reg = registry.lock().await;
+                let ids = eligible_workers(&reg, Instant::now(), &platform)
+                    .map(|(id, _)| id.clone())
+                    .collect();
+                Some(ids)
             }
-        }
+            None => None,
+        };
 
         // REAPI `Action.timeout` overrides the scheduler default; treat
         // missing / zero / negative as "use the default".
@@ -248,9 +246,40 @@ impl Scheduler {
             })
             .unwrap_or(self.default_execution_timeout);
 
+        // Pick a worker and claim a job sender + an in-flight slot under one
+        // lock on the connected set. Candidates = connected workers, narrowed
+        // to the registry-eligible ones when a registry is present.
+        let (worker_id, sender) = {
+            let mut connected = self.connected.lock().await;
+            let candidates: Vec<WorkerId> = match &eligible_ids {
+                Some(ids) => ids
+                    .iter()
+                    .filter(|id| connected.is_connected(id))
+                    .cloned()
+                    .collect(),
+                None => connected.connected_ids().cloned().collect(),
+            };
+            let Some(chosen) = self.strategy.choose(&candidates, &*connected) else {
+                tracing::warn!(
+                    action_digest = %action_digest,
+                    "no eligible connected worker for action platform; rejecting"
+                );
+                return Err(ExecutionError::NoEligibleWorker);
+            };
+            let Some(sender) = connected.sender(&chosen) else {
+                // Disconnected between selection and sender clone (racy); fail
+                // closed rather than route into the void.
+                return Err(ExecutionError::NoEligibleWorker);
+            };
+            connected.inc_inflight(&chosen);
+            (chosen, sender)
+        };
+
         let job_id = JobId::new(uuid::Uuid::new_v4().to_string())
             .map_err(|e| anyhow!("invalid job id: {e}"))?;
-        tracing::Span::current().record("job_id", job_id.as_str());
+        tracing::Span::current()
+            .record("job_id", job_id.as_str())
+            .record("worker_id", worker_id.as_str());
         let (tx, rx) = oneshot::channel();
         self.waiters.lock().await.insert(job_id.clone(), tx);
 
@@ -263,53 +292,59 @@ impl Scheduler {
             action: Some(action),
             command: Some(command),
         };
-        if self.queue_tx.send(job).is_err() {
-            // Drop the now-orphaned waiter so the map doesn't grow.
+        if sender.send(job).await.is_err() {
+            // The worker's channel closed (it disconnected after selection).
+            // Drop the waiter and release the in-flight slot.
             self.waiters.lock().await.remove(&job_id);
-            return Err(anyhow!("scheduler queue closed").into());
+            self.connected.lock().await.dec_inflight(&worker_id);
+            return Err(anyhow!("worker channel closed before dispatch").into());
         }
 
-        let report = match tokio::time::timeout(effective_timeout, rx).await {
-            Ok(Ok(report)) => report,
-            Ok(Err(_)) => {
-                // Waiter dropped without a value — the entry is already gone
-                // from the map (consumed by `report`).
-                return Err(anyhow!("worker did not report result").into());
+        // Await the result, then release the in-flight slot on every exit path.
+        // The inner `async` block lets `?` / early `return` short-circuit to
+        // `outcome` so the decrement below always runs exactly once.
+        let outcome: Result<ExecutionOutcome, ExecutionError> = async {
+            let report = match tokio::time::timeout(effective_timeout, rx).await {
+                Ok(Ok(report)) => report,
+                Ok(Err(_)) => {
+                    // Waiter dropped without a value (already removed by `report`).
+                    return Err(anyhow!("worker did not report result").into());
+                }
+                Err(_) => {
+                    // Reclaim the waiter slot so the map doesn't accumulate
+                    // stalled entries; a late report is then discarded on miss.
+                    self.waiters.lock().await.remove(&job_id);
+                    tracing::warn!(
+                        job_id = job_id.as_str(),
+                        timeout_secs = effective_timeout.as_secs_f64(),
+                        "scheduler: worker did not report within timeout"
+                    );
+                    return Err(ExecutionError::Timeout(effective_timeout));
+                }
+            };
+            if !report.error_message.is_empty() {
+                return Err(anyhow!("worker error: {}", report.error_message).into());
             }
-            Err(_) => {
-                // Time elapsed. Reclaim the waiter slot before returning so
-                // the map doesn't accumulate stalled entries; a late report
-                // from the worker will then be discarded by `report` because
-                // the lookup misses.
-                self.waiters.lock().await.remove(&job_id);
-                tracing::warn!(
-                    job_id = job_id.as_str(),
-                    timeout_secs = effective_timeout.as_secs_f64(),
-                    "scheduler: worker did not report within timeout"
-                );
-                return Err(ExecutionError::Timeout(effective_timeout));
+            let result = report
+                .result
+                .ok_or_else(|| anyhow!("worker reported no ActionResult"))?;
+            if result.exit_code == 0 {
+                self.action_cache
+                    .update_action_result(&action_digest, result.clone())
+                    .await
+                    .map_err(|e| anyhow!("action cache update: {e}"))?;
             }
-        };
-        if !report.error_message.is_empty() {
-            return Err(anyhow!("worker error: {}", report.error_message).into());
+            tracing::Span::current()
+                .record("cache_hit", false)
+                .record("exit_code", result.exit_code);
+            Ok(ExecutionOutcome {
+                result,
+                cache_hit: false,
+            })
         }
-        let result = report
-            .result
-            .ok_or_else(|| anyhow!("worker reported no ActionResult"))?;
-
-        if result.exit_code == 0 {
-            self.action_cache
-                .update_action_result(&action_digest, result.clone())
-                .await
-                .map_err(|e| anyhow!("action cache update: {e}"))?;
-        }
-        tracing::Span::current()
-            .record("cache_hit", false)
-            .record("exit_code", result.exit_code);
-        Ok(ExecutionOutcome {
-            result,
-            cache_hit: false,
-        })
+        .await;
+        self.connected.lock().await.dec_inflight(&worker_id);
+        outcome
     }
 
     /// Worker-side entry: receive a job result and wake the matching waiter.
@@ -499,6 +534,16 @@ mod tests {
         let timeout = Duration::from_millis(120);
         let scheduler = Scheduler::with_execution_timeout(cas, ac, timeout);
 
+        // Connect a worker (no registry → any connected worker is a
+        // candidate). Hold the receiver so the dispatched job buffers and
+        // `execute` awaits a result that never arrives → Timeout.
+        let (tx, _held_rx) = tokio::sync::mpsc::channel::<bv1::Job>(8);
+        scheduler
+            .connected_workers()
+            .lock()
+            .await
+            .connect(WorkerId::new("w1".to_string()).unwrap(), tx);
+
         let start = Instant::now();
         let err = scheduler.execute(action_digest, true).await.unwrap_err();
         let elapsed = start.elapsed();
@@ -579,12 +624,19 @@ mod tests {
         }
     }
 
-    fn registry_with_worker(labels: &[(&str, &str)]) -> SharedWorkerRegistry {
-        use brokkr_common::WorkerId;
+    /// Register a worker in `registry` with `labels` and connect it to
+    /// `scheduler`'s `ConnectedWorkers`, returning the held job receiver. Keep
+    /// the receiver alive so the per-worker channel stays open and dispatched
+    /// jobs buffer (instead of the sender erroring on a dropped receiver).
+    async fn register_and_connect(
+        scheduler: &Arc<Scheduler>,
+        registry: &SharedWorkerRegistry,
+        id: &str,
+        labels: &[(&str, &str)],
+    ) -> tokio::sync::mpsc::Receiver<bv1::Job> {
+        use crate::registry::WorkerCapabilities;
 
-        use crate::registry::{WorkerCapabilities, WorkerRegistry};
-
-        let mut reg = WorkerRegistry::default();
+        let wid = WorkerId::new(id.to_string()).unwrap();
         let caps = WorkerCapabilities {
             hostname: "w".to_string(),
             labels: labels
@@ -592,15 +644,16 @@ mod tests {
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect(),
         };
-        reg.register(
-            WorkerId::new("w1".to_string()).unwrap(),
-            caps,
-            Instant::now(),
-        );
-        Arc::new(Mutex::new(reg))
+        registry
+            .lock()
+            .await
+            .register(wid.clone(), caps, Instant::now());
+        let (tx, rx) = tokio::sync::mpsc::channel::<bv1::Job>(8);
+        scheduler.connected_workers().lock().await.connect(wid, tx);
+        rx
     }
 
-    /// No registered worker → admission control rejects before enqueue.
+    /// No connected worker → routing rejects before dispatch.
     #[tokio::test]
     async fn execute_rejects_when_no_eligible_worker() {
         use crate::registry::WorkerRegistry;
@@ -608,7 +661,7 @@ mod tests {
         let cas = Arc::new(brokkr_cas::InMemoryCas::new());
         let action_digest = stage_action(cas.as_ref(), Some(os_platform("linux"))).await;
         let ac = Arc::new(MockActionCache { force_error: false });
-        let registry = Arc::new(Mutex::new(WorkerRegistry::default())); // empty
+        let registry = Arc::new(Mutex::new(WorkerRegistry::default())); // empty, none connected
         let scheduler =
             Scheduler::with_registry_and_timeout(cas, ac, Duration::from_millis(200), registry);
 
@@ -619,15 +672,23 @@ mod tests {
         );
     }
 
-    /// A worker whose labels don't satisfy the platform is not eligible.
+    /// A connected worker whose labels don't satisfy the platform is filtered
+    /// out → NoEligibleWorker.
     #[tokio::test]
     async fn execute_rejects_when_worker_does_not_match_platform() {
+        use crate::registry::WorkerRegistry;
+
         let cas = Arc::new(brokkr_cas::InMemoryCas::new());
         let action_digest = stage_action(cas.as_ref(), Some(os_platform("linux"))).await;
         let ac = Arc::new(MockActionCache { force_error: false });
-        let registry = registry_with_worker(&[("os", "windows")]);
-        let scheduler =
-            Scheduler::with_registry_and_timeout(cas, ac, Duration::from_millis(200), registry);
+        let registry = Arc::new(Mutex::new(WorkerRegistry::default()));
+        let scheduler = Scheduler::with_registry_and_timeout(
+            cas,
+            ac,
+            Duration::from_millis(200),
+            registry.clone(),
+        );
+        let _held = register_and_connect(&scheduler, &registry, "w1", &[("os", "windows")]).await;
 
         let err = scheduler.execute(action_digest, true).await.unwrap_err();
         assert!(
@@ -636,22 +697,61 @@ mod tests {
         );
     }
 
-    /// An eligible worker present → admission passes; with no worker actually
-    /// consuming the queue the call then times out (proving it got past
-    /// admission rather than being rejected).
+    /// A connected, matching worker → routing dispatches; with no result coming
+    /// back the call times out (proving it got past selection rather than being
+    /// rejected).
     #[tokio::test]
-    async fn execute_passes_admission_with_matching_worker() {
+    async fn execute_passes_routing_with_matching_worker() {
+        use crate::registry::WorkerRegistry;
+
         let cas = Arc::new(brokkr_cas::InMemoryCas::new());
         let action_digest = stage_action(cas.as_ref(), Some(os_platform("linux"))).await;
         let ac = Arc::new(MockActionCache { force_error: false });
-        let registry = registry_with_worker(&[("os", "linux")]);
+        let registry = Arc::new(Mutex::new(WorkerRegistry::default()));
         let timeout = Duration::from_millis(120);
-        let scheduler = Scheduler::with_registry_and_timeout(cas, ac, timeout, registry);
+        let scheduler = Scheduler::with_registry_and_timeout(cas, ac, timeout, registry.clone());
+        let _held = register_and_connect(&scheduler, &registry, "w1", &[("os", "linux")]).await;
 
         let err = scheduler.execute(action_digest, true).await.unwrap_err();
         assert!(
             matches!(err, ExecutionError::Timeout(_)),
-            "expected Timeout (admission passed), got {err:?}"
+            "expected Timeout (selection passed), got {err:?}"
+        );
+    }
+
+    /// Two connected matching workers: `SimpleFifo` spreads — in-flight
+    /// tracking sends the second job to the idle worker, so each worker's
+    /// channel receives exactly one job.
+    #[tokio::test]
+    async fn execute_spreads_across_two_idle_workers() {
+        use crate::registry::WorkerRegistry;
+
+        let cas = Arc::new(brokkr_cas::InMemoryCas::new());
+        let action_digest = stage_action(cas.as_ref(), Some(os_platform("linux"))).await;
+        let ac = Arc::new(MockActionCache { force_error: false });
+        let registry = Arc::new(Mutex::new(WorkerRegistry::default()));
+        let timeout = Duration::from_millis(150);
+        let scheduler = Scheduler::with_registry_and_timeout(cas, ac, timeout, registry.clone());
+        let mut rx_a = register_and_connect(&scheduler, &registry, "w-a", &[("os", "linux")]).await;
+        let mut rx_b = register_and_connect(&scheduler, &registry, "w-b", &[("os", "linux")]).await;
+
+        // Two concurrent executes; neither worker reports, so both time out.
+        // pick+inc-in-flight is one critical section under the connected lock,
+        // so the second execute sees the first worker busy and picks the other.
+        let (s1, s2) = (scheduler.clone(), scheduler.clone());
+        let (d1, d2) = (action_digest.clone(), action_digest);
+        let h1 = tokio::spawn(async move { s1.execute(d1, true).await });
+        let h2 = tokio::spawn(async move { s2.execute(d2, true).await });
+        let _ = h1.await.unwrap();
+        let _ = h2.await.unwrap();
+
+        assert!(
+            rx_a.try_recv().is_ok(),
+            "worker a should have received exactly one job"
+        );
+        assert!(
+            rx_b.try_recv().is_ok(),
+            "worker b should have received exactly one job"
         );
     }
 }

--- a/crates/brokkr-control/src/scheduling.rs
+++ b/crates/brokkr-control/src/scheduling.rs
@@ -1,0 +1,268 @@
+//! Multi-worker scheduling primitives (ADR 0008): the connected-worker
+//! registry and the pluggable worker-selection [`Strategy`].
+//!
+//! This module is the data-model foundation for §16 task 3. The scheduler
+//! wiring that routes jobs through it is a separate increment; keeping the
+//! policy (`Strategy`) and the connection state (`ConnectedWorkers`) here —
+//! both proto-light and free of dispatch plumbing — makes them unit-testable
+//! in isolation.
+
+use std::collections::HashMap;
+
+use brokkr_common::WorkerId;
+use brokkr_proto::brokkr_v1 as bv1;
+use tokio::sync::mpsc;
+
+/// Read-only view of per-worker load, handed to a [`Strategy`] so policies can
+/// prefer (or avoid) busy workers without depending on `ConnectedWorkers`.
+pub trait LoadView {
+    /// Number of jobs dispatched to `worker` but not yet reported back
+    /// (its in-flight count). Unknown workers read as `0`.
+    fn inflight(&self, worker: &WorkerId) -> usize;
+}
+
+/// Worker-selection policy: pick one worker from an eligible candidate set.
+///
+/// Candidates are pre-filtered by the caller to workers that are *both*
+/// connected and satisfy the action's platform constraints
+/// ([`crate::matching::eligible_workers`]). The strategy only decides *which*
+/// of those gets the job.
+pub trait Strategy: Send + Sync {
+    /// Choose a worker from `candidates` given current `loads`. Returns `None`
+    /// iff `candidates` is empty.
+    fn choose(&self, candidates: &[WorkerId], loads: &dyn LoadView) -> Option<WorkerId>;
+}
+
+/// Simplest strategy: the least-loaded candidate, ties broken by worker id
+/// for determinism. Stateless, so it needs no `&mut self` / interior
+/// mutability. (`BinPacking` / `LocalityAware` are later increments behind the
+/// same trait — see ADR 0008.)
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SimpleFifo;
+
+impl Strategy for SimpleFifo {
+    fn choose(&self, candidates: &[WorkerId], loads: &dyn LoadView) -> Option<WorkerId> {
+        candidates
+            .iter()
+            .min_by(|a, b| {
+                loads
+                    .inflight(a)
+                    .cmp(&loads.inflight(b))
+                    .then_with(|| a.as_str().cmp(b.as_str()))
+            })
+            .cloned()
+    }
+}
+
+/// A connected worker's job-dispatch channel plus its live in-flight count.
+struct WorkerConn {
+    job_tx: mpsc::Sender<bv1::Job>,
+    inflight: usize,
+}
+
+/// Registry of workers that currently hold a live `WorkerService.Stream`, each
+/// with its own job channel.
+///
+/// Distinct from [`crate::registry::WorkerRegistry`]: that tracks liveness and
+/// capabilities (a worker is *registered* once it has handshaked and keeps
+/// heartbeating), whereas this tracks the *connection* (a worker is
+/// *connected* only while its bidi stream is open). The scheduler consults
+/// both — eligibility comes from the registry + matcher, routability from
+/// here.
+#[derive(Default)]
+pub struct ConnectedWorkers {
+    workers: HashMap<WorkerId, WorkerConn>,
+}
+
+impl ConnectedWorkers {
+    /// An empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a worker's job channel when its stream opens. Replaces any
+    /// previous connection for the same id (a reconnect supersedes the old
+    /// stream) and resets its in-flight count.
+    pub fn connect(&mut self, id: WorkerId, job_tx: mpsc::Sender<bv1::Job>) {
+        self.workers.insert(
+            id,
+            WorkerConn {
+                job_tx,
+                inflight: 0,
+            },
+        );
+    }
+
+    /// Remove a worker when its stream closes.
+    pub fn disconnect(&mut self, id: &WorkerId) {
+        self.workers.remove(id);
+    }
+
+    /// Whether `id` currently has an open stream.
+    pub fn is_connected(&self, id: &WorkerId) -> bool {
+        self.workers.contains_key(id)
+    }
+
+    /// The currently-connected worker ids.
+    pub fn connected_ids(&self) -> impl Iterator<Item = &WorkerId> {
+        self.workers.keys()
+    }
+
+    /// Number of connected workers.
+    pub fn len(&self) -> usize {
+        self.workers.len()
+    }
+
+    /// Whether no worker is connected.
+    pub fn is_empty(&self) -> bool {
+        self.workers.is_empty()
+    }
+
+    /// Clone the job sender for `id`, if connected. The clone lets the caller
+    /// send a job without holding the registry lock across the `.await`.
+    pub fn sender(&self, id: &WorkerId) -> Option<mpsc::Sender<bv1::Job>> {
+        self.workers.get(id).map(|c| c.job_tx.clone())
+    }
+
+    /// Increment `id`'s in-flight count (on dispatch). No-op if not connected.
+    pub fn inc_inflight(&mut self, id: &WorkerId) {
+        if let Some(conn) = self.workers.get_mut(id) {
+            conn.inflight += 1;
+        }
+    }
+
+    /// Decrement `id`'s in-flight count (on result / timeout), saturating at
+    /// zero. No-op if not connected.
+    pub fn dec_inflight(&mut self, id: &WorkerId) {
+        if let Some(conn) = self.workers.get_mut(id) {
+            conn.inflight = conn.inflight.saturating_sub(1);
+        }
+    }
+}
+
+impl LoadView for ConnectedWorkers {
+    fn inflight(&self, worker: &WorkerId) -> usize {
+        self.workers.get(worker).map(|c| c.inflight).unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn wid(s: &str) -> WorkerId {
+        WorkerId::new(s.to_string()).unwrap()
+    }
+
+    /// In-memory `LoadView` for testing strategies without a `ConnectedWorkers`.
+    struct MapLoads(HashMap<WorkerId, usize>);
+    impl LoadView for MapLoads {
+        fn inflight(&self, worker: &WorkerId) -> usize {
+            self.0.get(worker).copied().unwrap_or(0)
+        }
+    }
+
+    fn loads(pairs: &[(&str, usize)]) -> MapLoads {
+        MapLoads(pairs.iter().map(|(k, v)| (wid(k), *v)).collect())
+    }
+
+    #[test]
+    fn simple_fifo_empty_candidates_is_none() {
+        assert!(SimpleFifo.choose(&[], &loads(&[])).is_none());
+    }
+
+    #[test]
+    fn simple_fifo_picks_least_loaded() {
+        let cands = vec![wid("a"), wid("b"), wid("c")];
+        let l = loads(&[("a", 3), ("b", 1), ("c", 5)]);
+        assert_eq!(SimpleFifo.choose(&cands, &l), Some(wid("b")));
+    }
+
+    #[test]
+    fn simple_fifo_breaks_ties_by_id() {
+        let cands = vec![wid("zebra"), wid("alpha"), wid("mid")];
+        // All equally loaded → lexicographically smallest id wins.
+        let l = loads(&[("zebra", 2), ("alpha", 2), ("mid", 2)]);
+        assert_eq!(SimpleFifo.choose(&cands, &l), Some(wid("alpha")));
+    }
+
+    #[test]
+    fn simple_fifo_unknown_load_reads_as_zero() {
+        let cands = vec![wid("busy"), wid("fresh")];
+        // "fresh" has no entry → inflight 0 → chosen over busy=4.
+        let l = loads(&[("busy", 4)]);
+        assert_eq!(SimpleFifo.choose(&cands, &l), Some(wid("fresh")));
+    }
+
+    fn dummy_channel() -> mpsc::Sender<bv1::Job> {
+        let (tx, _rx) = mpsc::channel(1);
+        tx
+    }
+
+    #[test]
+    fn connect_disconnect_tracks_membership() {
+        let mut cw = ConnectedWorkers::new();
+        assert!(cw.is_empty());
+        cw.connect(wid("w1"), dummy_channel());
+        cw.connect(wid("w2"), dummy_channel());
+        assert_eq!(cw.len(), 2);
+        assert!(cw.is_connected(&wid("w1")));
+        assert!(cw.sender(&wid("w1")).is_some());
+
+        cw.disconnect(&wid("w1"));
+        assert!(!cw.is_connected(&wid("w1")));
+        assert!(cw.sender(&wid("w1")).is_none());
+        assert_eq!(cw.len(), 1);
+    }
+
+    #[test]
+    fn inflight_tracking_increments_decrements_and_saturates() {
+        let mut cw = ConnectedWorkers::new();
+        cw.connect(wid("w1"), dummy_channel());
+        assert_eq!(cw.inflight(&wid("w1")), 0);
+
+        cw.inc_inflight(&wid("w1"));
+        cw.inc_inflight(&wid("w1"));
+        assert_eq!(cw.inflight(&wid("w1")), 2);
+
+        cw.dec_inflight(&wid("w1"));
+        assert_eq!(cw.inflight(&wid("w1")), 1);
+
+        // Saturates at zero rather than underflowing.
+        cw.dec_inflight(&wid("w1"));
+        cw.dec_inflight(&wid("w1"));
+        assert_eq!(cw.inflight(&wid("w1")), 0);
+
+        // Unknown worker reads as zero; mutators are no-ops.
+        assert_eq!(cw.inflight(&wid("ghost")), 0);
+        cw.inc_inflight(&wid("ghost"));
+        assert_eq!(cw.inflight(&wid("ghost")), 0);
+    }
+
+    #[test]
+    fn reconnect_resets_inflight() {
+        let mut cw = ConnectedWorkers::new();
+        cw.connect(wid("w1"), dummy_channel());
+        cw.inc_inflight(&wid("w1"));
+        assert_eq!(cw.inflight(&wid("w1")), 1);
+        // Reconnect (new stream) replaces the entry and resets the count.
+        cw.connect(wid("w1"), dummy_channel());
+        assert_eq!(cw.inflight(&wid("w1")), 0);
+        assert_eq!(cw.len(), 1);
+    }
+
+    #[test]
+    fn connected_workers_is_a_loadview_for_the_strategy() {
+        let mut cw = ConnectedWorkers::new();
+        cw.connect(wid("a"), dummy_channel());
+        cw.connect(wid("b"), dummy_channel());
+        cw.inc_inflight(&wid("a"));
+        cw.inc_inflight(&wid("a"));
+        cw.inc_inflight(&wid("b"));
+
+        let cands = vec![wid("a"), wid("b")];
+        // b (1 in-flight) beats a (2 in-flight).
+        assert_eq!(SimpleFifo.choose(&cands, &cw), Some(wid("b")));
+    }
+}

--- a/crates/brokkr-control/src/scheduling.rs
+++ b/crates/brokkr-control/src/scheduling.rs
@@ -8,10 +8,11 @@
 //! in isolation.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use brokkr_common::WorkerId;
 use brokkr_proto::brokkr_v1 as bv1;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex};
 
 /// Read-only view of per-worker load, handed to a [`Strategy`] so policies can
 /// prefer (or avoid) busy workers without depending on `ConnectedWorkers`.
@@ -145,6 +146,10 @@ impl LoadView for ConnectedWorkers {
         self.workers.get(worker).map(|c| c.inflight).unwrap_or(0)
     }
 }
+
+/// Shared, mutex-guarded [`ConnectedWorkers`] handle. The scheduler reads it to
+/// route jobs and track load; `WorkerService.Stream` writes connect/disconnect.
+pub type SharedConnectedWorkers = Arc<Mutex<ConnectedWorkers>>;
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::disallowed_methods, clippy::panic)]

--- a/crates/brokkr-control/src/worker_service.rs
+++ b/crates/brokkr-control/src/worker_service.rs
@@ -1,5 +1,8 @@
 //! `brokkr.v1.WorkerService` server: registers workers and runs the bidi
-//! job-dispatch stream. Phase 1 only supports a single worker at a time.
+//! job-dispatch stream. Each connected worker is registered in the scheduler's
+//! [`ConnectedWorkers`](crate::scheduling::ConnectedWorkers) (keyed by the
+//! `worker_id` from its `Hello`) with its own job channel, so the scheduler can
+//! route jobs to a specific worker (ADR 0008).
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -175,74 +178,108 @@ impl WorkerService for WorkerServiceImpl {
         let _guard = span.enter();
         let mut inbound = request.into_inner();
         let scheduler = self.scheduler.clone();
-        let mut job_rx = scheduler
-            .take_receiver()
-            .await
-            .ok_or_else(|| Status::resource_exhausted("worker stream already claimed"))?;
+        let connected = scheduler.connected_workers();
 
-        let (out_tx, out_rx) = mpsc::channel(4);
+        // Outbound stream handed back to the worker (JobAssignments). We must
+        // return it now, but the worker id is only known from the first inbound
+        // message (Hello) — so the per-worker channel registration happens in
+        // the spawned pump once Hello arrives.
+        let (out_tx, out_rx) = mpsc::channel::<Result<JobAssignment, Status>>(4);
 
-        // Inbound pump: read Hello (ignored beyond presence) and JobResults.
-        // Issue #64: previously this loop pattern-matched `Ok(Some(msg))`
-        // and silently exited on `Ok(None)` (clean stream end) and on `Err`
-        // (transport error, decode failure, peer reset). The worker then
-        // appeared to function while its stream was broken. We now log
-        // each terminal state at the appropriate level so an operator
-        // monitoring the control plane can tell why the loop quit.
-        let scheduler_in = scheduler.clone();
-        tokio::spawn(async move {
-            loop {
-                match inbound.message().await {
+        tokio::spawn(
+            async move {
+                // The first message must be Hello carrying the worker id.
+                let worker_id = match inbound.message().await {
                     Ok(Some(msg)) => match msg.payload {
-                        Some(bv1::worker_stream_message::Payload::Hello(_)) => {
-                            tracing::debug!("worker stream: hello received");
-                        }
-                        Some(bv1::worker_stream_message::Payload::Result(result)) => {
-                            if let Err(e) = scheduler_in.report(result).await {
-                                tracing::error!(
-                                    error = %e,
-                                    "invalid job_id in worker result"
-                                );
+                        Some(bv1::worker_stream_message::Payload::Hello(hello)) => {
+                            match hello.worker_id.and_then(|w| WorkerId::new(w.id).ok()) {
+                                Some(id) => id,
+                                None => {
+                                    tracing::error!(
+                                        "worker stream: Hello missing/invalid worker_id — closing"
+                                    );
+                                    return;
+                                }
                             }
                         }
-                        None => {
-                            tracing::warn!(
-                                "worker stream: received WorkerStreamMessage with no payload"
-                            );
+                        _ => {
+                            tracing::error!("worker stream: first message was not Hello — closing");
+                            return;
                         }
                     },
                     Ok(None) => {
-                        tracing::info!(
-                            "worker stream: closed cleanly by the worker — pump exiting"
-                        );
-                        break;
+                        tracing::info!("worker stream: closed before Hello");
+                        return;
                     }
                     Err(status) => {
                         tracing::error!(
                             code = ?status.code(),
-                            message = status.message(),
-                            "worker stream: transport error — pump exiting; \
-                             pending jobs for this worker will time out via the \
-                             scheduler timeout"
+                            "worker stream: transport error before Hello"
                         );
-                        break;
+                        return;
+                    }
+                };
+                tracing::info!(worker_id = %worker_id, "worker stream connected");
+
+                // Register this worker's own job channel so the scheduler can
+                // route jobs to it; spawn the outbound pump that forwards them.
+                let (job_tx, mut job_rx) = mpsc::channel::<bv1::Job>(8);
+                connected.lock().await.connect(worker_id.clone(), job_tx);
+                let outbound = tokio::spawn(async move {
+                    while let Some(job) = job_rx.recv().await {
+                        if out_tx
+                            .send(Ok(JobAssignment { job: Some(job) }))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                });
+
+                // Inbound pump: process JobResults until the stream ends. Each
+                // terminal state is logged (issue #64) so an operator can tell
+                // why the pump stopped.
+                loop {
+                    match inbound.message().await {
+                        Ok(Some(msg)) => match msg.payload {
+                            Some(bv1::worker_stream_message::Payload::Hello(_)) => {
+                                tracing::debug!(worker_id = %worker_id, "duplicate hello ignored");
+                            }
+                            Some(bv1::worker_stream_message::Payload::Result(result)) => {
+                                if let Err(e) = scheduler.report(result).await {
+                                    tracing::error!(error = %e, "invalid job_id in worker result");
+                                }
+                            }
+                            None => {
+                                tracing::warn!("worker stream: message with no payload");
+                            }
+                        },
+                        Ok(None) => {
+                            tracing::info!(worker_id = %worker_id, "worker stream: closed cleanly");
+                            break;
+                        }
+                        Err(status) => {
+                            tracing::error!(
+                                worker_id = %worker_id,
+                                code = ?status.code(),
+                                message = status.message(),
+                                "worker stream: transport error — pump exiting; in-flight \
+                                 jobs for this worker time out via the scheduler timeout"
+                            );
+                            break;
+                        }
                     }
                 }
-            }
-        });
 
-        // Outbound pump: forward jobs from scheduler to worker.
-        tokio::spawn(async move {
-            while let Some(job) = job_rx.recv().await {
-                if out_tx
-                    .send(Ok(JobAssignment { job: Some(job) }))
-                    .await
-                    .is_err()
-                {
-                    break;
-                }
+                // Disconnect: deregister so the scheduler stops routing here,
+                // and stop the outbound pump (closing the worker's stream).
+                // Lease-based reassignment of in-flight jobs is task 4.
+                connected.lock().await.disconnect(&worker_id);
+                outbound.abort();
             }
-        });
+            .in_current_span(),
+        );
 
         Ok(Response::new(ReceiverStream::new(out_rx)))
     }

--- a/docs/architecture/0008-multi-worker-scheduling.md
+++ b/docs/architecture/0008-multi-worker-scheduling.md
@@ -1,0 +1,74 @@
+# 0008 — Multi-worker scheduling: per-worker queues + pluggable strategy
+
+- **Status:** accepted
+- **Date:** 2026-06-27
+- **Deciders:** Brokkr maintainers
+
+## Context
+
+Through Phase 4 task 2 the scheduler is still the Phase 1 shape: a single
+shared job queue (`mpsc`), and `WorkerService.Stream` claims *the* single
+receiver via `take_receiver()` — only one worker can ever be connected.
+Task 1 added a `WorkerRegistry` (liveness + capabilities) and task 2 added
+constraint matching (`matching::eligible_workers`) plus admission control,
+but jobs still flow through one queue to one worker.
+
+Phase 4 §16 task 3 requires real multi-worker scheduling with pluggable
+strategies (`SimpleFifo` → `BinPacking` → `LocalityAware`). That needs a way
+to (a) track which workers currently have a live stream, (b) route a job to a
+*specific* worker, and (c) choose *which* eligible worker gets each job.
+
+## Decision
+
+**Per-worker job queues with submit-time routing.**
+
+- A `ConnectedWorkers` registry maps `WorkerId → (job channel, in-flight
+  count)`. A worker is added on `Stream` connect and removed on disconnect.
+  This is distinct from `WorkerRegistry`: a worker is *registered* (known,
+  heartbeating) before and independently of being *connected* (streaming).
+- On `execute()`, the scheduler computes the eligible candidates
+  (`matching::eligible_workers` ∩ connected), asks a pluggable `Strategy` to
+  pick one, and routes the job by sending it to that worker's channel.
+- `Strategy::choose(candidates, loads)` is the policy seam. `SimpleFifo`
+  (the first/default strategy) picks the least-loaded candidate with a
+  deterministic id tie-break; `BinPacking` and `LocalityAware` are later
+  increments behind the same trait.
+- Per-worker in-flight counts are maintained by the dispatch path
+  (increment on send, decrement on result/timeout) and exposed to the
+  strategy via a `LoadView`.
+
+FIFO ordering is preserved *per worker* by each worker's own ordered channel;
+"SimpleFifo" here refers to the worker-selection policy (least-loaded), not a
+global job order.
+
+## Alternatives considered
+
+- **Central dispatcher + global pending queue.** A dispatcher task holds one
+  pending queue and assigns jobs to idle eligible workers on job-arrival or
+  worker-idle. Pros: global backpressure, natural home for leases and fair
+  scheduling (task 4). Cons: more moving parts now (idle tracking, requeue on
+  failure) than task 3 needs. **Deferred** — task 4's fair-scheduling/leases
+  work is the right time to introduce a global queue, evolving from this.
+- **Pull / work-stealing (workers pull jobs they're eligible for).** Rejected:
+  constraint matching is server-side and our worker transport is a
+  server-push bidi stream; a pull model would have to ship constraints to
+  workers or filter a shared queue per worker, fighting both.
+
+## Consequences
+
+- **Positive:** Incremental — fits the existing push/bidi worker stream;
+  lands the `Strategy` trait now; constraint matching (task 2) plugs straight
+  in as the candidate filter; each strategy is independently testable.
+- **Negative:** No *global* queue yet — a job routed to a busy worker waits in
+  that worker's channel rather than being rebalanced to a worker that frees up
+  first. Acceptable for task 3; task 4 (leases, fair scheduling) introduces
+  global queueing/rebalancing. Lease-based reassignment of a crashed worker's
+  in-flight jobs is also task 4.
+- **Neutral:** `ConnectedWorkers` and `WorkerRegistry` are separate concerns
+  (connection vs. liveness/capability); the scheduler consults both.
+
+## References
+
+- `docs/plan.md` §6.3 (scheduler), §16 (Phase 4 tasks 3–4)
+- ADR 0002 (REAPI compatibility) — push-based execution model
+- `crates/brokkr-control/src/matching.rs` (task 2 eligibility)

--- a/docs/journal/phase-4.md
+++ b/docs/journal/phase-4.md
@@ -339,3 +339,51 @@ soft/preferred constraints (needs a Brokkr convention — future ADR);
 richer worker capabilities; per-worker *routing* (multi-worker dispatch)
 and scheduling strategies are §16 task 3, the next milestone — that's the
 multi-worker redesign the I6 decision deferred.
+
+## I8 — multi-worker scheduling foundation (§16 task 3, ADR 0008)
+
+- **Date:** 2026-06-27
+- **Affected crate:** `brokkr-control` (+ ADR 0008)
+- **Decision taken with the owner:** dispatch model = **per-worker queues
+  with submit-time routing** (vs. a central dispatcher, or a
+  strategy-only first step). Recorded in
+  `docs/architecture/0008-multi-worker-scheduling.md`.
+- **Outcome:** `brokkr-control::scheduling` — the policy + connection
+  data model for multi-worker dispatch, with no dispatch plumbing yet so
+  it's fully unit-testable: a `Strategy` trait + `LoadView`, a
+  `SimpleFifo` strategy (least-loaded candidate, deterministic id
+  tie-break), and `ConnectedWorkers` (per-worker job channel + in-flight
+  count, distinct from `WorkerRegistry`). Eight unit tests;
+  `brokkr-control` green.
+
+### Decisions
+
+- **Per-worker queues, route at submit (ADR 0008).** On `execute` the
+  scheduler will compute eligible candidates (matcher ∩ connected), let
+  the `Strategy` pick one, and send the job to that worker's channel.
+  Chosen over a central pending-queue dispatcher (deferred to task 4,
+  where leases + fair scheduling want a global queue) and over a
+  pull/work-stealing model (rejected — fights server-side matching + the
+  push bidi stream).
+- **`ConnectedWorkers` ≠ `WorkerRegistry`.** Connection (stream open) and
+  liveness/capability (registered + heartbeating) are separate lifecycles;
+  the scheduler consults both. Keeping them in separate types avoids
+  conflating "known" with "reachable right now".
+- **`SimpleFifo` = least-loaded, not literally first.** "First available
+  worker" with no capacity cap would always pick `candidates[0]` and never
+  spread load. Least-loaded (stateless, deterministic tie-break) is the
+  simplest strategy that actually balances; documented in ADR 0008 that
+  per-worker FIFO ordering is preserved by each worker's own channel.
+- **Foundation split from wiring.** I8 lands the trait + registry +
+  strategy with unit tests; I9 does the riskier scheduler/worker-service
+  rewrite (replace the single `take_receiver` queue with per-worker
+  channels + routing). Both land on the task-3 PR.
+
+### Next increment (I9)
+
+Wire it in: `WorkerService.Stream` registers a per-worker channel in
+`ConnectedWorkers` on connect (and removes on disconnect) instead of the
+single `take_receiver`; `Scheduler::execute` routes via
+matcher → `Strategy::choose` → that worker's channel, tracking in-flight
+counts; results decrement in-flight. Plus an integration test with two
+connected workers proving jobs spread and constraints route correctly.

--- a/docs/journal/phase-4.md
+++ b/docs/journal/phase-4.md
@@ -387,3 +387,58 @@ single `take_receiver`; `Scheduler::execute` routes via
 matcher → `Strategy::choose` → that worker's channel, tracking in-flight
 counts; results decrement in-flight. Plus an integration test with two
 connected workers proving jobs spread and constraints route correctly.
+
+## I9 — multi-worker dispatch wiring (§16 task 3)
+
+- **Date:** 2026-06-27
+- **Affected crate:** `brokkr-control`
+- **Outcome:** The dispatch core is rewritten for per-worker routing. The
+  single shared queue (`Scheduler::take_receiver`) is gone;
+  `WorkerService.Stream` registers a per-worker channel in the shared
+  `ConnectedWorkers` keyed by the `Hello` worker id, and
+  `Scheduler::execute` routes each action to a `Strategy`-chosen eligible
+  connected worker, tracking in-flight load. 43 lib tests green; the
+  real-gRPC `end_to_end` test still passes (proving the new
+  Hello→connect→route→report path), plus a two-worker spread test.
+
+### Decisions
+
+- **Scheduler owns `ConnectedWorkers`; the worker service borrows it.**
+  `WorkerServiceImpl::new(scheduler)` reads `scheduler.connected_workers()`,
+  so the binary and the fixtures don't have to wire a third shared handle —
+  one accessor keeps the scheduler and stream pointed at the same map.
+- **Worker id comes from `Hello`, registration happens in the pump.** The
+  stream handler must return the outbound stream synchronously, but the
+  worker id is only known once the first inbound message arrives. So the
+  spawned pump reads `Hello`, *then* registers the per-worker channel and
+  spawns the outbound forwarder. A first message that isn't a valid
+  `Hello` closes the stream.
+- **In-flight inc/dec straddles the wait, owned by `execute`.** Increment
+  under the same `connected` lock as selection (so concurrent submits
+  can't both pick the one idle worker); decrement once after the result
+  *or* timeout resolves (an inner `async` block funnels every early
+  return through one decrement). The inbound pump does **not** touch
+  in-flight — keeps the accounting single-owner and race-free.
+- **Lock order: registry then connected, never both held.** `execute`
+  snapshots registry-eligible ids (releasing the registry lock) before
+  taking the `connected` lock, so the two mutexes are never held at once
+  — no lock-ordering deadlock against `register` (registry only) or the
+  stream (connected only).
+- **Fail-fast when no eligible connected worker.** No global pending
+  queue yet (ADR 0008 → task 4), so a submit with nothing to run on
+  returns `NoEligibleWorker` immediately. The in-process fixtures connect
+  their worker well within the existing readiness window, so the
+  real-gRPC e2e stays deterministic.
+- **Disconnect drops in-flight jobs to timeout.** When a worker's stream
+  ends, it's removed from `ConnectedWorkers`; its in-flight jobs' waiters
+  time out via the scheduler timeout. Lease-based reassignment to another
+  worker is task 4.
+
+### §16 task 3 status
+
+I8 (foundation) + I9 (wiring) deliver multi-worker dispatch with the
+`SimpleFifo` strategy on PR #100. **Next:** `BinPacking` and
+`LocalityAware` strategies (I10), then §16 task 4 (job leases,
+tenants/quotas, fair scheduling — where the global queue + lease-based
+reassignment land). A full two-process / two-worker gRPC integration test
+is also worth adding once a second strategy gives it more to assert.


### PR DESCRIPTION
## Motivation

Phase 4 §16 task 3: real multi-worker scheduling with pluggable strategies (`SimpleFifo` → `BinPacking` → `LocalityAware`). The scheduler is still the Phase 1 single-queue/single-worker shape (`take_receiver` claims the one stream). This milestone replaces that with multi-worker dispatch.

This is the largest architectural change in Phase 4, so it leads with an **ADR**. First commit lands the ADR + the unit-tested foundation; the scheduler/worker-service rewiring follows on this PR.

## Decision (ADR 0008)

**Per-worker job queues with submit-time routing** + a pluggable selection `Strategy`. Chosen (with the owner) over:
- a central dispatcher + global pending queue (deferred to task 4, where leases + fair scheduling want a global queue), and
- a pull/work-stealing model (rejected — fights server-side matching and the push bidi stream).

See `docs/architecture/0008-multi-worker-scheduling.md`.

## What changed (this commit — I8)

`brokkr-control::scheduling` — policy + connection data model, **no dispatch plumbing yet** (so it's fully unit-testable):
- `Strategy` trait + `LoadView`; `SimpleFifo` = least-loaded candidate, deterministic id tie-break (documented why "least-loaded" not literally "first").
- `ConnectedWorkers` — registry of workers with a live stream, each with its own job channel + in-flight count. Distinct from `WorkerRegistry` (connection vs. liveness/capability).

## How it was tested

8 unit tests (strategy: empty/least-loaded/tie-break/unknown-load; registry: connect-disconnect, in-flight inc/dec/saturate, reconnect-resets, `ConnectedWorkers` as `LoadView`). `brokkr-control` fmt + `clippy --all-targets -D warnings` + test green in WSL2.

## Next on this PR (I9)

Wire it in: `WorkerService.Stream` registers a per-worker channel on connect (replacing the single `take_receiver`); `Scheduler::execute` routes via matcher → `Strategy::choose` → that worker's channel, tracking in-flight counts; results decrement. Plus a two-worker integration test (spread + constraint routing).

## Related

`docs/plan.md` §16 task 3; ADR 0008; `docs/journal/phase-4.md` (I8). Builds on #98 (registry) + #99 (matching).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the foundation for multi-worker scheduling, enabling jobs to be routed to specific workers instead of a single shared queue.
  * Introduced configurable scheduling behavior with a default least-loaded, FIFO-style choice when multiple workers are available.
  * Improved tracking of worker load so scheduling can better balance work across connected workers.

* **Documentation**
  * Updated the changelog and architecture notes to reflect the new scheduling approach and next steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->