### PR TITLE
feat(control): lease-expiry reaper (Phase 4 §16 task 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -733,3 +733,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   knob to re-activate packing is a follow-up. Lease-*expiry* reassignment
   (slow worker, vs. disconnect) is also a follow-up; crash recovery via
   disconnect is live.
+- `brokkr-control` lease-expiry reaper: `Scheduler::reap_expired_leases`
+  (and the test seam `reap_expired_at(now)`) requeues jobs whose lease has
+  expired — a worker that is still connected but went silent — and
+  re-dispatches them, bounded by `MAX_ATTEMPTS`. `spawn_lease_reaper`
+  drives it on an interval (wired into the `brokkr-control` binary at half
+  the lease window); a zero interval disables it. Jobs now carry a
+  per-attempt `lease_duration` capped at `min(action timeout,
+  DEFAULT_LEASE_DURATION = 60s)`, so a hung worker is retried before the
+  caller's deadline. The shared requeue logic (disconnect + expiry) is
+  factored into `Inner::requeue_taken`. One scheduler test
+  (`lease_expiry_requeues_and_redispatches_job`). NOTE: an
+  expired-but-connected worker is not yet excluded from the re-dispatch
+  (it may be re-picked); "reassign strictly elsewhere" needs lease renewal
+  / tried-worker tracking — a follow-up.

--- a/crates/brokkr-control/src/lib.rs
+++ b/crates/brokkr-control/src/lib.rs
@@ -21,7 +21,7 @@ pub use membership::{Membership, MembershipServiceImpl};
 pub use registry::{
     HeartbeatPolicy, RegistryError, WorkerCapabilities, WorkerRecord, WorkerRegistry,
 };
-pub use scheduler::Scheduler;
+pub use scheduler::{spawn_lease_reaper, Scheduler};
 pub use scheduling::{BinPacking, ConnectedWorkers, LoadView, SimpleFifo, Strategy};
 pub use services::{ActionCacheService, CapabilitiesService, CasService, ExecutionService};
 pub use worker_service::{spawn_eviction_task, SharedWorkerRegistry, WorkerServiceImpl};

--- a/crates/brokkr-control/src/main.rs
+++ b/crates/brokkr-control/src/main.rs
@@ -3,13 +3,14 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use brokkr_cas::{RedbActionCache, RedbCas};
 use brokkr_control::registry::WorkerRegistry;
 use brokkr_control::{
-    spawn_eviction_task, ActionCacheService, CapabilitiesService, CasService, ExecutionService,
-    Scheduler, SharedWorkerRegistry, WorkerServiceImpl,
+    spawn_eviction_task, spawn_lease_reaper, ActionCacheService, CapabilitiesService, CasService,
+    ExecutionService, Scheduler, SharedWorkerRegistry, WorkerServiceImpl,
 };
 use brokkr_proto::brokkr_v1::worker_service_server::WorkerServiceServer;
 use brokkr_proto::reapi_v2::{
@@ -127,6 +128,10 @@ async fn main() -> Result<()> {
     // for the server's lifetime; aborting it on shutdown is implicit (process
     // exit). The eviction decision lives in `WorkerRegistry::evict_stale`.
     let _eviction = spawn_eviction_task(worker_registry.clone());
+    // Background lease reaper: reassign jobs whose lease expired (a connected
+    // but silent worker). Checked at a fraction of the lease window.
+    let reap_interval = (scheduler.lease_duration() / 2).max(Duration::from_secs(1));
+    let _lease_reaper = spawn_lease_reaper(scheduler.clone(), reap_interval);
 
     let mut server = Server::builder();
     if let Some(tls_cfg) = tls_cfg {

--- a/crates/brokkr-control/src/scheduler.rs
+++ b/crates/brokkr-control/src/scheduler.rs
@@ -19,6 +19,7 @@ use brokkr_proto::reapi_v2 as rapi;
 use prost::Message;
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot, Mutex};
+use tracing::Instrument;
 
 use crate::lease::LeaseTable;
 use crate::matching::eligible_workers;
@@ -34,6 +35,12 @@ const MAX_ATTEMPTS: u32 = 5;
 /// and a stalled / crashed worker hung the gRPC caller forever. REAPI's
 /// `Action.timeout`, when set, overrides this on a per-action basis.
 pub const DEFAULT_EXECUTION_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+
+/// Default lease duration: how long a dispatched job may run before its lease
+/// expires and it is reassigned (ADR 0009). It is capped by the action timeout
+/// and is shorter than the overall execute wait, so a hung-but-connected worker
+/// is retried elsewhere before the caller's deadline.
+pub const DEFAULT_LEASE_DURATION: Duration = Duration::from_secs(60);
 
 /// Errors returned by [`Scheduler::execute`]. Typed (instead of `anyhow`) so
 /// the gRPC service can map `Timeout` to `DEADLINE_EXCEEDED` and everything
@@ -86,6 +93,28 @@ struct Inner {
     leases: LeaseTable<PendingJob>,
 }
 
+impl Inner {
+    /// Requeue jobs taken from the lease table (on worker disconnect or lease
+    /// expiry) for reassignment, bumping each attempt count. Returns
+    /// `(requeued_count, give_up_job_ids)`; the caller fails the give-up jobs'
+    /// waiters outside the lock. Jobs go to the front so a reassignment is
+    /// retried promptly.
+    fn requeue_taken(&mut self, jobs: Vec<(JobId, PendingJob)>) -> (usize, Vec<JobId>) {
+        let mut requeued = 0usize;
+        let mut give_up: Vec<JobId> = Vec::new();
+        for (job_id, mut pj) in jobs {
+            pj.attempts += 1;
+            if pj.attempts >= MAX_ATTEMPTS {
+                give_up.push(job_id);
+            } else {
+                self.pending.push_front(pj);
+                requeued += 1;
+            }
+        }
+        (requeued, give_up)
+    }
+}
+
 /// Multi-worker job scheduler with a global pending queue and job leases
 /// (ADR 0008 + ADR 0009).
 pub struct Scheduler {
@@ -99,6 +128,9 @@ pub struct Scheduler {
     cas: Arc<dyn Cas>,
     action_cache: Arc<dyn ActionCache>,
     default_execution_timeout: Duration,
+    /// Per-attempt lease duration (capped by the action timeout). A lease that
+    /// expires before the worker reports causes the job to be reassigned.
+    lease_duration: Duration,
     /// Optional worker registry for platform-constraint filtering. When set,
     /// candidates are narrowed to healthy workers whose capabilities satisfy
     /// the action's platform; when `None` (e.g. fixtures that don't exercise
@@ -205,6 +237,7 @@ impl Scheduler {
             cas,
             action_cache,
             default_execution_timeout,
+            lease_duration: DEFAULT_LEASE_DURATION,
             worker_registry,
         })
     }
@@ -232,25 +265,9 @@ impl Scheduler {
             let mut inner = self.inner.lock().await;
             inner.connected.disconnect(worker_id);
             let held = inner.leases.take_worker(worker_id);
-            let mut requeued = 0usize;
-            let mut give_up: Vec<JobId> = Vec::new();
-            for (job_id, mut pj) in held {
-                pj.attempts += 1;
-                if pj.attempts >= MAX_ATTEMPTS {
-                    give_up.push(job_id);
-                } else {
-                    inner.pending.push_front(pj);
-                    requeued += 1;
-                }
-            }
-            (requeued, give_up)
+            inner.requeue_taken(held)
         };
-        for job_id in give_up {
-            // Too many reassignments — fail the caller by dropping its waiter
-            // (its `rx` then errors → `execute` returns an error).
-            self.waiters.lock().await.remove(&job_id);
-            tracing::error!(job_id = %job_id, "job exceeded max dispatch attempts; failing");
-        }
+        self.fail_jobs(give_up).await;
         if requeued > 0 {
             tracing::info!(
                 worker_id = %worker_id,
@@ -259,6 +276,39 @@ impl Scheduler {
             );
         }
         self.try_dispatch().await;
+    }
+
+    /// Reassign jobs whose lease has expired as of `now` (a worker that is
+    /// still connected but went silent), then attempt a dispatch. Split from
+    /// [`reap_expired_leases`] so tests can drive expiry with an explicit
+    /// instant.
+    async fn reap_expired_at(self: &Arc<Self>, now: Instant) {
+        let (requeued, give_up) = {
+            let mut inner = self.inner.lock().await;
+            let expired = inner.leases.take_expired(now);
+            inner.requeue_taken(expired)
+        };
+        self.fail_jobs(give_up).await;
+        if requeued > 0 {
+            tracing::warn!(requeued, "reassigned job(s) whose lease expired");
+            self.try_dispatch().await;
+        }
+    }
+
+    /// Reassign jobs whose lease has expired as of now. Called on an interval
+    /// by [`spawn_lease_reaper`].
+    pub async fn reap_expired_leases(self: &Arc<Self>) {
+        self.reap_expired_at(Instant::now()).await;
+    }
+
+    /// Fail each job in `job_ids` by dropping its result waiter (its `rx` then
+    /// errors → `execute` returns an error). Used when a job exceeds
+    /// [`MAX_ATTEMPTS`] reassignments.
+    async fn fail_jobs(&self, job_ids: Vec<JobId>) {
+        for job_id in job_ids {
+            self.waiters.lock().await.remove(&job_id);
+            tracing::error!(job_id = %job_id, "job exceeded max dispatch attempts; failing");
+        }
     }
 
     /// Place as many queued jobs as possible onto idle, eligible, connected
@@ -464,7 +514,9 @@ impl Scheduler {
                 job_id: job_id.clone(),
                 job,
                 platform,
-                lease_duration: effective_timeout,
+                // A single attempt may run up to the action timeout, but no
+                // longer than the lease window so a hung worker is retried.
+                lease_duration: effective_timeout.min(self.lease_duration),
                 attempts: 0,
             });
         }
@@ -547,6 +599,12 @@ impl Scheduler {
         Ok(())
     }
 
+    /// The lease window the scheduler applies to dispatched jobs. Used by
+    /// [`spawn_lease_reaper`] to pick a sensible reap interval.
+    pub fn lease_duration(&self) -> Duration {
+        self.lease_duration
+    }
+
     async fn fetch_message<M: Message + Default>(&self, digest: &Digest) -> Result<M> {
         let mut reads = self
             .cas
@@ -558,6 +616,33 @@ impl Scheduler {
             .map_err(|e| anyhow!("blob {} not in CAS: {e}", digest))?;
         M::decode(bytes.as_ref()).with_context(|| format!("decoding {} from CAS", digest))
     }
+}
+
+/// Spawn a background task that reaps expired job leases every `interval`,
+/// reassigning their jobs to other workers (ADR 0009). Mirrors
+/// [`crate::worker_service::spawn_eviction_task`]; wire it into the
+/// control-plane binary and hold the handle for the server's lifetime.
+pub fn spawn_lease_reaper(
+    scheduler: Arc<Scheduler>,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(
+        async move {
+            // `tokio::time::interval` panics on a zero period; a zero interval
+            // disables the reaper instead of crashing the server.
+            if interval == Duration::ZERO {
+                tracing::warn!("lease reaper disabled (interval is zero)");
+                return;
+            }
+            let mut ticker = tokio::time::interval(interval);
+            ticker.tick().await; // drop the immediate first tick
+            loop {
+                ticker.tick().await;
+                scheduler.reap_expired_leases().await;
+            }
+        }
+        .in_current_span(),
+    )
 }
 
 #[cfg(test)]
@@ -1059,5 +1144,86 @@ mod tests {
         let outcome = exec.await.unwrap().unwrap();
         assert_eq!(outcome.result.exit_code, 0);
         assert!(!outcome.cache_hit);
+    }
+
+    /// Drain one job from whichever of two receivers has it within `budget`.
+    async fn recv_either(
+        rx_a: &mut tokio::sync::mpsc::Receiver<bv1::Job>,
+        rx_b: &mut tokio::sync::mpsc::Receiver<bv1::Job>,
+        budget: Duration,
+    ) -> Option<bv1::Job> {
+        for _ in 0..((budget.as_millis() / 10).max(1)) {
+            if let Ok(job) = rx_a.try_recv() {
+                return Some(job);
+            }
+            if let Ok(job) = rx_b.try_recv() {
+                return Some(job);
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        None
+    }
+
+    /// An expired lease (a connected-but-silent worker) causes the job to be
+    /// requeued and re-dispatched. `reap_expired_at` is driven with a
+    /// far-future instant so the lease is unambiguously expired without
+    /// sleeping. NOTE: the re-dispatch may land on the *same* worker again — an
+    /// expired-but-connected worker is not excluded (proper "reassign
+    /// elsewhere" needs lease renewal / tried-worker tracking, a follow-up), so
+    /// this asserts the requeue + re-dispatch mechanism, not the target worker.
+    #[tokio::test]
+    async fn lease_expiry_requeues_and_redispatches_job() {
+        use crate::registry::WorkerRegistry;
+
+        let cas = Arc::new(brokkr_cas::InMemoryCas::new());
+        let action_digest = stage_action(cas.as_ref(), Some(os_platform("linux"))).await;
+        let ac = Arc::new(MockActionCache { force_error: false });
+        let registry = Arc::new(Mutex::new(WorkerRegistry::default()));
+        let scheduler = Scheduler::with_registry_and_timeout(
+            cas,
+            ac,
+            Duration::from_secs(10),
+            registry.clone(),
+        );
+        let mut rx_a = register_and_connect(&scheduler, &registry, "w-a", &[("os", "linux")]).await;
+        let mut rx_b = register_and_connect(&scheduler, &registry, "w-b", &[("os", "linux")]).await;
+
+        let exec = {
+            let s = scheduler.clone();
+            tokio::spawn(async move { s.execute(action_digest, true).await })
+        };
+
+        // First dispatch — learn the job id.
+        let first = recv_either(&mut rx_a, &mut rx_b, Duration::from_millis(500))
+            .await
+            .unwrap();
+        let job_id = first.job_id.clone();
+
+        // Force the lease past its deadline; the reaper requeues and
+        // re-dispatches the job.
+        scheduler
+            .reap_expired_at(Instant::now() + Duration::from_secs(3600))
+            .await;
+        let again = recv_either(&mut rx_a, &mut rx_b, Duration::from_millis(1000))
+            .await
+            .unwrap();
+        assert_eq!(again.job_id, job_id, "expired lease's job is re-dispatched");
+
+        // Report success for the re-dispatched job → execute completes.
+        scheduler
+            .report(bv1::JobResult {
+                job_id: job_id.clone(),
+                result: Some(rapi::ActionResult {
+                    exit_code: 0,
+                    ..Default::default()
+                }),
+                cache_hit: false,
+                error_message: String::new(),
+            })
+            .await
+            .unwrap();
+
+        let outcome = exec.await.unwrap().unwrap();
+        assert_eq!(outcome.result.exit_code, 0);
     }
 }

--- a/docs/journal/phase-4.md
+++ b/docs/journal/phase-4.md
@@ -583,3 +583,48 @@ Lease-expiry reaper (`tokio::time::interval` → `LeaseTable::take_expired`
 → requeue → `try_dispatch`), wired into the binary like the eviction
 reaper; a lease-renewal RPC for long actions; then §16 task 4's other
 halves — tenants/quotas and weighted fair queuing over the pending queue.
+
+## I13 — lease-expiry reaper (§16 task 4)
+
+- **Date:** 2026-06-28
+- **Affected crate:** `brokkr-control`
+- **Outcome:** `Scheduler::reap_expired_leases` (tested via
+  `reap_expired_at(now)`) requeues + re-dispatches jobs whose lease
+  expired — a worker still connected but gone silent — bounded by
+  `MAX_ATTEMPTS`. `spawn_lease_reaper` drives it on an interval, wired into
+  the binary at half the lease window. Jobs now carry a per-attempt
+  `lease_duration = min(action timeout, DEFAULT_LEASE_DURATION = 60s)`, so
+  a hung worker is retried before the caller's deadline (vs. the previous
+  lease == overall-timeout, where expiry coincided with giving up). 60 lib
+  tests green.
+
+### Decisions
+
+- **Shared requeue path.** Disconnect and expiry both end in
+  `Inner::requeue_taken` (bump attempts → push-front or give-up), and
+  give-up jobs are failed via `fail_jobs` (drop the waiter). One code path,
+  two triggers.
+- **Separate, shorter lease window.** Added `DEFAULT_LEASE_DURATION` (60s)
+  distinct from the overall execute timeout. Without it the lease only
+  expired when the caller had already given up, so the reaper was inert in
+  production; now a silent worker's job is retried mid-flight.
+- **Test seam `reap_expired_at(now)`.** The reaper reads `Instant::now()`;
+  splitting out an instant-taking inner method lets the test force expiry
+  with a far-future instant — deterministic, no sleeping on the real lease
+  window.
+- **Known limitation: expired-but-connected workers aren't excluded.**
+  Unlike disconnect (which removes the worker), an expired lease leaves the
+  worker connected, so the deterministic `Strategy` may re-pick it. The job
+  still makes progress (or fails after `MAX_ATTEMPTS`), but "reassign
+  strictly elsewhere" wants lease **renewal** (so a merely-slow worker
+  keeps its lease) or per-job tried-worker tracking. Documented + pinned by
+  a mechanism-level test (asserts re-dispatch, not the target). Renewal is
+  the natural next lease increment.
+
+### Next
+
+Lease renewal RPC (long-running actions extend their lease; only truly
+silent/dead workers expire), which also fixes the re-pick limitation. Then
+§16 task 4's other half: **tenants/quotas + weighted fair queuing** over
+the pending queue (the "two tenants get fair share" DoD) — its own ADR
+(0010) + an options check-in before implementing.


### PR DESCRIPTION
## Motivation

#107 delivered crash recovery via worker *disconnect*. This adds the other half of lease-based recovery: a worker that stays connected but goes **silent** past its lease. Its job is now requeued and re-dispatched instead of hanging until the caller's timeout.

## What changed

- `Scheduler::reap_expired_leases` (test seam `reap_expired_at(now)`) — `take_expired` → requeue (bump attempts, bounded by `MAX_ATTEMPTS`) → `try_dispatch`.
- `spawn_lease_reaper(scheduler, interval)` drives it on a tick; wired into the `brokkr-control` binary at half the lease window. Zero interval disables it (mirrors `spawn_eviction_task`).
- Jobs carry a per-attempt `lease_duration = min(action timeout, DEFAULT_LEASE_DURATION = 60s)`, **distinct from the overall execute wait** — so a hung worker is retried mid-flight rather than only when the caller gives up.
- Disconnect + expiry share `Inner::requeue_taken`; give-up jobs are failed via `fail_jobs`.

## How it was tested

`lease_expiry_requeues_and_redispatches_job` forces a lease past its deadline (far-future instant, no sleeping) and asserts the job is re-dispatched and completes. 60 lib tests + real-gRPC `end_to_end` + 200-RPC soak green; `brokkr-control` fmt + `clippy -D warnings` clean in WSL2.

## Known limitation (documented, follow-up)

An expired-but-**connected** worker isn't excluded from the re-dispatch (unlike disconnect, which removes the worker), so the deterministic `Strategy` may re-pick it. The job still progresses or fails after `MAX_ATTEMPTS`; "reassign strictly elsewhere" wants lease **renewal** (a merely-slow worker keeps its lease) or per-job tried-worker tracking — the natural next lease increment. The test asserts the requeue+re-dispatch *mechanism*, not the target worker.

## Related

`docs/plan.md` §16 task 4; ADR 0009; `docs/journal/phase-4.md` (I13). Builds on #103, #107.