### PR TITLE
feat(control): leases + global-queue ADR 0009 + LeaseTable (Phase 4 §16 task 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -700,3 +700,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   under `BinPacking(2)`). `LocalityAware` is deferred — it needs the
   action's input-root passed into `Strategy::choose` (a trait-signature
   change) plus per-worker locality state, so it gets its own increment.
+- ADR 0009 — job leases, a global pending queue, and crash reassignment
+  (the §16 DoD "worker crash mid-job → job retried on another worker").
+  `docs/architecture/0009-leases-and-fair-scheduling.md`.
+- `brokkr-control::lease::LeaseTable<P>` (plan §16 task 4 foundation):
+  tracks active job leases (`JobId → {worker, deadline, payload}`),
+  generic over the re-dispatch payload and clock-injected. `complete`
+  resolves a lease on report (returns the payload, or `None` for a late
+  report to discard); `take_expired(now)` and `take_worker(id)` remove
+  and return the `(job_id, payload)` pairs to requeue on lease expiry /
+  worker disconnect. Pure bookkeeping; the dispatcher wiring that drives
+  it is the next increment. Seven unit tests.

--- a/crates/brokkr-control/src/lease.rs
+++ b/crates/brokkr-control/src/lease.rs
@@ -1,0 +1,238 @@
+//! Job lease bookkeeping (ADR 0009).
+//!
+//! A lease records that a job has been dispatched to a worker and is expected
+//! to report before a deadline. The scheduler's dispatcher creates a lease on
+//! dispatch and resolves it on report; lease expiry or worker disconnect moves
+//! the job's payload back to the pending queue for reassignment (the §16 DoD
+//! crash-recovery path).
+//!
+//! This module is the pure bookkeeping core — the dispatcher wiring that drives
+//! it is a separate increment. It's generic over the re-dispatch `payload` and
+//! takes an explicit `now: Instant`, so it's deterministic under test.
+
+use std::collections::HashMap;
+use std::time::Instant;
+
+use brokkr_common::{JobId, WorkerId};
+
+/// An active lease: which worker holds the job, when it's due, and the payload
+/// needed to re-dispatch the job if the lease fails.
+#[derive(Debug, Clone)]
+struct Lease<P> {
+    worker_id: WorkerId,
+    deadline: Instant,
+    payload: P,
+}
+
+/// Tracks active job leases keyed by [`JobId`]. Generic over the re-dispatch
+/// `payload` so it can be unit-tested without the scheduler's job types.
+///
+/// Not internally synchronized — the scheduler holds it under its own lock.
+#[derive(Debug)]
+pub struct LeaseTable<P> {
+    leases: HashMap<JobId, Lease<P>>,
+}
+
+impl<P> Default for LeaseTable<P> {
+    fn default() -> Self {
+        Self {
+            leases: HashMap::new(),
+        }
+    }
+}
+
+impl<P> LeaseTable<P> {
+    /// An empty lease table.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a lease: `job_id` dispatched to `worker_id`, due by `deadline`,
+    /// carrying `payload` for re-dispatch. Replaces any existing lease for the
+    /// same job (a reassignment supersedes the old one).
+    pub fn insert(&mut self, job_id: JobId, worker_id: WorkerId, deadline: Instant, payload: P) {
+        self.leases.insert(
+            job_id,
+            Lease {
+                worker_id,
+                deadline,
+                payload,
+            },
+        );
+    }
+
+    /// Resolve a lease because the worker reported: drop it and return its
+    /// payload, or `None` if there was no such lease (a late report after
+    /// expiry/reassignment — the caller should discard the result).
+    pub fn complete(&mut self, job_id: &JobId) -> Option<P> {
+        self.leases.remove(job_id).map(|l| l.payload)
+    }
+
+    /// The worker currently holding `job_id`, if leased.
+    pub fn worker_of(&self, job_id: &JobId) -> Option<&WorkerId> {
+        self.leases.get(job_id).map(|l| &l.worker_id)
+    }
+
+    /// Whether `job_id` is currently leased.
+    pub fn contains(&self, job_id: &JobId) -> bool {
+        self.leases.contains_key(job_id)
+    }
+
+    /// Number of active leases.
+    pub fn len(&self) -> usize {
+        self.leases.len()
+    }
+
+    /// Whether there are no active leases.
+    pub fn is_empty(&self) -> bool {
+        self.leases.is_empty()
+    }
+
+    /// Remove and return every lease whose deadline has passed as of `now`
+    /// (`now >= deadline`), as `(job_id, payload)` pairs for requeue. Sorted by
+    /// job id for deterministic handling/logging.
+    pub fn take_expired(&mut self, now: Instant) -> Vec<(JobId, P)> {
+        let expired: Vec<JobId> = self
+            .leases
+            .iter()
+            .filter(|(_, l)| now >= l.deadline)
+            .map(|(id, _)| id.clone())
+            .collect();
+        Self::drain(&mut self.leases, expired)
+    }
+
+    /// Remove and return every lease held by `worker_id` (e.g. on disconnect),
+    /// as `(job_id, payload)` pairs for requeue. Sorted by job id.
+    pub fn take_worker(&mut self, worker_id: &WorkerId) -> Vec<(JobId, P)> {
+        let held: Vec<JobId> = self
+            .leases
+            .iter()
+            .filter(|(_, l)| &l.worker_id == worker_id)
+            .map(|(id, _)| id.clone())
+            .collect();
+        Self::drain(&mut self.leases, held)
+    }
+
+    fn drain(leases: &mut HashMap<JobId, Lease<P>>, mut ids: Vec<JobId>) -> Vec<(JobId, P)> {
+        ids.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        ids.into_iter()
+            .filter_map(|id| leases.remove(&id).map(|l| (id, l.payload)))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods, clippy::panic)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    fn jid(s: &str) -> JobId {
+        JobId::new(s.to_string()).unwrap()
+    }
+    fn wid(s: &str) -> WorkerId {
+        WorkerId::new(s.to_string()).unwrap()
+    }
+
+    #[test]
+    fn insert_then_complete_returns_payload() {
+        let t0 = Instant::now();
+        let mut t = LeaseTable::new();
+        t.insert(
+            jid("j1"),
+            wid("w1"),
+            t0 + Duration::from_secs(10),
+            "payload-1",
+        );
+        assert_eq!(t.len(), 1);
+        assert!(t.contains(&jid("j1")));
+        assert_eq!(t.worker_of(&jid("j1")), Some(&wid("w1")));
+
+        assert_eq!(t.complete(&jid("j1")), Some("payload-1"));
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn complete_absent_is_none() {
+        let mut t: LeaseTable<&str> = LeaseTable::new();
+        // A late report for a job that was already reassigned/expired.
+        assert_eq!(t.complete(&jid("ghost")), None);
+    }
+
+    #[test]
+    fn insert_replaces_existing_lease() {
+        let t0 = Instant::now();
+        let mut t = LeaseTable::new();
+        t.insert(jid("j1"), wid("w1"), t0 + Duration::from_secs(5), "first");
+        t.insert(jid("j1"), wid("w2"), t0 + Duration::from_secs(5), "second");
+        assert_eq!(t.len(), 1);
+        assert_eq!(t.worker_of(&jid("j1")), Some(&wid("w2")));
+        assert_eq!(t.complete(&jid("j1")), Some("second"));
+    }
+
+    #[test]
+    fn take_expired_returns_only_past_deadline_sorted() {
+        let t0 = Instant::now();
+        let mut t = LeaseTable::new();
+        t.insert(
+            jid("j-late"),
+            wid("w1"),
+            t0 + Duration::from_secs(1),
+            "late",
+        );
+        t.insert(
+            jid("j-early"),
+            wid("w1"),
+            t0 + Duration::from_secs(1),
+            "early",
+        );
+        t.insert(
+            jid("j-future"),
+            wid("w2"),
+            t0 + Duration::from_secs(60),
+            "future",
+        );
+
+        // At t0+2s the two 1s-deadline leases are expired; the 60s one is not.
+        let expired = t.take_expired(t0 + Duration::from_secs(2));
+        let ids: Vec<&str> = expired.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(ids, vec!["j-early", "j-late"]); // sorted by id
+        assert_eq!(t.len(), 1);
+        assert!(t.contains(&jid("j-future")));
+    }
+
+    #[test]
+    fn take_expired_is_inclusive_at_deadline() {
+        let t0 = Instant::now();
+        let mut t = LeaseTable::new();
+        let deadline = t0 + Duration::from_secs(5);
+        t.insert(jid("j1"), wid("w1"), deadline, "p");
+        // Exactly at the deadline counts as expired (now >= deadline).
+        let expired = t.take_expired(deadline);
+        assert_eq!(expired.len(), 1);
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn take_worker_returns_only_that_workers_leases() {
+        let t0 = Instant::now();
+        let d = t0 + Duration::from_secs(30);
+        let mut t = LeaseTable::new();
+        t.insert(jid("j1"), wid("w-dead"), d, "a");
+        t.insert(jid("j2"), wid("w-dead"), d, "b");
+        t.insert(jid("j3"), wid("w-live"), d, "c");
+
+        let reassigned = t.take_worker(&wid("w-dead"));
+        let ids: Vec<&str> = reassigned.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(ids, vec!["j1", "j2"]); // sorted
+        assert_eq!(t.len(), 1);
+        assert_eq!(t.worker_of(&jid("j3")), Some(&wid("w-live")));
+    }
+
+    #[test]
+    fn take_worker_unknown_is_empty() {
+        let mut t: LeaseTable<&str> = LeaseTable::new();
+        assert!(t.take_worker(&wid("nobody")).is_empty());
+    }
+}

--- a/crates/brokkr-control/src/lib.rs
+++ b/crates/brokkr-control/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![deny(missing_docs)]
 
+pub mod lease;
 pub mod matching;
 pub mod membership;
 pub mod registry;
@@ -14,6 +15,7 @@ pub mod scheduling;
 pub mod services;
 pub mod worker_service;
 
+pub use lease::LeaseTable;
 pub use matching::{eligible_workers, labels_satisfy_platform, worker_satisfies};
 pub use membership::{Membership, MembershipServiceImpl};
 pub use registry::{

--- a/docs/architecture/0009-leases-and-fair-scheduling.md
+++ b/docs/architecture/0009-leases-and-fair-scheduling.md
@@ -1,0 +1,92 @@
+# 0009 — Job leases, global queue, and crash reassignment
+
+- **Status:** accepted
+- **Date:** 2026-06-27
+- **Deciders:** Brokkr maintainers
+
+## Context
+
+After ADR 0008 the scheduler routes each action directly to a chosen connected
+worker (per-worker channels), and **fails fast** with `NoEligibleWorker` when
+no eligible worker is connected. Two gaps remain for Phase 4 §16 task 4 and its
+definition of done:
+
+1. **No crash recovery.** "Worker crash mid-job → job retried on another
+   worker, completes successfully" is the headline §16 DoD. Today a worker that
+   disconnects mid-job just drops its in-flight jobs to a timeout; nothing
+   retries them.
+2. **No global queue / backpressure.** A submit with every eligible worker busy
+   should *wait* (queue), not fail. ADR 0008 explicitly deferred the global
+   pending queue to this task; it is also the point at which fair scheduling
+   (per-tenant weighting) will later be applied.
+
+This ADR covers the queue + lease + reassignment mechanism. Tenants/quotas and
+weighted fair queuing build on the queue and are their own increments.
+
+## Decision
+
+**A global pending queue drained by an event-driven dispatcher, with
+time-bounded job leases and requeue-on-failure.**
+
+- **Worker capacity = 1 leased job.** A worker's control loop runs one action
+  at a time (receive → run → report), so the scheduler leases it exactly one
+  job and treats it as busy until it reports, the lease expires, or it
+  disconnects. (A future per-worker parallelism knob can raise this.)
+- **Global pending queue.** `execute()` builds the job, registers a result
+  waiter (keyed by `JobId`, surviving retries), pushes the job onto a FIFO
+  pending queue, and awaits its result under the existing overall execution
+  timeout. FIFO now; per-tenant weighted fair queuing replaces the ordering
+  later without changing this shape.
+- **Event-driven dispatcher.** A `try_dispatch` pass assigns queued jobs to
+  idle workers that satisfy each job's platform (reusing
+  `matching::eligible_workers` ∩ connected ∩ idle, picked by the ADR 0008
+  `Strategy`). It runs on every state change that could enable progress: job
+  enqueued, worker connected, worker became idle (reported), lease expired,
+  worker disconnected.
+- **Leases.** Dispatching creates a `Lease { worker_id, deadline, payload }`
+  keyed by `JobId`, where `payload` is everything needed to re-dispatch the
+  job. The worker must report before `deadline`. A `LeaseTable` tracks active
+  leases and supports: complete (worker reported), `take_expired(now)`, and
+  `take_worker(worker_id)` (for disconnect).
+- **Requeue on failure.** On lease expiry *or* worker disconnect the job's
+  payload is moved back to the pending queue (bounded retry count) and the
+  dispatcher reassigns it to another worker. The result waiter is untouched, so
+  the original `execute()` caller transparently gets the retried result.
+- **At-least-once, made safe by determinism.** A worker whose lease expired may
+  still finish and report late; by then the job may have been retried
+  elsewhere. Late reports for a job with no waiter/lease are discarded. Brokkr's
+  determinism axiom means a double-run yields the same result, so at-least-once
+  is acceptable (exactly-once would need fencing we don't want here).
+
+## Alternatives considered
+
+- **Keep fail-fast, no queue.** Simplest, but cannot satisfy the crash-recovery
+  DoD and pushes backpressure onto every client as retry-loops. Rejected.
+- **Per-worker job buffering (today's model) for retries.** Buffering several
+  jobs at a worker can't reassign them when that worker dies — the whole point
+  of leases is a central record that survives the worker. Rejected for task 4.
+- **Exactly-once via fencing tokens / dedup.** Heavier (needs persistent fencing
+  state, idempotency keys). Determinism already gives us safe retries, so
+  deferred unless a non-deterministic-action escape hatch ever needs it.
+- **Lease renewal RPC now.** A long-running action could outlive a fixed lease.
+  Renewal (worker periodically extends its lease) is real but additive; the
+  first cut sizes the lease from the action timeout and adds renewal as a
+  follow-up increment.
+
+## Consequences
+
+- **Positive:** Delivers the crash-recovery DoD; adds backpressure (submits
+  queue instead of failing); the queue is the natural seam for per-tenant fair
+  scheduling and quotas next.
+- **Negative:** Re-touches the dispatch core (again) — staged as ADR + tested
+  `LeaseTable`/queue foundation first, then the `execute`/dispatcher rewrite.
+  At-least-once can double-run an action across a lease-expiry boundary (safe
+  under determinism, but worth noting for any future non-deterministic path).
+- **Neutral:** Worker capacity is pinned at 1 for now; per-worker parallelism
+  and lease renewal are future knobs behind the same structures.
+
+## References
+
+- `docs/plan.md` §6.3 (scheduler), §16 task 4, §16 DoD
+- ADR 0008 (multi-worker scheduling — deferred the global queue here)
+- `crates/brokkr-control/src/{scheduler,scheduling,matching}.rs`

--- a/docs/journal/phase-4.md
+++ b/docs/journal/phase-4.md
@@ -483,3 +483,53 @@ shipped (I8–I10). Remaining under "scheduling strategies": `LocalityAware`
 reassigning a disconnected worker's in-flight jobs, deferred from I9),
 tenants/quotas, fair scheduling; this is where ADR 0008's deferred global
 pending queue lands, likely with its own ADR.
+
+## I11 — leases + global queue ADR + LeaseTable (§16 task 4)
+
+- **Date:** 2026-06-27
+- **Affected crate:** `brokkr-control` (+ ADR 0009)
+- **Decision taken with the owner:** task 4 starts with **global queue +
+  leases + crash-reassignment** (the §16 DoD), over tenants/quotas first
+  or finishing `LocalityAware`.
+- **Outcome:** ADR 0009 records the design — a global pending queue
+  drained by an event-driven dispatcher, time-bounded job leases, and
+  requeue-on-failure (lease expiry *or* worker disconnect → another
+  worker), at-least-once made safe by Brokkr's determinism axiom. The
+  first code increment lands `lease::LeaseTable<P>`, the pure lease
+  bookkeeping core, clock-injected and generic over the re-dispatch
+  payload. Seven unit tests; `brokkr-control` green.
+
+### Decisions
+
+- **Worker capacity = 1 leased job (ADR 0009).** The worker control loop
+  already runs actions serially, so the scheduler leases one job per
+  worker and treats it busy until report/expiry/disconnect. Per-worker
+  parallelism is a later knob.
+- **`LeaseTable` carries the re-dispatch payload.** A lease holds enough
+  to re-queue the job if it fails, so reassignment needs no separate
+  in-flight map. Generic `<P>` keeps the bookkeeping unit-testable
+  without the scheduler's `bv1::Job`/waiter types.
+- **`complete` returns `Option<P>`.** A late report after expiry/
+  reassignment finds no lease → `None` → caller discards it. This is the
+  at-least-once seam: the retry's result is the one that counts.
+- **`take_expired` / `take_worker` return sorted `(job_id, payload)`.**
+  Deterministic requeue order for logging/tests; `take_worker` is the
+  disconnect-reassignment path (the I9-deferred crash recovery).
+- **Inclusive expiry (`now >= deadline`).** Matches intuition for "due
+  by"; pinned by a test. (The registry uses strictly-greater for
+  staleness — different semantics, deliberately: a missed *heartbeat*
+  tolerates the exact boundary, a *lease* deadline does not.)
+- **Foundation split from wiring.** I11 = ADR + `LeaseTable` (tested);
+  I12 = the dispatcher/`execute` rewrite (pending queue, lease on
+  dispatch, requeue on expiry/disconnect, crash-reassignment integration
+  test). The dispatcher re-touches the scheduler core, so it's staged
+  behind the reviewable ADR.
+
+### Next increment (I12)
+
+The dispatcher rewrite: `execute` enqueues (waiter survives retries) +
+`try_dispatch` assigns queued jobs to idle eligible workers, leasing each;
+`report` completes the lease and re-dispatches; worker disconnect / lease
+expiry requeue via `take_worker` / `take_expired`. Headline test: a worker
+that disconnects mid-job → the job is reassigned to a second worker and
+completes (the §16 DoD).


### PR DESCRIPTION
## Motivation

Phase 4 §16 task 4, starting with the **DoD headline**: "worker crash mid-job → job retried on another worker, completes successfully." Today the scheduler routes directly to a worker and fails fast when none is free; there's no queue and no crash recovery. This milestone introduces a global pending queue + job leases + requeue-on-failure.

It's the biggest task-4 change, so it leads with an **ADR** and a tested bookkeeping foundation; the dispatcher/`execute` rewrite follows on this PR.

## Decision (ADR 0009)

A **global pending queue** drained by an **event-driven dispatcher**, with **time-bounded job leases** and **requeue-on-failure**:
- Worker capacity = 1 leased job (workers run serially).
- `execute()` enqueues (the result waiter survives retries) and awaits under the overall timeout.
- Dispatching creates a lease (`worker`, `deadline`, re-dispatch `payload`); the worker must report before the deadline.
- Lease expiry **or** worker disconnect → requeue the job to another worker. At-least-once, made safe by Brokkr's determinism axiom (a double-run yields the same result; late reports discarded).

See `docs/architecture/0009-leases-and-fair-scheduling.md`.

## What changed (this commit — I11)

`brokkr-control::lease::LeaseTable<P>` — pure lease bookkeeping, generic over the re-dispatch payload, clock-injected:
- `insert` / `complete` (→ payload, or `None` for a late report to discard) / `worker_of` / `contains` / `len`.
- `take_expired(now)` and `take_worker(id)` → sorted `(job_id, payload)` pairs to requeue (the expiry and disconnect-reassignment paths).

## How it was tested

7 unit tests (insert+complete, late-report→None, insert-replaces, take_expired sorted + inclusive-at-deadline, take_worker isolation, unknown-worker empty). `brokkr-control` fmt + `clippy --all-targets -D warnings` + test green in WSL2.

## Next on this PR (I12)

The dispatcher rewrite: pending queue + `try_dispatch` (lease to idle eligible workers) + `report` completes/redispatches + disconnect/expiry requeue, with a crash-reassignment integration test (the DoD).

## Related

`docs/plan.md` §16 task 4 + DoD; ADR 0009 (builds on ADR 0008). `docs/journal/phase-4.md` (I11). Builds on #98–#101.