### PR TITLE
feat(control): BinPacking strategy + selectable scheduler strategy (Phase 4 §16 task 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -688,3 +688,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   none connected, reject on label mismatch, route-then-timeout, two-worker
   spread) plus the existing real-gRPC end-to-end. In-flight job
   reassignment when a worker disconnects is deferred to task 4 (leases).
+- `brokkr-control::scheduling::BinPacking` — a second selection strategy
+  (plan §16 task 3). Packs a worker toward a soft per-worker in-flight
+  `cap` (prefers the most-loaded candidate under cap) before spreading to
+  a fresh worker, so idle workers can scale down; falls back to
+  least-loaded when every candidate is saturated. Deterministic id
+  tie-break. `Scheduler::with_strategy` makes the selection strategy
+  injectable, so the binary can pick `SimpleFifo` / `BinPacking` at
+  startup. Six `BinPacking` unit tests + a scheduler test proving the
+  injected strategy is honoured (two concurrent jobs pack onto one worker
+  under `BinPacking(2)`). `LocalityAware` is deferred — it needs the
+  action's input-root passed into `Strategy::choose` (a trait-signature
+  change) plus per-worker locality state, so it gets its own increment.

--- a/crates/brokkr-control/src/lib.rs
+++ b/crates/brokkr-control/src/lib.rs
@@ -20,6 +20,6 @@ pub use registry::{
     HeartbeatPolicy, RegistryError, WorkerCapabilities, WorkerRecord, WorkerRegistry,
 };
 pub use scheduler::Scheduler;
-pub use scheduling::{ConnectedWorkers, LoadView, SimpleFifo, Strategy};
+pub use scheduling::{BinPacking, ConnectedWorkers, LoadView, SimpleFifo, Strategy};
 pub use services::{ActionCacheService, CapabilitiesService, CasService, ExecutionService};
 pub use worker_service::{spawn_eviction_task, SharedWorkerRegistry, WorkerServiceImpl};

--- a/crates/brokkr-control/src/scheduler.rs
+++ b/crates/brokkr-control/src/scheduler.rs
@@ -85,7 +85,13 @@ impl Scheduler {
     /// default execution timeout ([`DEFAULT_EXECUTION_TIMEOUT`]) and no
     /// admission control.
     pub fn new(cas: Arc<dyn Cas>, action_cache: Arc<dyn ActionCache>) -> Arc<Self> {
-        Self::build(cas, action_cache, DEFAULT_EXECUTION_TIMEOUT, None)
+        Self::build(
+            cas,
+            action_cache,
+            DEFAULT_EXECUTION_TIMEOUT,
+            None,
+            Arc::new(SimpleFifo),
+        )
     }
 
     /// Construct a scheduler with a custom default per-action timeout. The
@@ -96,7 +102,13 @@ impl Scheduler {
         action_cache: Arc<dyn ActionCache>,
         default_execution_timeout: Duration,
     ) -> Arc<Self> {
-        Self::build(cas, action_cache, default_execution_timeout, None)
+        Self::build(
+            cas,
+            action_cache,
+            default_execution_timeout,
+            None,
+            Arc::new(SimpleFifo),
+        )
     }
 
     /// Construct a scheduler that performs platform-constraint admission
@@ -111,6 +123,7 @@ impl Scheduler {
             action_cache,
             DEFAULT_EXECUTION_TIMEOUT,
             Some(worker_registry),
+            Arc::new(SimpleFifo),
         )
     }
 
@@ -126,6 +139,25 @@ impl Scheduler {
             action_cache,
             default_execution_timeout,
             Some(worker_registry),
+            Arc::new(SimpleFifo),
+        )
+    }
+
+    /// Construct a scheduler with a custom worker-selection [`Strategy`] (and a
+    /// registry for constraint filtering), using the default timeout. Lets the
+    /// binary pick `SimpleFifo` / `BinPacking` / … at startup.
+    pub fn with_strategy(
+        cas: Arc<dyn Cas>,
+        action_cache: Arc<dyn ActionCache>,
+        worker_registry: SharedWorkerRegistry,
+        strategy: Arc<dyn Strategy>,
+    ) -> Arc<Self> {
+        Self::build(
+            cas,
+            action_cache,
+            DEFAULT_EXECUTION_TIMEOUT,
+            Some(worker_registry),
+            strategy,
         )
     }
 
@@ -134,10 +166,11 @@ impl Scheduler {
         action_cache: Arc<dyn ActionCache>,
         default_execution_timeout: Duration,
         worker_registry: Option<SharedWorkerRegistry>,
+        strategy: Arc<dyn Strategy>,
     ) -> Arc<Self> {
         Arc::new(Self {
             connected: Arc::new(Mutex::new(ConnectedWorkers::new())),
-            strategy: Arc::new(SimpleFifo),
+            strategy,
             waiters: Mutex::new(HashMap::new()),
             cas,
             action_cache,
@@ -753,5 +786,53 @@ mod tests {
             rx_b.try_recv().is_ok(),
             "worker b should have received exactly one job"
         );
+    }
+
+    /// The scheduler honours its injected strategy: `BinPacking` (cap 2) packs
+    /// both concurrent jobs onto the lower-id worker instead of spreading.
+    #[tokio::test]
+    async fn execute_uses_injected_binpacking_strategy() {
+        use crate::registry::WorkerRegistry;
+        use crate::scheduling::BinPacking;
+
+        let cas = Arc::new(brokkr_cas::InMemoryCas::new());
+        let action_digest = stage_action(cas.as_ref(), Some(os_platform("linux"))).await;
+        let ac = Arc::new(MockActionCache { force_error: false });
+        let registry = Arc::new(Mutex::new(WorkerRegistry::default()));
+        let scheduler =
+            Scheduler::with_strategy(cas, ac, registry.clone(), Arc::new(BinPacking::new(2)));
+        // Short timeout via the action would be cleaner, but with_strategy uses
+        // the default; the jobs just need to be dispatched, which happens
+        // before any wait — so we read the channels right after dispatch.
+        let mut rx_a = register_and_connect(&scheduler, &registry, "w-a", &[("os", "linux")]).await;
+        let mut rx_b = register_and_connect(&scheduler, &registry, "w-b", &[("os", "linux")]).await;
+
+        // Two concurrent executes. BinPacking(cap 2) packs w-a (lower id) to
+        // the cap before touching w-b, so both jobs land on w-a.
+        let (s1, s2) = (scheduler.clone(), scheduler.clone());
+        let (d1, d2) = (action_digest.clone(), action_digest);
+        let h1 = tokio::spawn(async move { s1.execute(d1, true).await });
+        let h2 = tokio::spawn(async move { s2.execute(d2, true).await });
+
+        // Both jobs are dispatched to w-a's channel; assert before the (long)
+        // default timeout elapses by polling the receivers with a short budget.
+        let mut a_count = 0;
+        for _ in 0..50 {
+            while rx_a.try_recv().is_ok() {
+                a_count += 1;
+            }
+            if a_count == 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(a_count, 2, "BinPacking should pack both jobs onto w-a");
+        assert!(
+            rx_b.try_recv().is_err(),
+            "w-b should have received no jobs under BinPacking"
+        );
+
+        h1.abort();
+        h2.abort();
     }
 }

--- a/crates/brokkr-control/src/scheduling.rs
+++ b/crates/brokkr-control/src/scheduling.rs
@@ -55,6 +55,59 @@ impl Strategy for SimpleFifo {
     }
 }
 
+/// Bin-packing: fill a worker toward `cap` in-flight jobs before spreading to a
+/// fresh one, so idle workers can scale down. Among candidates still under
+/// `cap`, picks the *most*-loaded (packs tight); if every candidate is at or
+/// over `cap`, falls back to the least-loaded so work still flows rather than
+/// stalling. Ties broken by worker id for determinism.
+#[derive(Debug, Clone, Copy)]
+pub struct BinPacking {
+    /// Soft per-worker in-flight target. A worker under this is preferred for
+    /// packing; the cap is not a hard admission limit (the fallback still
+    /// places work when everyone is saturated).
+    cap: usize,
+}
+
+impl BinPacking {
+    /// Create a bin-packing strategy with the given soft per-worker in-flight
+    /// `cap`. A `cap` of 0 is clamped to 1 (a 0 cap would send every candidate
+    /// straight to the least-loaded fallback, i.e. degenerate to spreading).
+    pub fn new(cap: usize) -> Self {
+        Self { cap: cap.max(1) }
+    }
+}
+
+impl Strategy for BinPacking {
+    fn choose(&self, candidates: &[WorkerId], loads: &dyn LoadView) -> Option<WorkerId> {
+        // Prefer the most-loaded worker still under cap (pack it tighter);
+        // `min_by` with a comparator that ranks higher load — then lower id —
+        // as "smaller" yields that worker deterministically.
+        let packed = candidates
+            .iter()
+            .filter(|w| loads.inflight(w) < self.cap)
+            .min_by(|a, b| {
+                loads
+                    .inflight(b)
+                    .cmp(&loads.inflight(a))
+                    .then_with(|| a.as_str().cmp(b.as_str()))
+            });
+        if let Some(w) = packed {
+            return Some(w.clone());
+        }
+        // Everyone is at/over cap — fall back to least-loaded so work still
+        // flows (same rule as `SimpleFifo`).
+        candidates
+            .iter()
+            .min_by(|a, b| {
+                loads
+                    .inflight(a)
+                    .cmp(&loads.inflight(b))
+                    .then_with(|| a.as_str().cmp(b.as_str()))
+            })
+            .cloned()
+    }
+}
+
 /// A connected worker's job-dispatch channel plus its live in-flight count.
 struct WorkerConn {
     job_tx: mpsc::Sender<bv1::Job>,
@@ -198,6 +251,55 @@ mod tests {
         // "fresh" has no entry → inflight 0 → chosen over busy=4.
         let l = loads(&[("busy", 4)]);
         assert_eq!(SimpleFifo.choose(&cands, &l), Some(wid("fresh")));
+    }
+
+    #[test]
+    fn bin_packing_empty_candidates_is_none() {
+        assert!(BinPacking::new(4).choose(&[], &loads(&[])).is_none());
+    }
+
+    #[test]
+    fn bin_packing_prefers_most_loaded_under_cap() {
+        let cands = vec![wid("a"), wid("b"), wid("c")];
+        // cap 4: a=3 (highest under cap) wins over b=1, c=0 — pack it tight.
+        let l = loads(&[("a", 3), ("b", 1), ("c", 0)]);
+        assert_eq!(BinPacking::new(4).choose(&cands, &l), Some(wid("a")));
+    }
+
+    #[test]
+    fn bin_packing_skips_workers_at_cap() {
+        let cands = vec![wid("a"), wid("b")];
+        // cap 2: a is at cap (2) so excluded; b (1, under cap) is chosen even
+        // though a is more loaded.
+        let l = loads(&[("a", 2), ("b", 1)]);
+        assert_eq!(BinPacking::new(2).choose(&cands, &l), Some(wid("b")));
+    }
+
+    #[test]
+    fn bin_packing_falls_back_to_least_loaded_when_all_at_cap() {
+        let cands = vec![wid("a"), wid("b"), wid("c")];
+        // cap 2: all at/over cap → least-loaded fallback picks c=2 (a=4, b=3).
+        let l = loads(&[("a", 4), ("b", 3), ("c", 2)]);
+        assert_eq!(BinPacking::new(2).choose(&cands, &l), Some(wid("c")));
+    }
+
+    #[test]
+    fn bin_packing_ties_break_by_id() {
+        let cands = vec![wid("zebra"), wid("alpha")];
+        // Equal load under cap → lower id wins.
+        let l = loads(&[("zebra", 1), ("alpha", 1)]);
+        assert_eq!(BinPacking::new(4).choose(&cands, &l), Some(wid("alpha")));
+    }
+
+    #[test]
+    fn bin_packing_zero_cap_is_clamped_and_spreads() {
+        // cap clamped to 1: with two idle workers nobody is under cap=1? 0<1 is
+        // true, so both are under cap → most-loaded (both 0) → lower id.
+        let cands = vec![wid("a"), wid("b")];
+        assert_eq!(
+            BinPacking::new(0).choose(&cands, &loads(&[])),
+            Some(wid("a"))
+        );
     }
 
     fn dummy_channel() -> mpsc::Sender<bv1::Job> {

--- a/docs/journal/phase-4.md
+++ b/docs/journal/phase-4.md
@@ -442,3 +442,44 @@ I8 (foundation) + I9 (wiring) deliver multi-worker dispatch with the
 tenants/quotas, fair scheduling — where the global queue + lease-based
 reassignment land). A full two-process / two-worker gRPC integration test
 is also worth adding once a second strategy gives it more to assert.
+
+## I10 — BinPacking strategy + selectable strategy (§16 task 3)
+
+- **Date:** 2026-06-27
+- **Affected crate:** `brokkr-control`
+- **Outcome:** A second selection strategy, `BinPacking`, behind the
+  existing `Strategy` trait, plus `Scheduler::with_strategy` so the
+  binary can choose. `BinPacking(cap)` packs the most-loaded worker still
+  under `cap` (then falls back to least-loaded when all are saturated),
+  versus `SimpleFifo`'s always-spread. Six unit tests + a scheduler test
+  proving the injected strategy is honoured. 50 lib tests green.
+
+### Decisions
+
+- **BinPacking fits the existing `choose(candidates, loads)` signature.**
+  It only needs per-worker load (from `LoadView`) + a `cap`, so no trait
+  change. The cap is a *soft* target: when everyone is at/over cap it
+  still places work (least-loaded fallback) rather than refusing — a hard
+  admission limit is a task-4 concern (backpressure/queueing).
+- **`cap` clamped to ≥1.** A 0 cap would send every candidate to the
+  fallback (degenerate spread); clamping keeps the knob meaningful.
+- **Selectable via a constructor, not a config flag yet.**
+  `Scheduler::with_strategy` takes `Arc<dyn Strategy>`; the existing
+  constructors keep defaulting to `SimpleFifo` (no call-site churn). A CLI
+  flag to pick the strategy at runtime is a small follow-up once there's a
+  reason to flip it in the binary.
+- **`LocalityAware` deferred — needs a trait change.** "Prefer a worker
+  that recently ran overlapping inputs" requires `choose` to see the
+  action's input-root digest (the current signature only passes load) and
+  per-worker recent-input state. Rather than speculatively widen the trait
+  now, it gets its own increment that designs the locality-hint plumbing
+  (and possibly a small ADR). Flagged here so it isn't silently dropped.
+
+### §16 task 3 status
+
+Multi-worker dispatch with two strategies (`SimpleFifo`, `BinPacking`)
+shipped (I8–I10). Remaining under "scheduling strategies": `LocalityAware`
+(own increment). **Next milestone:** §16 task 4 — job leases (incl.
+reassigning a disconnected worker's in-flight jobs, deferred from I9),
+tenants/quotas, fair scheduling; this is where ADR 0008's deferred global
+pending queue lands, likely with its own ADR.


### PR DESCRIPTION
## Motivation

Phase 4 §16 task 3 lists `SimpleFifo` → `BinPacking` → `LocalityAware`. #100 shipped multi-worker dispatch with `SimpleFifo`; this adds the second strategy and makes the scheduler's strategy injectable.

## What changed

- `brokkr-control::scheduling::BinPacking` — packs the most-loaded worker still under a soft per-worker in-flight `cap` before spreading to a fresh worker (so idle workers can scale down); falls back to least-loaded when every candidate is saturated. Deterministic id tie-break; `cap` clamps to ≥1.
- `Scheduler::with_strategy(cas, ac, registry, strategy)` — makes the selection strategy injectable. Existing constructors keep defaulting to `SimpleFifo`, so no call-site churn.
- Exported `BinPacking`.

## How it was tested

6 `BinPacking` unit tests (empty, most-loaded-under-cap, skip-at-cap, least-loaded fallback, id tie-break, zero-cap clamp) + a scheduler test proving the injected strategy is used: two concurrent jobs both pack onto the lower-id worker under `BinPacking(2)`, where `SimpleFifo` would spread. `brokkr-control` fmt + `clippy --all-targets -D warnings` + test green in WSL2 (50 lib tests).

## Deferred

`LocalityAware` — "prefer a worker that recently ran overlapping inputs" needs the action's input-root digest passed into `Strategy::choose` (a trait-signature change) plus per-worker locality state, so it gets its own increment (possibly a small ADR) rather than a speculative API change here.

## Related

`docs/plan.md` §16 task 3; ADR 0008; `docs/journal/phase-4.md` (I10). Builds on #100.