### PR TITLE
fix(sandbox): log instead of silently dropping a panicked output pump (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `brokkr-sandbox` host runner no longer swallows a panicked or
+  cancelled stdout/stderr capture task. `JoinError` was discarded by
+  `unwrap_or_default()`, so a crashed pump returned empty output with
+  no signal to the operator (issue #68). The join is now handled
+  explicitly: on error it logs a `warn` naming the affected stream and
+  falls back to an empty buffer.
 - `brokkr-sandbox::runner::seccomp` compiled with a stray `return`
   inside a single-arm `cfg` block which a newer clippy flagged as
   `needless_return`; replaced with bare expressions so all four

--- a/crates/brokkr-sandbox/src/host/linux.rs
+++ b/crates/brokkr-sandbox/src/host/linux.rs
@@ -215,8 +215,8 @@ pub(super) async fn run_action(
         },
     };
 
-    let stdout_buf = stdout_task.await.unwrap_or_default();
-    let stderr_buf = stderr_task.await.unwrap_or_default();
+    let stdout_buf = join_capture(stdout_task.await, "stdout");
+    let stderr_buf = join_capture(stderr_task.await, "stderr");
 
     // If the host's write hit EPIPE *and* the runner exited non-zero with
     // a diagnostic on stderr, prefer the runner's message — same M2 logic.
@@ -264,4 +264,49 @@ async fn read_to_end<R: tokio::io::AsyncRead + Unpin>(mut r: R) -> Vec<u8> {
     let mut buf = Vec::new();
     let _ = r.read_to_end(&mut buf).await;
     buf
+}
+
+/// Resolve a joined stdout/stderr pump task into its captured bytes.
+///
+/// A `JoinError` means the pump task panicked or was cancelled (e.g. the
+/// runtime shutting down mid-action). We can't recover the bytes it was
+/// holding, so we fall back to an empty buffer — but we log a warning so the
+/// truncation is visible to an operator instead of vanishing silently, which
+/// `unwrap_or_default()` would have done (issue #68).
+fn join_capture(joined: Result<Vec<u8>, tokio::task::JoinError>, stream: &str) -> Vec<u8> {
+    match joined {
+        Ok(buf) => buf,
+        Err(e) => {
+            tracing::warn!(
+                stream,
+                error = %e,
+                "output capture task failed to join; {stream} will be reported as empty"
+            );
+            Vec::new()
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods, clippy::panic)]
+mod tests {
+    use super::join_capture;
+
+    #[tokio::test]
+    async fn join_capture_passes_through_successful_output() {
+        let task = tokio::spawn(async { vec![1u8, 2, 3] });
+        assert_eq!(join_capture(task.await, "stdout"), vec![1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn join_capture_returns_empty_when_task_panics() {
+        // A panicking pump task yields a JoinError; the buffer must come back
+        // empty rather than propagating the panic or hanging.
+        let task = tokio::spawn(async {
+            panic!("simulated pump panic");
+            #[allow(unreachable_code)]
+            Vec::<u8>::new()
+        });
+        assert!(join_capture(task.await, "stderr").is_empty());
+    }
 }


### PR DESCRIPTION
## Motivation

In the sandbox host runner, the stdout/stderr pump tasks were joined with `unwrap_or_default()`:

```rust
let stdout_buf = stdout_task.await.unwrap_or_default();
let stderr_buf = stderr_task.await.unwrap_or_default();
```

A `JoinError` (the pump task panicked or was cancelled, e.g. on runtime shutdown) is turned into an empty buffer with **no signal**. An action whose output capture crashed would report empty stdout/stderr and the operator would never know (issue #68, H4).

## What changed

- Replaced both joins with a `join_capture(joined, stream)` helper in `host/linux.rs`. On `Ok`, it returns the captured bytes unchanged. On `JoinError`, it logs a `tracing::warn!` naming the affected stream (`stdout`/`stderr`) and the error, then falls back to an empty buffer.
- Behaviour is otherwise unchanged: a join failure is still non-fatal (we can't recover the bytes), but it is now **visible** instead of silent.

This is the minimal fix the issue asks for ("log a warning if the task panicked"); it does not change the capture path or introduce new failure modes.

## How it was tested

WSL2 (Linux), worktree off `origin/main`:
- `cargo fmt -p brokkr-sandbox` — clean
- `cargo clippy -p brokkr-sandbox --all-targets -- -D warnings` — clean (compiles the integration tests too)
- `cargo test -p brokkr-sandbox --lib host::linux::tests` — 2 new tests pass

New tests (`host::linux::tests`):
- `join_capture_passes_through_successful_output` — `Ok(bytes)` is returned unchanged.
- `join_capture_returns_empty_when_task_panics` — a panicking spawned task yields a `JoinError`, and the helper returns an empty buffer rather than propagating the panic.

Note: the sandbox integration/seccomp suites are not run here — they require Linux primitives that the WSL2 kernel doesn't support (per project convention). They are still compiled by the `--all-targets` clippy pass.

## Related

- Closes #68
- Phase 2 sandbox (`brokkr-sandbox`), host runner.