### PR TITLE
docs(sandbox): document why seccomp allows socketpair (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Reviewed the seccomp `socket` / `socketpair` allowance (issue #69) and
+  replaced the terse "netns blocks egress" comment with the full
+  rationale: the action's network namespace scopes abstract `AF_UNIX`
+  sockets (and blocks IP), the mount namespace hides host pathname
+  sockets, and `socketpair` is intra-process — so `SCM_RIGHTS` cannot
+  smuggle fds across the sandbox boundary. No behavioural change;
+  `socketpair` stays allowed because removing it would break legitimate
+  in-sandbox IPC for no security gain.
+
 ### Fixed
 - `brokkr-sandbox::runner::seccomp` compiled with a stray `return`
   inside a single-arm `cfg` block which a newer clippy flagged as

--- a/crates/brokkr-sandbox/src/runner/seccomp.rs
+++ b/crates/brokkr-sandbox/src/runner/seccomp.rs
@@ -158,8 +158,21 @@ const DEFAULT_ALLOW: &[&str] = &[
     "ppoll",
     "select",
     "pselect6",
+    // Sockets are allowed, but the action cannot use them to reach anything
+    // outside the sandbox or smuggle fds across its boundary (issue #69):
+    //   * It runs in a fresh network namespace (NetworkPolicy::None leaves no
+    //     routable interface), which also scopes *abstract* AF_UNIX sockets to
+    //     the sandbox — they cannot name a host socket.
+    //   * The mount namespace exposes no host *pathname* AF_UNIX sockets (the
+    //     default rootfs is ro /usr + tmpfs), so connect() has no external
+    //     endpoint to reach.
+    //   * socketpair() has no external endpoint at all — both ends belong to
+    //     the action — so an SCM_RIGHTS cmsg over it only passes fds between
+    //     the action's own processes, which fork already permits. Cross-
+    //     boundary fd smuggling needs an external socket endpoint, and the
+    //     namespaces above guarantee there is none.
     "socket",
-    "socketpair", // intentionally allowed; netns blocks egress
+    "socketpair",
     "connect",
     "bind",
     "listen",

--- a/docs/phase-2-plan.md
+++ b/docs/phase-2-plan.md
@@ -632,7 +632,10 @@ const DEFAULT_ALLOW: &[&str] = &[
     "futex", "futex_waitv", "set_robust_list", "get_robust_list",
     "epoll_create", "epoll_create1", "epoll_ctl", "epoll_wait", "epoll_pwait",
     "poll", "ppoll", "select", "pselect6",
-    "socket", "socketpair",       // intentionally allowed; netns blocks egress
+    "socket", "socketpair",       // allowed; no external endpoint reachable —
+                                  // netns scopes abstract AF_UNIX + blocks IP,
+                                  // mount ns hides host pathname sockets, and
+                                  // socketpair is intra-process (issue #69)
     "uname", "sysinfo",
     "getrandom",
     // …iterate from real workloads; every addition needs a one-line


### PR DESCRIPTION
## Motivation

Issue #69 (H5) flagged that the seccomp allowlist permits `socket`/`socketpair` with only a terse `// intentionally allowed; netns blocks egress` comment, and argued that `socketpair(AF_UNIX)` + `SCM_RIGHTS` could smuggle fds across the sandbox boundary — calling the netns justification "weak."

## Investigation / verdict

I reviewed the actual isolation and concluded **`socketpair` is safe to keep** — cross-boundary fd smuggling is already impossible, for three independent reasons:

1. **Network namespace** — the action runs in a fresh `CLONE_NEWNET` netns (`NetworkPolicy::None` leaves no routable interface). A netns also scopes **abstract** `AF_UNIX` sockets, so the action cannot name a host abstract socket.
2. **Mount namespace** — the default rootfs binds only ro `/usr` + tmpfs (`/etc`, `/tmp`, `/work`); no host **pathname** `AF_UNIX` socket is visible, so `connect()` has no external endpoint.
3. **`socketpair` is intra-process** — both ends belong to the action. An `SCM_RIGHTS` cmsg over it only passes fds between the action's own processes, which `fork` already permits. No escalation.

Removing `socketpair` would break legitimate in-sandbox IPC (many runtimes/build tools use it) for **zero** security gain: the SCM_RIGHTS cross-boundary vector is closed by the mount + network namespaces, not by this allowlist entry, and `socket`/`sendmsg`/`recvmsg` remain regardless. Filtering `SCM_RIGHTS` out of `sendmsg` would add real complexity to block something the namespaces already block.

## What changed

- Replaced the weak comment in the source allowlist (`runner/seccomp.rs`) with the full rationale above.
- Updated the matching comment in `docs/phase-2-plan.md` §5.6.
- **No behavioural change** — the filter is byte-for-byte identical.

## How it was tested

WSL2 (Linux), worktree off `origin/main`:
- `cargo fmt -p brokkr-sandbox` — clean
- `cargo clippy -p brokkr-sandbox --all-targets -- -D warnings` — clean

The seccomp behaviour is unchanged, so the (Linux-capability-dependent) `evil_seccomp_caps` suite is unaffected; it cannot run under WSL2 per project convention, but no rule was modified.

## If you disagree

If you'd prefer defence-in-depth over documentation, the alternatives are: (a) drop `socketpair` from the allowlist (accepting that some in-sandbox IPC may break), or (b) add `sendmsg`/`recvmsg` argument filtering to reject `SCM_RIGHTS` cmsgs. I judged both unnecessary given the namespace isolation, but they're straightforward follow-ups if wanted.

## Related

- Closes #69
- `docs/phase-2-plan.md` §5.6 (seccomp allowlist), `runner/netns.rs` (netns policy), `runner/userns.rs` (`CLONE_NEWNET`).