### PR TITLE
fix(control): bound CAS batch request sizes at the service boundary (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `brokkr-control` CAS service now bounds batch request sizes at the
+  service boundary. `FindMissingBlobs`, `BatchReadBlobs`, and
+  `BatchUpdateBlobs` previously iterated over an unbounded request, so a
+  client could exhaust control-plane memory with one giant batch (issue
+  #66). A new `BatchLimits` config (default 1000 blobs/request, 4 MiB
+  payload — matching the advertised `max_batch_total_size_bytes`) is
+  enforced before allocation; oversized requests are rejected with
+  `INVALID_ARGUMENT`. Construct with `CasService::with_limits` to
+  override.
 - `brokkr-sandbox::runner::seccomp` compiled with a stray `return`
   inside a single-arm `cfg` block which a newer clippy flagged as
   `needless_return`; replaced with bare expressions so all four

--- a/crates/brokkr-control/src/services/cas.rs
+++ b/crates/brokkr-control/src/services/cas.rs
@@ -12,15 +12,57 @@ use tonic::{Request, Response, Status};
 
 use super::{digest_to_proto, proto_to_digest};
 
+/// Per-request bounds for the CAS batch RPCs, enforced at the service boundary
+/// so a malicious or buggy client cannot exhaust control-plane memory with a
+/// single oversized request (issue #66).
+#[derive(Debug, Clone, Copy)]
+pub struct BatchLimits {
+    /// Maximum number of blobs in one `FindMissingBlobs`, `BatchReadBlobs`,
+    /// or `BatchUpdateBlobs` request.
+    pub max_blobs_per_request: usize,
+    /// Maximum total payload bytes in one `BatchUpdateBlobs` request.
+    pub max_request_bytes: usize,
+}
+
+impl Default for BatchLimits {
+    fn default() -> Self {
+        // `max_request_bytes` mirrors the `max_batch_total_size_bytes` the
+        // `Capabilities` service advertises (4 MiB), so the server enforces
+        // exactly the bound it tells clients to respect.
+        Self {
+            max_blobs_per_request: 1000,
+            max_request_bytes: 4 * 1024 * 1024,
+        }
+    }
+}
+
 /// REAPI `ContentAddressableStorage` service backed by a [`Cas`].
 pub struct CasService<C: Cas> {
     backend: Arc<C>,
+    limits: BatchLimits,
 }
 
 impl<C: Cas> CasService<C> {
-    /// Wrap a CAS backend into a tonic service.
+    /// Wrap a CAS backend into a tonic service with default [`BatchLimits`].
     pub fn new(backend: Arc<C>) -> Self {
-        Self { backend }
+        Self::with_limits(backend, BatchLimits::default())
+    }
+
+    /// Wrap a CAS backend with explicit per-request [`BatchLimits`].
+    pub fn with_limits(backend: Arc<C>, limits: BatchLimits) -> Self {
+        Self { backend, limits }
+    }
+
+    /// Reject a batch whose blob count exceeds
+    /// [`BatchLimits::max_blobs_per_request`].
+    fn check_blob_count(&self, count: usize) -> Result<(), Status> {
+        if count > self.limits.max_blobs_per_request {
+            return Err(Status::invalid_argument(format!(
+                "batch has {count} blobs, exceeding the per-request limit of {}",
+                self.limits.max_blobs_per_request
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -32,6 +74,7 @@ impl<C: Cas> CasSvc for CasService<C> {
     ) -> Result<Response<rapi::FindMissingBlobsResponse>, Status> {
         let span = tracing::info_span!("cas::find_missing_blobs");
         let req = request.into_inner();
+        self.check_blob_count(req.blob_digests.len())?;
         let digests: Vec<super::Digest> = req
             .blob_digests
             .iter()
@@ -56,6 +99,14 @@ impl<C: Cas> CasSvc for CasService<C> {
         let span = tracing::info_span!("cas::batch_update_blobs");
         let req = request.into_inner();
         let request_count = req.requests.len();
+        self.check_blob_count(request_count)?;
+        let total_bytes: usize = req.requests.iter().map(|r| r.data.len()).sum();
+        if total_bytes > self.limits.max_request_bytes {
+            return Err(Status::invalid_argument(format!(
+                "batch payload is {total_bytes} bytes, exceeding the per-request limit of {}",
+                self.limits.max_request_bytes
+            )));
+        }
 
         // Verify each entry's declared digest against its bytes *before*
         // we hand the batch to the backend. The backend re-verifies (issue
@@ -134,6 +185,7 @@ impl<C: Cas> CasSvc for CasService<C> {
         let span = tracing::info_span!("cas::batch_read_blobs");
         let req = request.into_inner();
         let digest_count = req.digests.len();
+        self.check_blob_count(digest_count)?;
         let digests: Vec<super::Digest> = req
             .digests
             .iter()

--- a/crates/brokkr-control/src/services/mod.rs
+++ b/crates/brokkr-control/src/services/mod.rs
@@ -18,7 +18,7 @@ pub mod execution;
 // Re-export so `crate::services::*` continues to work.
 pub use action_cache::ActionCacheService;
 pub use capabilities::CapabilitiesService;
-pub use cas::CasService;
+pub use cas::{BatchLimits, CasService};
 pub use execution::ExecutionService;
 
 // Shared helpers used across service implementations.

--- a/crates/brokkr-control/tests/batch_limits.rs
+++ b/crates/brokkr-control/tests/batch_limits.rs
@@ -1,0 +1,116 @@
+//! Tests for CAS batch request-size enforcement at the service boundary.
+//!
+//! Verifies that `CasService` rejects oversized `FindMissingBlobs`,
+//! `BatchReadBlobs`, and `BatchUpdateBlobs` requests before allocating,
+//! per the configured `BatchLimits` (issue #66).
+
+#![allow(clippy::unwrap_used, clippy::panic, clippy::disallowed_methods)]
+
+use std::sync::Arc;
+
+use brokkr_cas::InMemoryCas;
+use brokkr_control::services::{BatchLimits, CasService};
+use brokkr_proto::reapi_v2 as rapi;
+use rapi::batch_update_blobs_request::Request as UpdateRequest;
+use rapi::content_addressable_storage_server::ContentAddressableStorage as _;
+use tonic::{Code, Request};
+
+/// Tiny limits so tests can trip them without huge payloads.
+fn small_limits() -> BatchLimits {
+    BatchLimits {
+        max_blobs_per_request: 2,
+        max_request_bytes: 8,
+    }
+}
+
+fn service() -> CasService<InMemoryCas> {
+    CasService::with_limits(Arc::new(InMemoryCas::new()), small_limits())
+}
+
+/// A shape-valid digest. Content is irrelevant: the count check runs before
+/// digest parsing, and `find_missing` does not verify content.
+fn dummy_digest() -> rapi::Digest {
+    rapi::Digest {
+        hash: "a".repeat(64),
+        size_bytes: 1,
+    }
+}
+
+#[tokio::test]
+async fn find_missing_blobs_rejects_too_many_digests() {
+    let req = rapi::FindMissingBlobsRequest {
+        blob_digests: vec![dummy_digest(), dummy_digest(), dummy_digest()],
+        ..Default::default()
+    };
+    let err = service()
+        .find_missing_blobs(Request::new(req))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(err.message().contains("blobs"));
+}
+
+#[tokio::test]
+async fn find_missing_blobs_allows_within_limit() {
+    let req = rapi::FindMissingBlobsRequest {
+        blob_digests: vec![dummy_digest(), dummy_digest()],
+        ..Default::default()
+    };
+    let resp = service()
+        .find_missing_blobs(Request::new(req))
+        .await
+        .unwrap();
+    // Both are absent from a fresh in-memory CAS, so both come back missing.
+    assert_eq!(resp.into_inner().missing_blob_digests.len(), 2);
+}
+
+#[tokio::test]
+async fn batch_read_blobs_rejects_too_many_digests() {
+    let req = rapi::BatchReadBlobsRequest {
+        digests: vec![dummy_digest(), dummy_digest(), dummy_digest()],
+        ..Default::default()
+    };
+    let err = service()
+        .batch_read_blobs(Request::new(req))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+}
+
+#[tokio::test]
+async fn batch_update_blobs_rejects_too_many_blobs() {
+    let blob = || UpdateRequest {
+        digest: Some(dummy_digest()),
+        data: vec![1],
+        ..Default::default()
+    };
+    let req = rapi::BatchUpdateBlobsRequest {
+        requests: vec![blob(), blob(), blob()],
+        ..Default::default()
+    };
+    let err = service()
+        .batch_update_blobs(Request::new(req))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(err.message().contains("blobs"));
+}
+
+#[tokio::test]
+async fn batch_update_blobs_rejects_oversized_payload() {
+    // One blob (within the count limit) but 9 bytes > the 8-byte limit.
+    let req = rapi::BatchUpdateBlobsRequest {
+        requests: vec![UpdateRequest {
+            digest: Some(dummy_digest()),
+            data: vec![0u8; 9],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let err = service()
+        .batch_update_blobs(Request::new(req))
+        .await
+        .unwrap_err();
+    assert_eq!(err.code(), Code::InvalidArgument);
+    assert!(err.message().contains("bytes"));
+}


### PR DESCRIPTION
## Motivation

`FindMissingBlobs`, `BatchReadBlobs`, and `BatchUpdateBlobs` iterated over the request with no cap. A malicious or buggy client could send a batch with, say, 1,000,000 digests or a multi-gigabyte payload and exhaust control-plane memory before the backend ever ran (issue #66, H2). The `Capabilities` service advertised a 4 MiB `max_batch_total_size_bytes`, but nothing actually enforced it.

## What changed

- Added a `BatchLimits` config struct (`max_blobs_per_request`, `max_request_bytes`) carried by `CasService`.
  - Default: **1000 blobs/request** and **4 MiB payload** — the byte limit deliberately mirrors the advertised `max_batch_total_size_bytes`, so the server enforces exactly the bound it tells clients to respect.
- Enforced at the service boundary, **before allocation**:
  - `FindMissingBlobs` / `BatchReadBlobs` — reject when the digest count exceeds the limit.
  - `BatchUpdateBlobs` — reject when the blob count *or* total payload bytes exceed the limits.
  - All rejections are `INVALID_ARGUMENT` with a message naming the offending size.
- `CasService::new` keeps the default limits (no API break — existing callers unchanged); `CasService::with_limits` overrides. `BatchLimits` is re-exported from `brokkr_control::services`.

Config is an explicit struct per project convention; wiring a CLI override is left for when the binary needs it.

## How it was tested

WSL2 (Linux), worktree off `origin/main`:
- `cargo fmt -p brokkr-control` — clean
- `cargo clippy -p brokkr-control --all-targets -- -D warnings` — clean
- `cargo test -p brokkr-control` — all suites pass, including 5 new tests

New `tests/batch_limits.rs` (integration), using tiny limits (2 blobs / 8 bytes):
- over-count rejection for `find_missing_blobs`, `batch_read_blobs`, `batch_update_blobs`
- over-bytes rejection for `batch_update_blobs` (1 blob, 9 bytes)
- within-limit `find_missing_blobs` still succeeds

The existing `grpc_smoke` / `end_to_end` suites (which use `CasService::new` with default limits) still pass, confirming no regression on normal-sized batches.

## Related

- Closes #66
- The byte default is coupled to `capabilities.rs::max_batch_total_size_bytes` (4 MiB) — noted in a code comment as the source of truth to keep in sync.
- Minor overlap note: if #102 (instance_name guard, #72) merges first, both touch the top of the CAS handlers and may need a trivial conflict resolution.