### PR TITLE
fix(sdk): surface google.rpc.Status code from failed executions (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `brokkr-sdk` no longer discards the `google.rpc.Status.code` on a
+  failed execution. The streamed `Operation` error path flattened the
+  code into an `anyhow!` string, and the `ExecuteResponse.status` path
+  stringified the structured `ExecuteError` — so callers could not tell
+  `RESOURCE_EXHAUSTED` / `UNAVAILABLE` / `DEADLINE_EXCEEDED` apart for
+  retry decisions (issue #62). Both paths now propagate the structured
+  `ExecuteError::Status { code, message }`, recoverable by downcasting
+  the returned `anyhow::Error`.
 - `brokkr-sandbox::runner::seccomp` compiled with a stray `return`
   inside a single-arm `cfg` block which a newer clippy flagged as
   `needless_return`; replaced with bare expressions so all four

--- a/crates/brokkr-sdk/src/client.rs
+++ b/crates/brokkr-sdk/src/client.rs
@@ -15,13 +15,19 @@ use sha2::{Digest as _, Sha256};
 use thiserror::Error;
 use tonic::transport::{Channel, Endpoint};
 
-/// Errors from [`check_status`].
+/// A server-reported execution failure carrying the `google.rpc.Status` code.
+///
+/// Surfaced from both [`check_status`] (the `ExecuteResponse.status` path) and
+/// the streamed `Operation` error path, so callers can inspect `code` for
+/// retry decisions instead of parsing a message string (issue #62).
 #[derive(Debug, Error)]
 pub enum ExecuteError {
     /// Server returned a non-OK status.
     #[error("execution failed: {message} (code={code})")]
     Status {
-        /// The gRPC status code (non-zero).
+        /// The gRPC / `google.rpc.Status` code (non-zero). Tells the caller
+        /// whether the failure is retryable (`RESOURCE_EXHAUSTED`,
+        /// `UNAVAILABLE`, `DEADLINE_EXCEEDED`, …).
         code: i32,
         /// The error message from the server.
         message: String,
@@ -187,6 +193,18 @@ pub fn check_status(resp: &rapi::ExecuteResponse) -> Result<rapi::ActionResult, 
     }
 }
 
+/// Map a streamed `Operation` error `Status` into a structured [`ExecuteError`].
+///
+/// The `google.rpc.Status.code` is what tells a caller whether the failure is
+/// retryable, so it must survive in the error type rather than being flattened
+/// into a formatted string (issue #62).
+fn operation_error(status: brokkr_proto::rpc::Status) -> ExecuteError {
+    ExecuteError::Status {
+        code: status.code,
+        message: status.message,
+    }
+}
+
 /// Run `argv` on the cluster and return its result.
 ///
 /// Builds an `Action` (with empty input root + the given Command), uploads
@@ -318,7 +336,9 @@ pub async fn run_command(
                 let resp = rapi::ExecuteResponse::decode(any.value.as_slice())
                     .context("decoding ExecuteResponse")?;
                 let status_code = resp.status.as_ref().map(|s| s.code).unwrap_or(0);
-                let result = check_status(&resp).map_err(|e| anyhow!("{e}"))?;
+                // Propagate the structured ExecuteError (not a stringified copy)
+                // so callers can downcast and inspect the code (issue #62).
+                let result = check_status(&resp)?;
                 if status_code != 0 {
                     tracing::Span::current().record("exec_status_code", status_code);
                 }
@@ -333,7 +353,7 @@ pub async fn run_command(
                 });
             }
             Some(brokkr_proto::longrunning::operation::Result::Error(s)) => {
-                return Err(anyhow!("execution failed: {} ({})", s.message, s.code));
+                return Err(operation_error(s).into());
             }
             None => {
                 return Err(anyhow!("Operation done with no result"));
@@ -347,5 +367,40 @@ fn digest_of(bytes: &[u8]) -> rapi::Digest {
     rapi::Digest {
         hash: hex::encode(Sha256::digest(bytes)),
         size_bytes: bytes.len() as i64,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods, clippy::panic)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn operation_error_surfaces_code_for_retry_inspection() {
+        let status = brokkr_proto::rpc::Status {
+            code: 8, // RESOURCE_EXHAUSTED
+            message: "quota exceeded".to_string(),
+            details: vec![],
+        };
+        let ExecuteError::Status { code, message } = operation_error(status) else {
+            panic!("expected Status variant");
+        };
+        assert_eq!(code, 8);
+        assert_eq!(message, "quota exceeded");
+    }
+
+    #[test]
+    fn execute_error_code_survives_anyhow_boxing() {
+        // run_command returns anyhow::Result, so a caller recovers the code by
+        // downcasting the boxed error rather than parsing the message.
+        let err: anyhow::Error = ExecuteError::Status {
+            code: 14, // UNAVAILABLE
+            message: "try again".to_string(),
+        }
+        .into();
+        assert!(matches!(
+            err.downcast_ref::<ExecuteError>(),
+            Some(ExecuteError::Status { code: 14, .. })
+        ));
     }
 }


### PR DESCRIPTION
## Motivation

The SDK could not implement correct retry logic because the `google.rpc.Status.code` — which tells a client whether a failure is retryable (`DEADLINE_EXCEEDED`, `RESOURCE_EXHAUSTED`, `UNAVAILABLE`, …) — was discarded on the error path (issue #62, C4).

Two places dropped it:
- The streamed `Operation` error path flattened it into a string: `Err(anyhow!("execution failed: {} ({})", s.message, s.code))`.
- The `ExecuteResponse.status` path stringified the already-structured `ExecuteError`: `check_status(&resp).map_err(|e| anyhow!("{e}"))?`.

## What changed

- Added a private `operation_error(status) -> ExecuteError` mapper that preserves the code/message, and used it on the `Operation::Error` path: `return Err(operation_error(s).into());`.
- Dropped the `.map_err(|e| anyhow!("{e}"))` on the response-status path so `?` propagates the structured `ExecuteError` unchanged.
- Expanded the `ExecuteError` rustdoc to document that the code carries retry guidance and is surfaced from both paths.

`run_command` still returns `anyhow::Result`, so this is source-compatible: existing callers that print the error are unaffected, while callers that want retry guidance can now `err.downcast_ref::<ExecuteError>()` and match on `ExecuteError::Status { code, .. }`.

## How it was tested

WSL2 (Linux), worktree off `origin/main`:
- `cargo fmt -p brokkr-sdk` — clean
- `cargo clippy -p brokkr-sdk --all-targets -- -D warnings` — clean
- `cargo test -p brokkr-sdk` — 2 new unit tests + 4 existing `status_check` integration tests pass

New tests (`client::tests`):
- `operation_error_surfaces_code_for_retry_inspection` — the mapper yields `ExecuteError::Status` with the original code/message.
- `execute_error_code_survives_anyhow_boxing` — after `.into()` to `anyhow::Error` (the `run_command` return type), the code is recoverable via `downcast_ref`.

## Related

- Closes #62
- Builds on the `ExecuteError` type introduced for #61 (`check_status`).