### PR TITLE
fix(worker,sandbox): bound captured stdout/stderr to 50 MiB (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `brokkr-worker` and `brokkr-sandbox` now bound how much of an action's
+  stdout/stderr they buffer. The worker's plain runner used
+  `Command::output()` and the sandbox host drained the runner pipes with
+  an unbounded `read_to_end`, so an action writing gigabytes to stdout
+  could OOM the worker (issue #67). Both paths now cap each stream at
+  50 MiB (`read_capped`), draining and dropping the excess with a `warn`
+  rather than buffering it.
 - `brokkr-sandbox::runner::seccomp` compiled with a stray `return`
   inside a single-arm `cfg` block which a newer clippy flagged as
   `needless_return`; replaced with bare expressions so all four

--- a/crates/brokkr-sandbox/src/host/linux.rs
+++ b/crates/brokkr-sandbox/src/host/linux.rs
@@ -133,8 +133,8 @@ pub(super) async fn run_action(
         step: "take stderr",
         source: io::Error::other("child stderr already taken"),
     })?;
-    let stdout_task = tokio::spawn(read_to_end(stdout));
-    let stderr_task = tokio::spawn(read_to_end(stderr));
+    let stdout_task = tokio::spawn(read_capped(stdout, MAX_CAPTURED_OUTPUT_BYTES, "stdout"));
+    let stderr_task = tokio::spawn(read_capped(stderr, MAX_CAPTURED_OUTPUT_BYTES, "stderr"));
 
     // Write the JSON payload. EPIPE is tolerated — see M2 notes for why.
     let write_err = {
@@ -260,8 +260,44 @@ pub(super) async fn run_action(
     })
 }
 
-async fn read_to_end<R: tokio::io::AsyncRead + Unpin>(mut r: R) -> Vec<u8> {
+/// Maximum bytes captured from a single runner output stream before
+/// truncation.
+///
+/// A sandboxed action can write unbounded data to stdout/stderr; buffering it
+/// all on the host is an OOM vector (issue #67). Past the cap we keep draining
+/// the pipe (so the runner doesn't block on a full pipe) but discard the rest.
+const MAX_CAPTURED_OUTPUT_BYTES: usize = 50 * 1024 * 1024;
+
+/// Read from `r`, retaining at most `cap` bytes; drain and drop the excess
+/// with a one-time `warn`.
+async fn read_capped<R: tokio::io::AsyncRead + Unpin>(
+    mut r: R,
+    cap: usize,
+    stream: &str,
+) -> Vec<u8> {
     let mut buf = Vec::new();
-    let _ = r.read_to_end(&mut buf).await;
+    let mut chunk = [0u8; 8192];
+    let mut warned = false;
+    loop {
+        match r.read(&mut chunk).await {
+            Ok(0) => break,
+            Ok(n) => {
+                if buf.len() < cap {
+                    let take = (cap - buf.len()).min(n);
+                    buf.extend_from_slice(&chunk[..take]);
+                    if buf.len() >= cap && !warned {
+                        warned = true;
+                        tracing::warn!(
+                            stream,
+                            cap,
+                            "captured runner output exceeded cap; truncating and draining the rest"
+                        );
+                    }
+                }
+                // Past the cap we keep looping to drain `r` without buffering.
+            }
+            Err(_) => break,
+        }
+    }
     buf
 }

--- a/crates/brokkr-worker/src/runner.rs
+++ b/crates/brokkr-worker/src/runner.rs
@@ -16,6 +16,7 @@
 //!   and feeds the result through `Sandbox::run`.
 
 use std::path::PathBuf;
+use std::process::Stdio;
 
 use anyhow::{anyhow, Result};
 use brokkr_proto::reapi_v2 as rapi;
@@ -25,6 +26,7 @@ use brokkr_sandbox::{
 };
 use bytes::Bytes;
 use sha2::{Digest as _, Sha256};
+use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::Command;
 
 /// Outcome of running a `Command`.
@@ -150,16 +152,84 @@ async fn run_plain(command: &rapi::Command) -> Result<RunOutcome> {
     for env in &command.environment_variables {
         cmd.env(&env.name, &env.value);
     }
-    let output = cmd
-        .output()
+    // Pipe stdout/stderr so we can bound how much we buffer. `Command::output`
+    // drains both streams to EOF with no limit, so an action that writes
+    // gigabytes to stdout would OOM the worker (issue #67).
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn().map_err(|e| anyhow!("spawning {argv0}: {e}"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("child stdout was not piped"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| anyhow!("child stderr was not piped"))?;
+    // Drain both pipes concurrently with `wait` so a child that fills one pipe
+    // cannot deadlock against us while we wait on the other.
+    let stdout_task = tokio::spawn(read_capped(stdout, MAX_CAPTURED_OUTPUT_BYTES, "stdout"));
+    let stderr_task = tokio::spawn(read_capped(stderr, MAX_CAPTURED_OUTPUT_BYTES, "stderr"));
+    let status = child
+        .wait()
         .await
-        .map_err(|e| anyhow!("spawning {argv0}: {e}"))?;
-    let exit_code = output.status.code().unwrap_or(-1);
+        .map_err(|e| anyhow!("waiting for {argv0}: {e}"))?;
+    let stdout = stdout_task
+        .await
+        .map_err(|e| anyhow!("stdout capture task failed: {e}"))?;
+    let stderr = stderr_task
+        .await
+        .map_err(|e| anyhow!("stderr capture task failed: {e}"))?;
+    let exit_code = status.code().unwrap_or(-1);
     Ok(RunOutcome {
         exit_code,
-        stdout: Bytes::from(output.stdout),
-        stderr: Bytes::from(output.stderr),
+        stdout: Bytes::from(stdout),
+        stderr: Bytes::from(stderr),
     })
+}
+
+/// Maximum bytes captured from a single output stream before truncation.
+///
+/// A malicious or runaway action can write unbounded data to stdout/stderr;
+/// buffering all of it in worker memory is an OOM vector (issue #67). Past
+/// this cap we keep draining the pipe (so the child doesn't block on a full
+/// pipe) but discard the excess.
+const MAX_CAPTURED_OUTPUT_BYTES: usize = 50 * 1024 * 1024;
+
+/// Read from `r`, retaining at most `cap` bytes.
+///
+/// Bytes past `cap` are drained and dropped (with a one-time `warn`) instead
+/// of buffered, so the child can keep writing and exit cleanly.
+async fn read_capped<R: AsyncRead + Unpin>(mut r: R, cap: usize, stream: &str) -> Vec<u8> {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 8192];
+    let mut warned = false;
+    loop {
+        match r.read(&mut chunk).await {
+            Ok(0) => break,
+            Ok(n) => {
+                if buf.len() < cap {
+                    let take = (cap - buf.len()).min(n);
+                    buf.extend_from_slice(&chunk[..take]);
+                    if buf.len() >= cap && !warned {
+                        warned = true;
+                        tracing::warn!(
+                            stream,
+                            cap,
+                            "captured output exceeded cap; truncating and draining the rest"
+                        );
+                    }
+                }
+                // Past the cap we keep looping to drain `r` without buffering.
+            }
+            Err(e) => {
+                tracing::warn!(stream, error = %e, "error reading captured output; stopping");
+                break;
+            }
+        }
+    }
+    buf
 }
 
 async fn run_sandboxed(runner: &SandboxRunner, command: &rapi::Command) -> Result<RunOutcome> {
@@ -224,5 +294,31 @@ pub fn proto_digest(bytes: &[u8]) -> rapi::Digest {
     rapi::Digest {
         hash: hex::encode(Sha256::digest(bytes)),
         size_bytes: bytes.len() as i64,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods, clippy::panic)]
+mod tests {
+    use super::{read_capped, MAX_CAPTURED_OUTPUT_BYTES};
+
+    #[tokio::test]
+    async fn read_capped_truncates_at_cap() {
+        let data = [b'x'; 100];
+        let out = read_capped(&data[..], 10, "stdout").await;
+        assert_eq!(out.len(), 10);
+        assert!(out.iter().all(|&b| b == b'x'));
+    }
+
+    #[tokio::test]
+    async fn read_capped_returns_all_when_under_cap() {
+        let data = [b'y'; 5];
+        let out = read_capped(&data[..], 10, "stderr").await;
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn default_cap_is_fifty_mib() {
+        assert_eq!(MAX_CAPTURED_OUTPUT_BYTES, 50 * 1024 * 1024);
     }
 }


### PR DESCRIPTION
## Motivation

Both output-capture paths drained the action's stdout/stderr with no size limit:
- `brokkr-worker::runner::run_plain` used `Command::output()`.
- `brokkr-sandbox`'s host runner drained the runner pipes with `read_to_end`.

A malicious or runaway action that writes gigabytes to stdout would allocate all of it in worker memory and OOM the process (issue #67, H3).

## What changed

- Added a `read_capped(reader, cap, stream)` helper to both crates. It reads in 8 KiB chunks, retains at most `cap` bytes, and once the cap is reached **keeps draining** the pipe (so the child can't deadlock on a full pipe) while **discarding** the excess and emitting a one-time `tracing::warn!`.
- `run_plain` is restructured to pipe stdout/stderr (`Stdio::piped()`) and drain both concurrently with `child.wait()`, replacing `Command::output()`.
- The sandbox host's `read_to_end` is replaced by `read_capped` at the two spawn sites.
- Cap is **50 MiB per stream** in both paths.

The cap drops excess with a warning rather than writing to a temp file — the simpler of the two options the issue suggested; spilling to disk can be added later if a use case needs the full output.

## How it was tested

WSL2 (Linux), worktree off `origin/main`:
- `cargo fmt` (worker + sandbox) — clean
- `cargo clippy -p brokkr-worker -p brokkr-sandbox --all-targets -- -D warnings` — clean
- `cargo test -p brokkr-worker --lib runner::tests` — 3 tests pass

New tests (`runner::tests`):
- `read_capped_truncates_at_cap` — 100 bytes in, cap 10 → 10 bytes out.
- `read_capped_returns_all_when_under_cap` — 5 bytes in, cap 10 → all 5.
- `default_cap_is_fifty_mib` — guards the constant.

The sandbox `read_capped` uses the same algorithm; its capture path is exercised by the (Linux-only) sandbox integration suite, which is compiled by the `--all-targets` clippy pass but not run under WSL2 per project convention.

## Related

- Closes #67
- Minor overlap note: PR #104 (#68) restructures the *join* of these same sandbox capture tasks (`linux.rs`). This PR changes the *read* function and its call sites; the regions are adjacent, so whichever merges second may need a trivial conflict resolution.