### PR TITLE
fix(control): reject non-empty instance_name on REAPI handlers (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `brokkr-control` REAPI services (`ContentAddressableStorage`,
+  `ActionCache`, `Execution`, `Capabilities`) now reject any request
+  carrying a non-empty `instance_name` with `INVALID_ARGUMENT` instead
+  of silently serving it from the single default instance. Phase 1 has
+  no multi-tenant isolation, so accepting a caller-named instance was a
+  latent cross-instance access gap (issue #72). The SDK always sends an
+  empty `instance_name`, so this is transparent to existing clients.
 - `brokkr-sandbox::runner::seccomp` compiled with a stray `return`
   inside a single-arm `cfg` block which a newer clippy flagged as
   `needless_return`; replaced with bare expressions so all four

--- a/crates/brokkr-control/src/services/action_cache.rs
+++ b/crates/brokkr-control/src/services/action_cache.rs
@@ -6,7 +6,7 @@ use brokkr_cas::ActionCache;
 use brokkr_proto::reapi_v2::{self as rapi, action_cache_server::ActionCache as AcSvc};
 use tonic::{Request, Response, Status};
 
-use super::proto_to_digest;
+use super::{proto_to_digest, validate_instance_name};
 
 /// REAPI [`ActionCache`] service backed by a [`brokkr_cas::ActionCache`].
 pub struct ActionCacheService<A: ActionCache> {
@@ -28,6 +28,7 @@ impl<A: ActionCache> AcSvc for ActionCacheService<A> {
     ) -> Result<Response<rapi::ActionResult>, Status> {
         let span = tracing::info_span!("action_cache::get_action_result");
         let req = request.into_inner();
+        validate_instance_name(&req.instance_name)?;
         let digest = proto_to_digest(
             req.action_digest
                 .as_ref()
@@ -54,6 +55,7 @@ impl<A: ActionCache> AcSvc for ActionCacheService<A> {
     ) -> Result<Response<rapi::ActionResult>, Status> {
         let span = tracing::info_span!("action_cache::update_action_result");
         let req = request.into_inner();
+        validate_instance_name(&req.instance_name)?;
         let digest = proto_to_digest(
             req.action_digest
                 .as_ref()

--- a/crates/brokkr-control/src/services/capabilities.rs
+++ b/crates/brokkr-control/src/services/capabilities.rs
@@ -3,6 +3,8 @@
 use brokkr_proto::reapi_v2::{self as rapi, capabilities_server::Capabilities as CapSvc};
 use tonic::{Request, Response, Status};
 
+use super::validate_instance_name;
+
 /// REAPI `Capabilities` service. Returns a static, Phase-1-appropriate set.
 #[derive(Default)]
 pub struct CapabilitiesService;
@@ -11,9 +13,10 @@ pub struct CapabilitiesService;
 impl CapSvc for CapabilitiesService {
     async fn get_capabilities(
         &self,
-        _request: Request<rapi::GetCapabilitiesRequest>,
+        request: Request<rapi::GetCapabilitiesRequest>,
     ) -> Result<Response<rapi::ServerCapabilities>, Status> {
         let span = tracing::info_span!("capabilities::get_capabilities");
+        validate_instance_name(&request.into_inner().instance_name)?;
         let _enter = span.enter();
         let caps = rapi::ServerCapabilities {
             cache_capabilities: Some(rapi::CacheCapabilities {

--- a/crates/brokkr-control/src/services/cas.rs
+++ b/crates/brokkr-control/src/services/cas.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 
-use super::{digest_to_proto, proto_to_digest};
+use super::{digest_to_proto, proto_to_digest, validate_instance_name};
 
 /// REAPI `ContentAddressableStorage` service backed by a [`Cas`].
 pub struct CasService<C: Cas> {
@@ -32,6 +32,7 @@ impl<C: Cas> CasSvc for CasService<C> {
     ) -> Result<Response<rapi::FindMissingBlobsResponse>, Status> {
         let span = tracing::info_span!("cas::find_missing_blobs");
         let req = request.into_inner();
+        validate_instance_name(&req.instance_name)?;
         let digests: Vec<super::Digest> = req
             .blob_digests
             .iter()
@@ -55,6 +56,7 @@ impl<C: Cas> CasSvc for CasService<C> {
     ) -> Result<Response<rapi::BatchUpdateBlobsResponse>, Status> {
         let span = tracing::info_span!("cas::batch_update_blobs");
         let req = request.into_inner();
+        validate_instance_name(&req.instance_name)?;
         let request_count = req.requests.len();
 
         // Verify each entry's declared digest against its bytes *before*
@@ -133,6 +135,7 @@ impl<C: Cas> CasSvc for CasService<C> {
     ) -> Result<Response<rapi::BatchReadBlobsResponse>, Status> {
         let span = tracing::info_span!("cas::batch_read_blobs");
         let req = request.into_inner();
+        validate_instance_name(&req.instance_name)?;
         let digest_count = req.digests.len();
         let digests: Vec<super::Digest> = req
             .digests
@@ -200,5 +203,71 @@ impl<C: Cas> CasSvc for CasService<C> {
         Err(Status::unimplemented(
             "SpliceBlob not implemented in Phase 1",
         ))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods, clippy::panic)]
+mod tests {
+    use std::sync::Arc;
+
+    use brokkr_cas::InMemoryCas;
+    use brokkr_proto::reapi_v2 as rapi;
+    use rapi::content_addressable_storage_server::ContentAddressableStorage as _;
+    use tonic::{Code, Request};
+
+    use super::CasService;
+
+    fn service() -> CasService<InMemoryCas> {
+        CasService::new(Arc::new(InMemoryCas::new()))
+    }
+
+    #[tokio::test]
+    async fn find_missing_blobs_rejects_named_instance() {
+        let req = rapi::FindMissingBlobsRequest {
+            instance_name: "tenant-a".to_string(),
+            ..Default::default()
+        };
+        let err = service()
+            .find_missing_blobs(Request::new(req))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn find_missing_blobs_accepts_default_instance() {
+        // Empty instance_name is the single Phase-1 instance — must succeed.
+        let resp = service()
+            .find_missing_blobs(Request::new(rapi::FindMissingBlobsRequest::default()))
+            .await
+            .unwrap();
+        assert!(resp.into_inner().missing_blob_digests.is_empty());
+    }
+
+    #[tokio::test]
+    async fn batch_read_blobs_rejects_named_instance() {
+        let req = rapi::BatchReadBlobsRequest {
+            instance_name: "tenant-a".to_string(),
+            ..Default::default()
+        };
+        let err = service()
+            .batch_read_blobs(Request::new(req))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn batch_update_blobs_rejects_named_instance() {
+        let req = rapi::BatchUpdateBlobsRequest {
+            instance_name: "tenant-a".to_string(),
+            ..Default::default()
+        };
+        let err = service()
+            .batch_update_blobs(Request::new(req))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), Code::InvalidArgument);
     }
 }

--- a/crates/brokkr-control/src/services/execution.rs
+++ b/crates/brokkr-control/src/services/execution.rs
@@ -9,7 +9,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tonic::{Request, Response, Status};
 use tracing::Instrument;
 
-use super::proto_to_digest;
+use super::{proto_to_digest, validate_instance_name};
 use crate::scheduler::{ExecutionError, Scheduler};
 
 fn execute_response_to_any(resp: rapi::ExecuteResponse) -> prost_types::Any {
@@ -44,6 +44,7 @@ impl ExecSvc for ExecutionService {
         request: Request<rapi::ExecuteRequest>,
     ) -> Result<Response<Self::ExecuteStream>, Status> {
         let req = request.into_inner();
+        validate_instance_name(&req.instance_name)?;
         let action_digest_proto = req
             .action_digest
             .ok_or_else(|| Status::invalid_argument("missing action_digest"))?;

--- a/crates/brokkr-control/src/services/mod.rs
+++ b/crates/brokkr-control/src/services/mod.rs
@@ -33,3 +33,41 @@ pub(crate) fn digest_to_proto(d: &Digest) -> rapi::Digest {
         size_bytes: d.size_bytes(),
     }
 }
+
+/// Reject any request that targets a *named* REAPI instance.
+///
+/// Phase 1 serves a single, unnamed instance backed by one global CAS and
+/// action cache. The SDK always sends an empty `instance_name`. Accepting a
+/// non-empty value would silently serve a caller-named instance out of that
+/// one shared store — a latent cross-instance access gap (issue #72). Until
+/// multi-tenant routing exists, anything non-empty is rejected as
+/// `INVALID_ARGUMENT` rather than served from the default instance.
+pub(crate) fn validate_instance_name(instance_name: &str) -> Result<(), Status> {
+    if instance_name.is_empty() {
+        Ok(())
+    } else {
+        Err(Status::invalid_argument(format!(
+            "unknown instance_name {instance_name:?}: this server has no multi-tenant \
+             support yet — only the default (empty) instance is served"
+        )))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_instance_name_is_accepted() {
+        assert!(validate_instance_name("").is_ok());
+    }
+
+    #[test]
+    fn named_instance_is_rejected_as_invalid_argument() {
+        let err = validate_instance_name("tenant-a").unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        // The offending value is echoed back to help a confused client.
+        assert!(err.message().contains("tenant-a"));
+    }
+}


### PR DESCRIPTION
## Motivation

Phase 1 serves a single, unnamed REAPI instance backed by one global CAS and action cache. The service handlers accepted any `instance_name` and served it from that shared store with no validation. With no multi-tenant isolation, a caller-supplied `instance_name` was silently served from the one global store — a latent cross-instance access gap (issue #72, H8).

## What changed

- Added a shared `validate_instance_name(&str) -> Result<(), Status>` guard in `services/mod.rs`. Empty (the default Phase-1 instance) is accepted; any non-empty value is rejected with `INVALID_ARGUMENT` and a message naming the offending value.
- Wired the guard into every implemented REAPI handler that carries `instance_name`:
  - **CAS** — `FindMissingBlobs`, `BatchUpdateBlobs`, `BatchReadBlobs`
  - **ActionCache** — `GetActionResult`, `UpdateActionResult`
  - **Execution** — `Execute` (rejects before spawning the scheduler task)
  - **Capabilities** — `GetCapabilities`
- The SDK always sends an empty `instance_name`, so existing clients are unaffected.

This is the minimal Phase-1-appropriate guard (reject named instances) rather than introducing multi-tenant routing, which is out of scope for Phase 1.

## How it was tested

WSL2 (Linux), worktree off `origin/main`:
- `cargo fmt --all` — clean
- `cargo clippy -p brokkr-control --all-targets -- -D warnings` — clean
- `cargo test -p brokkr-control` — 40 lib tests + integration suites pass

New tests:
- `services::tests` — unit tests for the guard (empty → Ok; named → `InvalidArgument`, message echoes the value).
- `services::cas::tests` — handler-wiring tests using `InMemoryCas`: `find_missing_blobs` / `batch_read_blobs` / `batch_update_blobs` reject a named instance with `InvalidArgument`, and `find_missing_blobs` accepts the default instance.

Existing `grpc_smoke` integration tests (which exercise the default empty instance) still pass, confirming the happy path is unbroken.

## Related

- Closes #72
- Phase 1 (single-instance) per `docs/plan.md`. Multi-tenant routing is explicitly deferred; the guard is the interim safeguard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests with a non-empty REAPI instance name are now rejected with `INVALID_ARGUMENT` instead of being handled as the default instance.
  * Applied this validation consistently across capabilities, action cache, content-addressable storage, and execution requests.
  * Added coverage to confirm empty instance names continue to work and named instances return a clear error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->