### PR TITLE
feat(common,control): tenant id + fair-queue foundation + ADR 0010 (Phase 4 §16 task 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -774,3 +774,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reassigned (and that worker is also evicted from the registry). No proto
   or worker-side change — it reuses the existing `Heartbeat` RPC. Two
   `LeaseTable::renew_worker` unit tests.
+- ADR 0010 — tenants + weighted fair scheduling: tenant id from a gRPC
+  metadata header (`x-brokkr-tenant`, default fallback) and virtual-time
+  Start-time Fair Queuing over per-tenant-tagged pending jobs.
+  `docs/architecture/0010-tenants-and-fair-scheduling.md`.
+- `brokkr_common::TenantId` — tenant identifier newtype (`Default` =
+  `"default"`, `DEFAULT_TENANT`), same validation as the other id
+  newtypes. Two unit tests.
+- `brokkr-control::fairqueue::FairQueue<J>` (plan §16 task 4 foundation):
+  a pure, generic Start-time Fair Queue. `push(tenant, job)` assigns an
+  SFQ virtual start tag (`start = max(virtual_time, last_finish[tenant])`,
+  tenant clock += `cost/weight`, unit cost); `slots()` + `take(index)` let
+  the scheduler dequeue the lowest-start-tag *dispatchable* job (respecting
+  worker eligibility); `pop()` / `set_weight` / `retain` round it out.
+  Seven unit tests (single-tenant FIFO, equal-tenant interleave,
+  weight-proportional service, eligibility-filtered take, idle-tenant
+  no-hoard). Wiring into the scheduler is the next increment.

--- a/crates/brokkr-common/src/ids.rs
+++ b/crates/brokkr-common/src/ids.rs
@@ -172,6 +172,84 @@ impl TryFrom<&str> for JobId {
     }
 }
 
+/// The tenant id used when a request carries no explicit tenant.
+pub const DEFAULT_TENANT: &str = "default";
+
+/// A tenant (authenticated entity) identifier. Carried through the control
+/// plane for quota accounting and fair scheduling; the source is a request
+/// metadata header until auth makes it authoritative (plan §16 task 8).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(try_from = "String")]
+pub struct TenantId(String);
+
+impl TenantId {
+    /// Construct a [`TenantId`], validating it is non-empty and within
+    /// [`ID_MAX_LEN`].
+    pub fn new(inner: String) -> Result<Self, IdError> {
+        if inner.is_empty() {
+            return Err(IdError::Empty);
+        }
+        if inner.len() > ID_MAX_LEN {
+            return Err(IdError::TooLong {
+                max: ID_MAX_LEN,
+                len: inner.len(),
+            });
+        }
+        Ok(Self(inner))
+    }
+
+    /// Returns the raw string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consumes self and returns the inner [`String`].
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl Default for TenantId {
+    fn default() -> Self {
+        Self(DEFAULT_TENANT.to_string())
+    }
+}
+
+impl fmt::Display for TenantId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for TenantId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for TenantId {
+    type Err = IdError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s.to_string())
+    }
+}
+
+impl TryFrom<String> for TenantId {
+    type Error = IdError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl TryFrom<&str> for TenantId {
+    type Error = IdError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::new(value.to_string())
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::panic, clippy::disallowed_methods)]
 mod tests {
@@ -253,5 +331,21 @@ mod tests {
         map.insert(id.clone(), "value");
         // Should work with &str lookup via Borrow<str>
         assert_eq!(map.remove("job-key"), Some("value"));
+    }
+
+    // TenantId tests
+    #[test]
+    fn tenant_id_default_is_default_tenant() {
+        assert_eq!(TenantId::default().as_str(), DEFAULT_TENANT);
+        assert_eq!(DEFAULT_TENANT, "default");
+    }
+
+    #[test]
+    fn tenant_id_new_validates_and_roundtrips() {
+        assert_eq!(TenantId::new(String::new()).unwrap_err(), IdError::Empty);
+        let id = TenantId::new("team-acme".to_string()).unwrap();
+        assert_eq!(id.as_str(), "team-acme");
+        let parsed: TenantId = id.to_string().parse().unwrap();
+        assert_eq!(id, parsed);
     }
 }

--- a/crates/brokkr-common/src/lib.rs
+++ b/crates/brokkr-common/src/lib.rs
@@ -9,4 +9,4 @@ pub mod digest;
 pub mod ids;
 
 pub use digest::{Digest, DigestError};
-pub use ids::{IdError, JobId, WorkerId};
+pub use ids::{IdError, JobId, TenantId, WorkerId, DEFAULT_TENANT};

--- a/crates/brokkr-control/src/fairqueue.rs
+++ b/crates/brokkr-control/src/fairqueue.rs
@@ -1,0 +1,294 @@
+//! Per-tenant virtual-time fair queue (Start-time Fair Queuing) for the
+//! scheduler's pending jobs (ADR 0010).
+//!
+//! Each enqueued job is tagged with a virtual *start* time
+//! `start = max(virtual_time, last_finish[tenant])`, and its tenant's clock
+//! advances by `cost / weight`. Jobs are serviced in increasing start-tag
+//! order, which gives each tenant a share of dispatch slots proportional to its
+//! weight. Action cost is unknown up front, so every job is unit cost — a
+//! weight-2 tenant is simply serviced twice as often as a weight-1 tenant.
+//!
+//! Dequeue is *eligibility-constrained*: the scheduler doesn't always want the
+//! global minimum start tag, but the lowest-start-tag job that has an idle
+//! eligible worker. So this structure exposes its entries (in no particular
+//! order, each with its start tag) for the caller to scan, plus a `take(index)`
+//! that removes a chosen entry and advances virtual time — mirroring how the
+//! scheduler already scans its pending list under one lock.
+//!
+//! Pure + generic over the job payload `J` so it is unit-testable without the
+//! scheduler's job types. Not internally synchronized.
+
+use std::collections::HashMap;
+
+use brokkr_common::TenantId;
+
+/// Virtual-time cost of one unit-weight job. A tenant of weight `w` advances
+/// its virtual clock by `COST / w` per job, so higher weight ⇒ smaller
+/// increments ⇒ more frequent service. Picked large enough that integer
+/// division by realistic weights keeps useful resolution.
+const COST: u64 = 1_000_000;
+
+struct Entry<J> {
+    start: u64,
+    job: J,
+}
+
+/// A borrowed view of one queued job: its index (for [`FairQueue::take`]), its
+/// virtual start tag, and the job payload.
+pub struct Slot<'a, J> {
+    /// Index for [`FairQueue::take`]. Valid until the next mutation.
+    pub index: usize,
+    /// Virtual start tag — lower means "more owed service".
+    pub start: u64,
+    /// The queued job.
+    pub job: &'a J,
+}
+
+/// Start-time fair queue keyed by tenant.
+pub struct FairQueue<J> {
+    entries: Vec<Entry<J>>,
+    virtual_time: u64,
+    tenant_finish: HashMap<TenantId, u64>,
+    weights: HashMap<TenantId, u32>,
+}
+
+impl<J> Default for FairQueue<J> {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            virtual_time: 0,
+            tenant_finish: HashMap::new(),
+            weights: HashMap::new(),
+        }
+    }
+}
+
+impl<J> FairQueue<J> {
+    /// An empty fair queue.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set a tenant's scheduling weight (default 1). A weight-2 tenant is
+    /// serviced about twice as often as a weight-1 tenant. Zero is clamped to 1.
+    pub fn set_weight(&mut self, tenant: TenantId, weight: u32) {
+        self.weights.insert(tenant, weight.max(1));
+    }
+
+    fn weight_of(&self, tenant: &TenantId) -> u64 {
+        self.weights.get(tenant).copied().unwrap_or(1).max(1) as u64
+    }
+
+    /// Number of queued jobs.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Whether the queue is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Enqueue `job` for `tenant`, assigning it an SFQ start tag.
+    pub fn push(&mut self, tenant: TenantId, job: J) {
+        let weight = self.weight_of(&tenant);
+        let last_finish = self.tenant_finish.get(&tenant).copied().unwrap_or(0);
+        let start = self.virtual_time.max(last_finish);
+        let finish = start.saturating_add(COST / weight);
+        self.tenant_finish.insert(tenant, finish);
+        self.entries.push(Entry { start, job });
+    }
+
+    /// Iterate queued jobs as [`Slot`]s (unordered). The caller picks the
+    /// lowest-`start` slot that is dispatchable and calls [`take`](Self::take).
+    pub fn slots(&self) -> impl Iterator<Item = Slot<'_, J>> {
+        self.entries.iter().enumerate().map(|(index, e)| Slot {
+            index,
+            start: e.start,
+            job: &e.job,
+        })
+    }
+
+    /// Remove the entry at `index`, returning its job and advancing virtual
+    /// time to that entry's start tag (the SFQ service rule). `None` if the
+    /// index is out of range.
+    pub fn take(&mut self, index: usize) -> Option<J> {
+        if index >= self.entries.len() {
+            return None;
+        }
+        let entry = self.entries.swap_remove(index);
+        self.virtual_time = self.virtual_time.max(entry.start);
+        Some(entry.job)
+    }
+
+    /// Pop the globally lowest-start-tag job (no eligibility constraint).
+    /// Convenience for callers / tests that don't filter; equivalent to taking
+    /// the minimum-`start` slot.
+    pub fn pop(&mut self) -> Option<J> {
+        let idx = self
+            .entries
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, e)| e.start)
+            .map(|(i, _)| i)?;
+        self.take(idx)
+    }
+
+    /// Drop queued jobs for which `keep` returns false (e.g. a job whose caller
+    /// timed out). Does not touch virtual-time bookkeeping.
+    pub fn retain<F: FnMut(&J) -> bool>(&mut self, mut keep: F) {
+        self.entries.retain(|e| keep(&e.job));
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::disallowed_methods, clippy::panic)]
+mod tests {
+    use super::*;
+
+    fn tid(s: &str) -> TenantId {
+        TenantId::new(s.to_string()).unwrap()
+    }
+
+    /// Drain the whole queue in service (start-tag) order via `pop`.
+    fn drain<J>(q: &mut FairQueue<J>) -> Vec<J> {
+        let mut out = Vec::new();
+        while let Some(j) = q.pop() {
+            out.push(j);
+        }
+        out
+    }
+
+    #[test]
+    fn empty_queue() {
+        let mut q: FairQueue<u32> = FairQueue::new();
+        assert!(q.is_empty());
+        assert_eq!(q.len(), 0);
+        assert!(q.pop().is_none());
+    }
+
+    #[test]
+    fn single_tenant_is_fifo() {
+        let mut q = FairQueue::new();
+        for i in 0..5 {
+            q.push(tid("a"), i);
+        }
+        assert_eq!(drain(&mut q), vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn two_equal_tenants_interleave() {
+        let mut q = FairQueue::new();
+        // All of A enqueued, then all of B — fair queuing must still interleave
+        // them rather than serving all of A first.
+        for i in 0..3 {
+            q.push(tid("a"), format!("a{i}"));
+        }
+        for i in 0..3 {
+            q.push(tid("b"), format!("b{i}"));
+        }
+        let order = drain(&mut q);
+        // Equal weights ⇒ A and B alternate (ties broken by insertion via
+        // swap_remove/min, but each tenant keeps its internal order).
+        let a_positions: Vec<usize> = order
+            .iter()
+            .enumerate()
+            .filter(|(_, s)| s.starts_with('a'))
+            .map(|(i, _)| i)
+            .collect();
+        // A's three jobs land at alternating-ish positions, not all up front:
+        // with fair queuing the last A job is not before the first B job.
+        assert!(
+            a_positions.iter().max().unwrap() >= &2,
+            "fair queue should interleave tenants, got {order:?}"
+        );
+        // Each tenant's own jobs stay in order.
+        let a_order: Vec<&String> = order.iter().filter(|s| s.starts_with('a')).collect();
+        assert_eq!(a_order, vec!["a0", "a1", "a2"]);
+    }
+
+    #[test]
+    fn higher_weight_tenant_serviced_more_often() {
+        let mut q = FairQueue::new();
+        q.set_weight(tid("big"), 3);
+        q.set_weight(tid("small"), 1);
+        // Plenty of jobs from both, enqueued small-first to be adversarial.
+        for i in 0..9 {
+            q.push(tid("small"), format!("s{i}"));
+        }
+        for i in 0..9 {
+            q.push(tid("big"), format!("b{i}"));
+        }
+        // Over the first 8 dispatches, the weight-3 tenant should get clearly
+        // more than the weight-1 tenant.
+        let mut big = 0;
+        let mut small = 0;
+        for _ in 0..8 {
+            match q.pop().unwrap().chars().next().unwrap() {
+                'b' => big += 1,
+                's' => small += 1,
+                _ => unreachable!(),
+            }
+        }
+        assert!(
+            big > small,
+            "weight-3 tenant should be serviced more: big={big} small={small}"
+        );
+    }
+
+    #[test]
+    fn take_lowest_eligible_slot_respects_a_filter() {
+        // Mimics the scheduler: only "b*" jobs are dispatchable right now.
+        let mut q = FairQueue::new();
+        q.push(tid("a"), "a0".to_string());
+        q.push(tid("b"), "b0".to_string());
+        q.push(tid("a"), "a1".to_string());
+
+        // Pick the lowest-start slot whose job starts with 'b'.
+        let idx = q
+            .slots()
+            .filter(|s| s.job.starts_with('b'))
+            .min_by_key(|s| s.start)
+            .map(|s| s.index)
+            .unwrap();
+        assert_eq!(q.take(idx).unwrap(), "b0");
+        assert_eq!(q.len(), 2);
+        // The a* jobs remain.
+        assert_eq!(drain(&mut q), vec!["a0".to_string(), "a1".to_string()]);
+    }
+
+    #[test]
+    fn retain_drops_matching_jobs() {
+        let mut q = FairQueue::new();
+        q.push(tid("a"), 1u32);
+        q.push(tid("a"), 2);
+        q.push(tid("a"), 3);
+        q.retain(|j| *j != 2);
+        assert_eq!(drain(&mut q), vec![1, 3]);
+    }
+
+    #[test]
+    fn idle_tenant_does_not_hoard_backlog_credit() {
+        // A tenant that was absent shouldn't get a burst of priority when it
+        // returns: its start tag is clamped to the current virtual time, not
+        // its stale finish tag.
+        let mut q = FairQueue::new();
+        q.push(tid("a"), "a0".to_string());
+        // Service a few of A so virtual_time advances.
+        let _ = q.pop();
+        q.push(tid("a"), "a1".to_string());
+        let _ = q.pop();
+        // Now B arrives for the first time and A also has one queued.
+        q.push(tid("a"), "a2".to_string());
+        q.push(tid("b"), "b0".to_string());
+        // B's start tag is the current virtual time, so it isn't starved behind
+        // A's accumulated finish tag — B should be served no later than A here.
+        let order = drain(&mut q);
+        let b_pos = order.iter().position(|s| s == "b0").unwrap();
+        let a2_pos = order.iter().position(|s| s == "a2").unwrap();
+        assert!(
+            b_pos <= a2_pos,
+            "newly-arriving tenant must not be starved: {order:?}"
+        );
+    }
+}

--- a/crates/brokkr-control/src/lib.rs
+++ b/crates/brokkr-control/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![deny(missing_docs)]
 
+pub mod fairqueue;
 pub mod lease;
 pub mod matching;
 pub mod membership;
@@ -15,6 +16,7 @@ pub mod scheduling;
 pub mod services;
 pub mod worker_service;
 
+pub use fairqueue::FairQueue;
 pub use lease::LeaseTable;
 pub use matching::{eligible_workers, labels_satisfy_platform, worker_satisfies};
 pub use membership::{Membership, MembershipServiceImpl};

--- a/docs/architecture/0010-tenants-and-fair-scheduling.md
+++ b/docs/architecture/0010-tenants-and-fair-scheduling.md
@@ -1,0 +1,87 @@
+# 0010 — Tenants and weighted fair scheduling
+
+- **Status:** accepted
+- **Date:** 2026-06-28
+- **Deciders:** Brokkr maintainers
+
+## Context
+
+Phase 4 §16 task 4 calls for multi-tenancy: every request carries a tenant id,
+tenants have quotas (max concurrent jobs, CPU-seconds/day, storage), and the
+scheduler shares capacity fairly — "two tenants running concurrently each get
+fair share" is a §16 definition-of-done item. The scheduler currently has a
+single global FIFO pending queue (ADR 0009); fairness needs per-tenant
+accounting on top of it.
+
+Auth-derived identity is a *later* task (§16 task 8). This ADR covers how
+tenancy and fair scheduling work *before* auth lands, in a way auth can slot
+into without rework.
+
+## Decision
+
+**Tenant id from a gRPC metadata header; virtual-time (start-time) fair queuing
+over per-tenant-tagged pending jobs.**
+
+### Tenant identity
+
+- The control plane reads the tenant id from a request metadata header,
+  `x-brokkr-tenant`, falling back to a `"default"` tenant when absent. A
+  `brokkr_common::TenantId` newtype carries it through the scheduler.
+- This is **client-asserted** until auth (§16 task 8); auth then becomes the
+  authoritative source of the same `TenantId`, so no plumbing changes. We do
+  **not** overload the REAPI `instance_name` field (it means routing/namespace,
+  not identity).
+
+### Fair queuing — virtual-time SFQ
+
+- The global pending queue becomes a **per-tenant-tagged** fair queue using
+  **Start-time Fair Queuing (SFQ)**: each enqueued job gets a virtual *start*
+  tag `start = max(virtual_time, last_finish[tenant])` and advances its tenant's
+  clock by `cost / weight`; the scheduler services jobs in increasing start-tag
+  order, setting `virtual_time` to the start tag of the job it dispatches.
+- **Unit cost.** Action cost is unknown up front (we don't know runtime), so
+  every job is cost 1. With per-tenant `weight`, a weight-2 tenant is serviced
+  twice as often as a weight-1 tenant — proportional share without needing to
+  predict job size.
+- **Eligibility-constrained dequeue.** Dispatch still respects platform
+  matching + idle workers (ADR 0008/0009): the scheduler dequeues the
+  *lowest-start-tag job that has an idle eligible worker*, not strictly the
+  global minimum. So fairness degrades gracefully when a tenant's jobs can only
+  run on busy/again-constrained workers.
+- Integer fixed-point virtual time (no floats) keeps it deterministic and
+  `Ord`-clean for tests.
+
+### Quotas
+
+- Enforced at admission in `execute`, starting with **max concurrent jobs** per
+  tenant (the cheapest to track: a per-tenant in-flight gauge). CPU-seconds/day
+  and storage quotas are later sub-increments (they need usage accounting that
+  doesn't exist yet). Over-quota → gRPC `RESOURCE_EXHAUSTED`.
+
+## Alternatives considered
+
+- **Deficit/weighted round-robin** instead of SFQ. Simpler, but coarser and
+  less precise under bursty arrivals; SFQ gives cleaner proportional share and
+  is the textbook fit. Chosen against per the owner's call.
+- **REAPI `instance_name` as tenant.** Rejected — conflates routing with
+  identity and gets awkward when auth lands.
+- **Tenant only after auth.** Rejected — we want to demo the two-tenant
+  fair-share DoD now; the header is a fine pre-auth source.
+
+## Consequences
+
+- **Positive:** Delivers the fair-share DoD; the SFQ structure is a small,
+  pure, unit-testable component; auth later just supplies the `TenantId`.
+- **Negative:** Unit cost means a tenant submitting many tiny jobs and one
+  submitting few huge jobs are treated equally per-job, not per-CPU-second —
+  acceptable until usage accounting (CPU-second quotas) exists. Client-asserted
+  tenant id is spoofable until auth (documented; task 8 closes it).
+- **Neutral:** Per-worker capacity stays 1 (ADR 0009); fairness is over
+  *dispatch order*, not over concurrent slots-per-tenant (that's the
+  max-concurrent quota's job).
+
+## References
+
+- `docs/plan.md` §6.3, §16 task 4 + DoD, §16 task 8 (auth)
+- ADR 0008 (multi-worker scheduling), ADR 0009 (leases + global queue)
+- SFQ: Goyal, Vin, Cheng, "Start-time Fair Queueing" (SIGCOMM '96)

--- a/docs/journal/phase-4.md
+++ b/docs/journal/phase-4.md
@@ -670,3 +670,47 @@ disconnect (I12), expiry reaper (I13), renewal on heartbeat (I14).
 get fair share" DoD. That's the next milestone: ADR 0010 + an
 AskUserQuestion on tenant-id source, quota types, and the WFQ algorithm
 before implementing.
+
+## I15 — tenants + fair-queue foundation (§16 task 4, ADR 0010)
+
+- **Date:** 2026-06-28
+- **Affected crates:** `brokkr-common`, `brokkr-control` (+ ADR 0010)
+- **Decisions taken with the owner:** tenant id from a **gRPC metadata
+  header** (`x-brokkr-tenant`, default fallback); **virtual-time WFQ
+  (SFQ)** for fair sharing.
+- **Outcome:** ADR 0010 records the design. `brokkr_common::TenantId`
+  newtype + `brokkr-control::fairqueue::FairQueue<J>`, a pure Start-time
+  Fair Queue: per-tenant virtual start tags, weight-proportional service,
+  eligibility-constrained dequeue via `slots()` + `take(index)`. 7 fair-queue
+  + 2 tenant unit tests; both crates green. Scheduler wiring is I16.
+
+### Decisions
+
+- **SFQ with unit cost.** Action runtime is unknown up front, so every job
+  is cost 1; a tenant of weight `w` advances its virtual clock by `COST/w`
+  per job, so weight-2 is serviced ~2× as often. Integer fixed-point
+  virtual time (no floats) keeps it deterministic + `Ord`-clean.
+- **Eligibility-constrained dequeue, not strict global min.** Dispatch must
+  still honour platform matching + idle workers (ADR 0008/0009), so
+  `FairQueue` exposes `slots()` (each with its start tag) for the scheduler
+  to scan and `take(index)` to remove the chosen one + advance virtual
+  time. This mirrors the existing under-one-lock scan in `try_dispatch`, so
+  wiring it in won't reintroduce a borrow/lock tangle. A `pop()` convenience
+  (global min) backs the unit tests.
+- **Header-sourced tenant id, pre-auth.** `x-brokkr-tenant` with a
+  `"default"` fallback; client-asserted until auth (§16 task 8) makes it
+  authoritative. Deliberately *not* REAPI `instance_name` (routing, not
+  identity).
+- **Foundation split from wiring.** I15 is the pure, fully-unit-tested
+  pieces; I16 replaces `Inner.pending: VecDeque<PendingJob>` with the
+  `FairQueue`, extracts the tenant in the `Execution`/`WorkerService`
+  handlers, threads it into `PendingJob`, and switches `try_dispatch`'s
+  scan to `slots()`/`take`. I17 adds the max-concurrent-per-tenant quota at
+  admission.
+
+### Next increment (I16)
+
+Wire `FairQueue` into the scheduler: tenant extraction in `execute`
+(header → `TenantId`), `PendingJob.tenant`, `Inner.pending: FairQueue`,
+`try_dispatch` scans `slots()` for the lowest-start dispatchable job. Then
+a two-tenant fairness integration test (the §16 DoD), and I17 quotas.


### PR DESCRIPTION
## Motivation

The last piece of Phase 4 §16 task 4: multi-tenancy + fair scheduling (the "two tenants running concurrently each get fair share" DoD). This lands the design (ADR 0010) and the tested foundation; scheduler wiring follows.

## Decisions (ADR 0010, with the owner)

- **Tenant id** from a gRPC metadata header `x-brokkr-tenant` (default `"default"`); client-asserted until auth (§16 task 8) makes it authoritative. Not REAPI `instance_name` (that's routing, not identity).
- **Virtual-time WFQ** — Start-time Fair Queuing over per-tenant-tagged jobs; unit cost (action runtime is unknown up front), weight-proportional service.

## What changed (this commit — I15)

- `brokkr_common::TenantId` newtype (`Default` = `"default"`, `DEFAULT_TENANT`).
- `brokkr-control::fairqueue::FairQueue<J>` — pure, generic SFQ:
  - `push(tenant, job)` assigns a virtual start tag (`start = max(virtual_time, last_finish[tenant])`, tenant clock `+= COST/weight`).
  - `slots()` + `take(index)` — the scheduler scans for the lowest-start-tag **dispatchable** job (respecting worker eligibility) and removes it, advancing virtual time.
  - `pop()` / `set_weight` / `retain`.

Pure foundation only — no scheduler behaviour change yet.

## How it was tested

7 fair-queue unit tests (single-tenant FIFO, equal-tenant interleave, weight-proportional service, eligibility-filtered take, idle-tenant no-hoard) + 2 `TenantId` tests. `brokkr-common` + `brokkr-control` fmt + `clippy -D warnings` + test green in WSL2 (69 control lib tests).

## Next on this milestone (I16 / I17)

- **I16:** replace `Inner.pending: VecDeque` with `FairQueue`, extract the tenant in the `Execution` handler, thread it into `PendingJob`, switch `try_dispatch` to `slots()`/`take`; two-tenant fairness integration test (the DoD).
- **I17:** max-concurrent-per-tenant quota at admission (`RESOURCE_EXHAUSTED`).

## Related

`docs/plan.md` §16 task 4 + DoD; ADR 0010 (builds on 0008/0009); `docs/journal/phase-4.md` (I15).