### PR TITLE
feat(control): lease renewal via heartbeat (Phase 4 §16 task 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -764,3 +764,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   expired-but-connected worker is not yet excluded from the re-dispatch
   (it may be re-picked); "reassign strictly elsewhere" needs lease renewal
   / tried-worker tracking — a follow-up.
+- `brokkr-control` lease renewal via heartbeat: each worker heartbeat now
+  renews the leases that worker holds (`Scheduler::renew_worker_leases` →
+  `LeaseTable::renew_worker`), so a lease expires only when a worker stops
+  heartbeating (dead / partitioned) rather than merely running a long
+  action. This aligns lease lifetime with heartbeat liveness and resolves
+  the I13 caveat: a live, heartbeating worker never has its lease expire,
+  so it can't be re-picked; only a genuinely silent worker's job is
+  reassigned (and that worker is also evicted from the registry). No proto
+  or worker-side change — it reuses the existing `Heartbeat` RPC. Two
+  `LeaseTable::renew_worker` unit tests.

--- a/crates/brokkr-control/src/lease.rs
+++ b/crates/brokkr-control/src/lease.rs
@@ -119,6 +119,20 @@ impl<P> LeaseTable<P> {
         Self::drain(&mut self.leases, held)
     }
 
+    /// Extend the deadline of every lease held by `worker_id` to `new_deadline`
+    /// (e.g. on a heartbeat — the worker is alive, so keep its job leased).
+    /// Returns the number of leases renewed.
+    pub fn renew_worker(&mut self, worker_id: &WorkerId, new_deadline: Instant) -> usize {
+        let mut renewed = 0;
+        for lease in self.leases.values_mut() {
+            if &lease.worker_id == worker_id {
+                lease.deadline = new_deadline;
+                renewed += 1;
+            }
+        }
+        renewed
+    }
+
     fn drain(leases: &mut HashMap<JobId, Lease<P>>, mut ids: Vec<JobId>) -> Vec<(JobId, P)> {
         ids.sort_by(|a, b| a.as_str().cmp(b.as_str()));
         ids.into_iter()
@@ -240,6 +254,34 @@ mod tests {
     fn take_worker_unknown_is_empty() {
         let mut t: LeaseTable<&str> = LeaseTable::new();
         assert!(t.take_worker(&wid("nobody")).is_empty());
+    }
+
+    #[test]
+    fn renew_worker_extends_deadline_and_defers_expiry() {
+        let t0 = Instant::now();
+        let mut t = LeaseTable::new();
+        t.insert(jid("j1"), wid("w1"), t0 + Duration::from_secs(10), "a");
+        t.insert(jid("j2"), wid("w1"), t0 + Duration::from_secs(10), "b");
+        t.insert(jid("j3"), wid("w2"), t0 + Duration::from_secs(10), "c");
+
+        // Heartbeat from w1 pushes its two leases out to t0+100s.
+        let renewed = t.renew_worker(&wid("w1"), t0 + Duration::from_secs(100));
+        assert_eq!(renewed, 2);
+
+        // At t0+50s only w2's (un-renewed) lease has expired.
+        let expired = t.take_expired(t0 + Duration::from_secs(50));
+        let ids: Vec<&str> = expired.iter().map(|(id, _)| id.as_str()).collect();
+        assert_eq!(ids, vec!["j3"]);
+        assert_eq!(t.len(), 2); // w1's renewed leases survive
+
+        // Past the renewed deadline they expire too.
+        assert_eq!(t.take_expired(t0 + Duration::from_secs(101)).len(), 2);
+    }
+
+    #[test]
+    fn renew_worker_unknown_renews_nothing() {
+        let mut t: LeaseTable<&str> = LeaseTable::new();
+        assert_eq!(t.renew_worker(&wid("nobody"), Instant::now()), 0);
     }
 
     #[test]

--- a/crates/brokkr-control/src/scheduler.rs
+++ b/crates/brokkr-control/src/scheduler.rs
@@ -301,6 +301,17 @@ impl Scheduler {
         self.reap_expired_at(Instant::now()).await;
     }
 
+    /// Renew the leases held by `worker_id`, pushing their deadlines out by the
+    /// lease window. Called on each heartbeat: a worker that is alive (still
+    /// heartbeating) keeps its in-flight job leased rather than having it
+    /// expire and be reassigned. A lease therefore expires only when a worker
+    /// stops heartbeating (dead / partitioned). Returns the number renewed.
+    pub async fn renew_worker_leases(&self, worker_id: &WorkerId) -> usize {
+        let new_deadline = Instant::now() + self.lease_duration;
+        let mut inner = self.inner.lock().await;
+        inner.leases.renew_worker(worker_id, new_deadline)
+    }
+
     /// Fail each job in `job_ids` by dropping its result waiter (its `rx` then
     /// errors → `execute` returns an error). Used when a job exceeds
     /// [`MAX_ATTEMPTS`] reassignments.

--- a/crates/brokkr-control/src/worker_service.rs
+++ b/crates/brokkr-control/src/worker_service.rs
@@ -163,7 +163,12 @@ impl WorkerService for WorkerServiceImpl {
                 .is_ok()
         };
         tracing::Span::current().record("known", known);
-        if !known {
+        if known {
+            // The worker is alive — renew the lease on whatever job it's
+            // running so a long action isn't reassigned out from under it. A
+            // lease only expires once a worker stops heartbeating (ADR 0009).
+            self.scheduler.renew_worker_leases(&worker_id).await;
+        } else {
             tracing::warn!("heartbeat from unknown worker; signalling re-register");
         }
         Ok(Response::new(HeartbeatResponse { known }))

--- a/docs/journal/phase-4.md
+++ b/docs/journal/phase-4.md
@@ -628,3 +628,45 @@ silent/dead workers expire), which also fixes the re-pick limitation. Then
 §16 task 4's other half: **tenants/quotas + weighted fair queuing** over
 the pending queue (the "two tenants get fair share" DoD) — its own ADR
 (0010) + an options check-in before implementing.
+
+## I14 — lease renewal via heartbeat (§16 task 4)
+
+- **Date:** 2026-06-28
+- **Affected crate:** `brokkr-control`
+- **Outcome:** Each worker heartbeat renews the leases that worker holds
+  (`Scheduler::renew_worker_leases` → `LeaseTable::renew_worker`), so a
+  lease expires only when a worker *stops heartbeating*, not merely because
+  it's running a long action. Closes the lease lifecycle. 62 lib tests
+  green.
+
+### Decisions
+
+- **Renew on heartbeat, not a new RPC.** The simplest, most elegant
+  design: the worker already heartbeats every `heartbeat_seconds` to prove
+  liveness; piggybacking lease renewal on that signal means *no proto
+  change and no worker-side change*. Lease lifetime becomes "the worker is
+  alive" — exactly what a lease should track. A dedicated `RenewLease` RPC
+  (or an `active_job_id` on the heartbeat) would only matter if we needed
+  per-job renewal semantics; with capacity-1 "renew the worker's lease" is
+  unambiguous.
+- **This resolves the I13 re-pick caveat.** Because a live worker's lease
+  is renewed every heartbeat (5s) and the lease window is 60s, a healthy
+  worker's lease never expires → it's never wrongly reassigned/re-picked.
+  Only a worker that genuinely stopped heartbeating expires — and that
+  worker is also being evicted from the registry and will disconnect, so
+  the reassignment lands elsewhere. Lease expiry is now a true
+  dead-worker backstop, complementing disconnect-based recovery.
+- **Hung-action bound is the action timeout, not the lease.** A worker that
+  is alive (heartbeating) but stuck in an infinite-loop action keeps its
+  lease renewed; the *action timeout* (`execute`'s overall wait) is what
+  bounds that case and returns `Timeout`. Lease = worker liveness; action
+  timeout = work liveness. Clean separation.
+
+### §16 task 4 status
+
+Lease machinery is complete: global queue (I12), crash reassignment on
+disconnect (I12), expiry reaper (I13), renewal on heartbeat (I14).
+**Remaining:** tenants/quotas + weighted fair queuing — the "two tenants
+get fair share" DoD. That's the next milestone: ADR 0010 + an
+AskUserQuestion on tenant-id source, quota types, and the WFQ algorithm
+before implementing.


### PR DESCRIPTION
## Motivation

Completes the lease lifecycle. After #107 (crash reassignment on disconnect) and #110 (expiry reaper), a lease still expired purely on a fixed timer — so a worker running a *long but healthy* action could have its job reassigned out from under it, and an expired-but-connected worker could be re-picked (the #110 caveat). This ties lease lifetime to **heartbeat liveness**.

## What changed

- `LeaseTable::renew_worker(worker_id, new_deadline)` — extend every lease a worker holds.
- `Scheduler::renew_worker_leases(worker_id)` — push the worker's lease deadlines out by the lease window.
- The `Heartbeat` handler calls it on every heartbeat: a worker that's alive (still heartbeating, every ~5s) keeps its 60s lease renewed, so **a lease expires only when a worker stops heartbeating** (dead / partitioned).

**No proto change and no worker-side change** — it reuses the existing `Heartbeat` RPC.

## Why this is the right model

- Lease lifetime = *worker* liveness (heartbeat); the action timeout (`execute`'s overall wait) = *work* liveness. A hung-but-alive action is bounded by the action timeout, not the lease.
- Resolves the #110 caveat: a healthy worker's lease never expires → it can't be wrongly re-picked. Only a genuinely silent worker expires, and that worker is also being evicted from the registry → reassignment lands elsewhere.

## How it was tested

`renew_worker_extends_deadline_and_defers_expiry` + `renew_worker_unknown_renews_nothing`; existing heartbeat-handler tests still pass. 62 lib tests + real-gRPC e2e + 200-RPC soak green; `brokkr-control` fmt + `clippy -D warnings` clean in WSL2.

## Related

`docs/plan.md` §16 task 4; ADR 0009; `docs/journal/phase-4.md` (I14). Builds on #103, #107, #110. **This completes the lease machinery**; next is task 4's other half — tenants/quotas + fair scheduling (ADR 0010, options check-in first).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker heartbeats now refresh active job leases, helping keep in-progress work assigned to the same worker while it continues responding.
  * Lease handling now tracks worker liveness more accurately, reducing unnecessary re-dispatches.

* **Tests**
  * Added coverage for lease renewal behavior, including successful renewal and no-op handling for unknown workers.

* **Documentation**
  * Updated the changelog and project journal to reflect the new heartbeat-based lease renewal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->